### PR TITLE
Bump version of guava to deal with CVE-2018-10237

### DIFF
--- a/jpsonic-main/cve-suppressed.xml
+++ b/jpsonic-main/cve-suppressed.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
 
+	<!-- Jpsonic >> -->
+    <suppress>
+        <notes><![CDATA[As hotfix, add suppression with update of guava]]></notes>
+        <gav regex="true">^.*$</gav>
+        <cve>CVE-2018-10237</cve>
+    </suppress>
+	<!-- << Jpsonic -->
+    
     <suppress>
         <notes><![CDATA[RC4 vulnerability in ssl. We don't use ssl at the application container level]]></notes>
         <gav regex="true">^.*$</gav>

--- a/jpsonic-main/cve-suppressed.xml
+++ b/jpsonic-main/cve-suppressed.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
 
-	<!-- Jpsonic >> -->
-    <suppress>
-        <notes><![CDATA[As hotfix, add suppression with update of guava]]></notes>
-        <gav regex="true">^.*$</gav>
-        <cve>CVE-2018-10237</cve>
-    </suppress>
-	<!-- << Jpsonic -->
-    
     <suppress>
         <notes><![CDATA[RC4 vulnerability in ssl. We don't use ssl at the application container level]]></notes>
         <gav regex="true">^.*$</gav>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>20.0</version>
+                <version>27.0-jre</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -215,7 +215,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>3.3.2</version>
+                    <version>3.3.4</version>
                     <inherited>true</inherited>
                     <configuration>
                         <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>


### PR DESCRIPTION
Although jpsonic's correspondence was inadequate,
merge because airsonic is doing the correct modification.