### PR TITLE
Extension of Database/Metadata for JP

### DIFF
--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -531,6 +531,16 @@
             <version>2.1.2</version>
             <scope>runtime</scope>
         </dependency>
+		<dependency>
+			<groupId>com.atilika.kuromoji</groupId>
+			<artifactId>kuromoji-ipadic</artifactId>
+			<version>0.9.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.ibm.icu</groupId>
+			<artifactId>icu4j</artifactId>
+			<version>61.1</version>
+		</dependency>
     </dependencies>
 
     <build>

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileJPSupport.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileJPSupport.java
@@ -1,0 +1,170 @@
+/*
+ This file is part of Jpsonic.
+
+ Jpsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Jpsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Airsonic.  If not, see <http://www.gnu.org/licenses/>.
+
+ Copyright 2018 (C) tesshu.com
+ */
+package com.tesshu.jpsonic.service;
+
+import com.atilika.kuromoji.ipadic.Token;
+import com.atilika.kuromoji.ipadic.Tokenizer;
+import com.ibm.icu.text.Transliterator;
+
+import org.airsonic.player.domain.Artist;
+import org.airsonic.player.domain.MediaFile;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Collector;
+
+/**
+ * Provide analysis of Japanese name.
+ * @author tesshu
+ */
+@Service
+public class MediaFileJPSupport {
+    
+    public static final Pattern ALPHA = Pattern.compile("^[a-zA-Z]+$");
+    private static final Pattern KATAKANA = Pattern.compile("^[\\u30A0-\\u30FF]+$");
+    private static final String ASTER = "*";
+    private final Tokenizer tokenizer = new Tokenizer();
+	private Map<String, String> readingMap = new HashMap<>();
+
+    /** Determine reading for token. */
+    private final Function<Token, String> readingAnalysis = token -> {
+    	if(KATAKANA.matcher(token.getSurface()).matches()
+    			|| ALPHA.matcher(token.getSurface()).matches()
+    			|| ASTER.equals(token.getReading())) {
+    		return token.getSurface();
+    	}
+        return token.getReading();
+    };
+    
+    /**
+     * When first letter of MediaFile#artist is other than alphabet,
+     * try reading Japanese and set MediaFile#artistReading.
+     * @param mediaFile
+     */
+	public void analyzeArtistReading(MediaFile mediaFile) {
+		String artist = mediaFile.getArtist();
+		mediaFile.setArtistReading(createReading(artist));
+	}
+
+	public void analyzeAlbumReading(MediaFile mediaFile) {
+		String albumName = mediaFile.getAlbumName();
+		mediaFile.setAlbumReading(createReading(albumName));
+	}
+
+	public void analyzeNameReading(Artist artist) {
+		String name = artist.getName();
+		artist.setReading(createReading(name));
+	}
+
+	public void analyzeArtistSort(MediaFile mediaFile) {
+		if (StringUtils.isEmpty(mediaFile.getArtistReading())
+				|| StringUtils.isEmpty(mediaFile.getArtistSort())
+				|| mediaFile.getArtistSort().equals(mediaFile.getArtistReading())) {
+			mediaFile.setArtistSort(null);
+			return;
+		}
+		String sort = createReading(mediaFile.getArtistSort());
+		if (!StringUtils.isEmpty(sort) && !sort.equals(mediaFile.getArtistReading())) {
+			mediaFile.setArtistSort(sort);
+		} else {
+			mediaFile.setArtistSort(null);
+		}
+	}
+
+	public void clear() {
+		readingMap.clear();
+	}
+
+	public String createReading(String s) {
+		if (StringUtils.isEmpty(s) || ALPHA.matcher(s.substring(0, 1)).matches()) {
+			return null;
+		}
+		if(readingMap.containsKey(s)) {
+			return readingMap.get(s);
+		}
+		Collector<String, StringBuilder, String> join =
+				Collector.of(StringBuilder::new, StringBuilder::append, StringBuilder::append, StringBuilder::toString);
+		List<Token> tokens = tokenizer.tokenize(s);
+		String reading = cleanUp(tokens.stream().map(readingAnalysis).collect(join));
+		readingMap.put(s, reading);
+		return reading;
+	}
+
+    /**
+     * This method returns the normalized Artist name that can also be used to create the index prefix.
+     * @param mediaFile
+     * @return indexable Name
+     */
+    public String createIndexableName(MediaFile mediaFile) {
+        // http://www.unicode.org/reports/tr15/
+    	if(!StringUtils.isEmpty(mediaFile.getArtistSort())) {
+    		return Normalizer.normalize(mediaFile.getArtistSort(), Normalizer.Form.NFD);
+    	}
+    	if(!StringUtils.isEmpty(mediaFile.getArtistReading())) {
+    		return Normalizer.normalize(mediaFile.getArtistReading(), Normalizer.Form.NFD);
+    	}
+        return mediaFile.getName();
+    }
+
+	public String createIndexableName(Artist artist) {
+		if (!StringUtils.isEmpty(artist.getSort())) {
+			return Normalizer.normalize(artist.getSort(), Normalizer.Form.NFD);
+		}
+		if (!StringUtils.isEmpty(artist.getReading())) {
+			return Normalizer.normalize(artist.getReading(), Normalizer.Form.NFD);
+		}
+		return artist.getName();
+	}
+
+    public List<MediaFile> createArtistSortToBeUpdate(List<MediaFile> candidates) {
+    	List<MediaFile> toBeUpdate = new ArrayList<>();
+    	for(MediaFile candidate : candidates) {
+    		String cleanedUpSort = cleanUp(candidate.getArtistSort());
+    		if(!candidate.getArtistReading().equals(cleanedUpSort)) {
+    			candidate.setArtistSort(cleanedUpSort);
+    			toBeUpdate.add(candidate);
+    		}
+    	}
+    	return toBeUpdate;
+    }
+
+    public List<MediaFile> createAlbumSortToBeUpdate(List<MediaFile> candidates) {
+    	List<MediaFile> toBeUpdate = new ArrayList<>();
+    	for(MediaFile candidate : candidates) {
+    		String cleanedUpSort = cleanUp(candidate.getAlbumSort());
+    		if(!candidate.getAlbumReading().equals(cleanedUpSort)) {
+    			candidate.setAlbumSort(cleanedUpSort);
+    			toBeUpdate.add(candidate);
+    		}
+    	}
+    	return toBeUpdate;
+    }
+
+    public String cleanUp(String dirty) {
+    	return Normalizer.normalize(
+    			Transliterator.getInstance("Hiragana-Katakana").transliterate(dirty), Normalizer.Form.NFKC);
+    }
+}

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/tagger/tag/FieldKeyExtension.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/tagger/tag/FieldKeyExtension.java
@@ -1,0 +1,8 @@
+package com.tesshu.jpsonic.tagger.tag;
+
+public enum FieldKeyExtension {
+	ARTISTSORT,
+	ALBUMSORT,
+	ALBUMARTISTSORT,
+	TITLESORT
+}

--- a/jpsonic-main/src/main/java/org/airsonic/player/dao/AlbumDao.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/dao/AlbumDao.java
@@ -41,7 +41,7 @@ import java.util.*;
 public class AlbumDao extends AbstractDao {
     private static final String INSERT_COLUMNS = "path, name, artist, song_count, duration_seconds, cover_art_path, " +
                                           "year, genre, play_count, last_played, comment, created, last_scanned, present, " +
-                                          "folder_id, mb_release_id";
+                                          "folder_id, artist_sort, name_sort, mb_release_id";
 
     private static final String QUERY_COLUMNS = "id, " + INSERT_COLUMNS;
 
@@ -129,19 +129,21 @@ public class AlbumDao extends AbstractDao {
                      "last_scanned=?," +
                      "present=?, " +
                      "folder_id=?, " +
+                     "artist_sort=?, " +
+                     "name_sort=?, " +
                      "mb_release_id=? " +
                      "where artist=? and name=?";
 
         int n = update(sql, album.getPath(), album.getSongCount(), album.getDurationSeconds(), album.getCoverArtPath(), album.getYear(),
                        album.getGenre(), album.getPlayCount(), album.getLastPlayed(), album.getComment(), album.getCreated(),
-                       album.getLastScanned(), album.isPresent(), album.getFolderId(), album.getMusicBrainzReleaseId(), album.getArtist(), album.getName());
+                       album.getLastScanned(), album.isPresent(), album.getFolderId(), album.getArtistSort(), album.getNameSort(), album.getMusicBrainzReleaseId(), album.getArtist(), album.getName());
 
         if (n == 0) {
 
             update("insert into album (" + INSERT_COLUMNS + ") values (" + questionMarks(INSERT_COLUMNS) + ")", album.getPath(),
                    album.getName(), album.getArtist(), album.getSongCount(), album.getDurationSeconds(),
                    album.getCoverArtPath(), album.getYear(), album.getGenre(), album.getPlayCount(), album.getLastPlayed(),
-                   album.getComment(), album.getCreated(), album.getLastScanned(), album.isPresent(), album.getFolderId(), album.getMusicBrainzReleaseId());
+                   album.getComment(), album.getCreated(), album.getLastScanned(), album.isPresent(), album.getFolderId(), album.getArtistSort(), album.getNameSort(), album.getMusicBrainzReleaseId());
         }
 
         int id = queryForInt("select id from album where artist=? and name=?", null, album.getArtist(), album.getName());
@@ -407,7 +409,9 @@ public class AlbumDao extends AbstractDao {
                     rs.getTimestamp(14),
                     rs.getBoolean(15),
                     rs.getInt(16),
-                    rs.getString(17));
+                    rs.getString(17),
+                    rs.getString(18),
+                    rs.getString(19));
         }
     }
 }

--- a/jpsonic-main/src/main/java/org/airsonic/player/dao/ArtistDao.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/dao/ArtistDao.java
@@ -40,7 +40,7 @@ import java.util.*;
 public class ArtistDao extends AbstractDao {
 
     private static final Logger LOG = LoggerFactory.getLogger(ArtistDao.class);
-    private static final String INSERT_COLUMNS = "name, cover_art_path, album_count, last_scanned, present, folder_id";
+    private static final String INSERT_COLUMNS = "name, cover_art_path, album_count, last_scanned, present, folder_id, reading, sort";
     private static final String QUERY_COLUMNS = "id, " + INSERT_COLUMNS;
 
     private final RowMapper rowMapper = new ArtistMapper();
@@ -97,14 +97,16 @@ public class ArtistDao extends AbstractDao {
                      "album_count=?," +
                      "last_scanned=?," +
                      "present=?," +
-                     "folder_id=? " +
+                     "folder_id=?," +
+                     "reading=?," +
+                     "sort=? " +
                      "where name=?";
 
-        int n = update(sql, artist.getCoverArtPath(), artist.getAlbumCount(), artist.getLastScanned(), artist.isPresent(), artist.getFolderId(), artist.getName());
+        int n = update(sql, artist.getCoverArtPath(), artist.getAlbumCount(), artist.getLastScanned(), artist.isPresent(), artist.getFolderId(), artist.getReading(), artist.getSort(), artist.getName());
 
         if (n == 0) {
             update("insert into artist (" + INSERT_COLUMNS + ") values (" + questionMarks(INSERT_COLUMNS) + ")",
-                   artist.getName(), artist.getCoverArtPath(), artist.getAlbumCount(), artist.getLastScanned(), artist.isPresent(), artist.getFolderId());
+                   artist.getName(), artist.getCoverArtPath(), artist.getAlbumCount(), artist.getLastScanned(), artist.isPresent(), artist.getFolderId(), artist.getReading(), artist.getSort());
         }
 
         int id = queryForInt("select id from artist where name=?", null, artist.getName());
@@ -208,7 +210,9 @@ public class ArtistDao extends AbstractDao {
                     rs.getInt(4),
                     rs.getTimestamp(5),
                     rs.getBoolean(6),
-                    rs.getInt(7));
+                    rs.getInt(7),
+                    rs.getString(8),
+                    rs.getString(9));
         }
     }
 }

--- a/jpsonic-main/src/main/java/org/airsonic/player/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/dao/MediaFileDao.java
@@ -46,12 +46,13 @@ public class MediaFileDao extends AbstractDao {
     private static final String INSERT_COLUMNS = "path, folder, type, format, title, album, artist, album_artist, disc_number, " +
                                                 "track_number, year, genre, bit_rate, variable_bit_rate, duration_seconds, file_size, width, height, cover_art_path, " +
                                                 "parent_path, play_count, last_played, comment, created, changed, last_scanned, children_last_updated, present, " +
-                                                "version, mb_release_id";
+                                                "version, artist_reading, title_sort, album_sort, artist_sort, album_artist_sort, album_reading, mb_release_id";
 
     private static final String QUERY_COLUMNS = "id, " + INSERT_COLUMNS;
     private static final String GENRE_COLUMNS = "name, song_count, album_count";
 
-    public static final int VERSION = 4;
+    private static final int JP_VERSION = 4;
+    public static final int VERSION = 4 + JP_VERSION;
 
     private final RowMapper<MediaFile> rowMapper = new MediaFileMapper();
     private final RowMapper musicFileInfoRowMapper = new MusicFileInfoMapper();
@@ -164,6 +165,12 @@ public class MediaFileDao extends AbstractDao {
                      "children_last_updated=?," +
                      "present=?, " +
                      "version=?, " +
+                     "artist_reading=?, " +
+                     "title_sort=?, " +
+                     "album_sort=?, " +
+                     "artist_sort=?, " +
+                     "album_artist_sort=?, " +
+                     "album_reading=?, " +
                      "mb_release_id=? " +
                      "where path=?";
 
@@ -174,7 +181,14 @@ public class MediaFileDao extends AbstractDao {
                        file.getAlbumArtist(), file.getDiscNumber(), file.getTrackNumber(), file.getYear(), file.getGenre(), file.getBitRate(),
                        file.isVariableBitRate(), file.getDurationSeconds(), file.getFileSize(), file.getWidth(), file.getHeight(),
                        file.getCoverArtPath(), file.getParentPath(), file.getPlayCount(), file.getLastPlayed(), file.getComment(),
-                       file.getChanged(), file.getLastScanned(), file.getChildrenLastUpdated(), file.isPresent(), VERSION,
+                       file.getChanged(), file.getLastScanned(), file.getChildrenLastUpdated(), file.isPresent(),
+                       VERSION,
+                       file.getArtistReading(),
+                       file.getTitleSort(),
+                       file.getAlbumSort(),
+                       file.getArtistSort(),
+                       file.getAlbumArtistSort(),
+                       file.getAlbumReading(),
                        file.getMusicBrainzReleaseId(), file.getPath());
 
         if (n == 0) {
@@ -193,7 +207,9 @@ public class MediaFileDao extends AbstractDao {
                    file.isVariableBitRate(), file.getDurationSeconds(), file.getFileSize(), file.getWidth(), file.getHeight(),
                    file.getCoverArtPath(), file.getParentPath(), file.getPlayCount(), file.getLastPlayed(), file.getComment(),
                    file.getCreated(), file.getChanged(), file.getLastScanned(),
-                   file.getChildrenLastUpdated(), file.isPresent(), VERSION, file.getMusicBrainzReleaseId());
+                   file.getChildrenLastUpdated(), file.isPresent(), VERSION,
+                   file.getArtistReading(), file.getTitleSort(), file.getAlbumSort(), file.getArtistSort(), file.getAlbumArtistSort(), file.getAlbumReading(),
+                   file.getMusicBrainzReleaseId());
         }
 
         int id = queryForInt("select id from media_file where path=?", null, file.getPath());
@@ -721,7 +737,13 @@ public class MediaFileDao extends AbstractDao {
                     rs.getTimestamp(28),
                     rs.getBoolean(29),
                     rs.getInt(30),
-                    rs.getString(31));
+                    rs.getString(31),
+                    rs.getString(32),
+                    rs.getString(33),
+                    rs.getString(34),
+                    rs.getString(35),
+                    rs.getString(36),
+                    rs.getString(37));
         }
     }
 

--- a/jpsonic-main/src/main/java/org/airsonic/player/domain/Album.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/domain/Album.java
@@ -43,6 +43,8 @@ public class Album {
     private Date lastScanned;
     private boolean present;
     private Integer folderId;
+    private String artistSort;
+    private String nameSort;
     private String musicBrainzReleaseId;
 
     public Album() {
@@ -50,7 +52,7 @@ public class Album {
 
     public Album(int id, String path, String name, String artist, int songCount, int durationSeconds, String coverArtPath,
             Integer year, String genre, int playCount, Date lastPlayed, String comment, Date created, Date lastScanned,
-            boolean present, Integer folderId, String musicBrainzReleaseId) {
+            boolean present, Integer folderId, String artistSort, String nameSort, String musicBrainzReleaseId) {
         this.id = id;
         this.path = path;
         this.name = name;
@@ -67,6 +69,8 @@ public class Album {
         this.lastScanned = lastScanned;
         this.folderId = folderId;
         this.present = present;
+        this.artistSort = artistSort;
+        this.nameSort = nameSort;
         this.musicBrainzReleaseId = musicBrainzReleaseId;
     }
 
@@ -197,6 +201,22 @@ public class Album {
     public Integer getFolderId() {
         return folderId;
     }
+
+	public String getArtistSort() {
+		return artistSort;
+	}
+
+	public void setArtistSort(String artistSort) {
+		this.artistSort = artistSort;
+	}
+
+	public String getNameSort() {
+		return nameSort;
+	}
+
+	public void setNameSort(String nameSort) {
+		this.nameSort = nameSort;
+	}
 
     public String getMusicBrainzReleaseId() {
         return musicBrainzReleaseId;

--- a/jpsonic-main/src/main/java/org/airsonic/player/domain/Artist.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/domain/Artist.java
@@ -34,11 +34,14 @@ public class Artist {
     private Date lastScanned;
     private boolean present;
     private Integer folderId;
+    private String reading;
+    private String sort;
 
     public Artist() {
     }
 
-    public Artist(int id, String name, String coverArtPath, int albumCount, Date lastScanned, boolean present, Integer folderId) {
+    public Artist(int id, String name, String coverArtPath, int albumCount, Date lastScanned, boolean present, Integer folderId,
+    		String reading, String sort) {
         this.id = id;
         this.name = name;
         this.coverArtPath = coverArtPath;
@@ -46,6 +49,8 @@ public class Artist {
         this.lastScanned = lastScanned;
         this.present = present;
         this.folderId = folderId;
+        this.reading = reading;
+        this.sort = sort;
     }
 
     public int getId() {
@@ -103,4 +108,21 @@ public class Artist {
     public Integer getFolderId() {
         return folderId;
     }
+
+	public String getReading() {
+		return reading;
+	}
+
+	public void setReading(String reading) {
+		this.reading = reading;
+	}
+
+	public String getSort() {
+		return sort;
+	}
+
+	public void setSort(String sort) {
+		this.sort = sort;
+	}
+    
 }

--- a/jpsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/domain/MediaFile.java
@@ -67,13 +67,21 @@ public class MediaFile {
     private Date childrenLastUpdated;
     private boolean present;
     private int version;
+    private String artistReading;
+    private String titleSort;
+    private String albumSort;
+    private String artistSort;
+    private String albumArtistSort;
+    private String albumReading;
     private String musicBrainzReleaseId;
 
-    public MediaFile(int id, String path, String folder, MediaType mediaType, String format, String title,
+	public MediaFile(int id, String path, String folder, MediaType mediaType, String format, String title,
                      String albumName, String artist, String albumArtist, Integer discNumber, Integer trackNumber, Integer year, String genre, Integer bitRate,
                      boolean variableBitRate, Integer durationSeconds, Long fileSize, Integer width, Integer height, String coverArtPath,
                      String parentPath, int playCount, Date lastPlayed, String comment, Date created, Date changed, Date lastScanned,
-                     Date childrenLastUpdated, boolean present, int version, String musicBrainzReleaseId) {
+                     Date childrenLastUpdated, boolean present, int version,
+                     String artistReading, String titleSort, String albumSort, String artistSort, String albumArtistSort, String albumReading,
+                     String musicBrainzReleaseId) {
         this.id = id;
         this.path = path;
         this.folder = folder;
@@ -104,6 +112,11 @@ public class MediaFile {
         this.childrenLastUpdated = childrenLastUpdated;
         this.present = present;
         this.version = version;
+        this.artistReading = artistReading;
+        this.titleSort = titleSort;
+        this.albumSort = albumSort;
+        this.artistSort = artistSort;
+        this.albumReading = albumReading;
         this.musicBrainzReleaseId = musicBrainzReleaseId;
     }
 
@@ -452,8 +465,56 @@ public class MediaFile {
         // TODO: Optimize
         return coverArtPath == null ? null : new File(coverArtPath);
     }
+    
+	public String getArtistReading() {
+		return artistReading;
+	}
 
-    @Override
+	public void setArtistReading(String artistReading) {
+		this.artistReading = artistReading;
+	}
+	
+    public String getTitleSort() {
+		return titleSort;
+	}
+
+	public void setTitleSort(String titleSort) {
+		this.titleSort = titleSort;
+	}
+
+	public String getAlbumSort() {
+		return albumSort;
+	}
+
+	public void setAlbumSort(String albumSort) {
+		this.albumSort = albumSort;
+	}
+
+	public String getArtistSort() {
+		return artistSort;
+	}
+
+	public void setArtistSort(String artistSort) {
+		this.artistSort = artistSort;
+	}
+	
+	public String getAlbumArtistSort() {
+		return albumArtistSort;
+	}
+
+	public void setAlbumArtistSort(String albumArtistSort) {
+		this.albumArtistSort = albumArtistSort;
+	}
+
+	public String getAlbumReading() {
+		return albumReading;
+	}
+
+	public void setAlbumReading(String albumReading) {
+		this.albumReading = albumReading;
+	}
+
+	@Override
     public String toString() {
         return getName();
     }

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java
@@ -19,8 +19,11 @@
  */
 package org.airsonic.player.service;
 
+import com.tesshu.jpsonic.service.MediaFileJPSupport;
+
 import net.sf.ehcache.Ehcache;
 import net.sf.ehcache.Element;
+
 import org.airsonic.player.dao.AlbumDao;
 import org.airsonic.player.dao.MediaFileDao;
 import org.airsonic.player.domain.*;
@@ -66,6 +69,8 @@ public class MediaFileService {
     @Autowired
     private MetaDataParserFactory metaDataParserFactory;
     private boolean memoryCacheEnabled = true;
+    @Autowired
+    private MediaFileJPSupport mediaFileJPSupport;
 
     /**
      * Returns a media file instance for the given file.  If possible, a cached value is returned.
@@ -503,7 +508,13 @@ public class MediaFileService {
                 mediaFile.setVariableBitRate(metaData.getVariableBitRate());
                 mediaFile.setHeight(metaData.getHeight());
                 mediaFile.setWidth(metaData.getWidth());
+                mediaFile.setTitleSort(metaData.getTitleSort());
+                mediaFile.setAlbumSort(metaData.getAlbumSort());
+                mediaFile.setArtistSort(metaData.getArtistSort());
+                mediaFile.setAlbumArtistSort(metaData.getAlbumArtistSort());
                 mediaFile.setMusicBrainzReleaseId(metaData.getMusicBrainzReleaseId());
+                mediaFileJPSupport.analyzeArtistReading(mediaFile);
+                mediaFileJPSupport.analyzeArtistSort(mediaFile);
             }
             String format = StringUtils.trimToNull(StringUtils.lowerCase(FilenameUtils.getExtension(mediaFile.getPath())));
             mediaFile.setFormat(format);
@@ -549,6 +560,8 @@ public class MediaFileService {
                 } else {
                     mediaFile.setArtist(file.getName());
                 }
+                mediaFileJPSupport.analyzeArtistReading(mediaFile);
+                mediaFileJPSupport.analyzeAlbumReading(mediaFile);
             }
         }
 

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/MediaScannerService.java
@@ -19,6 +19,8 @@
  */
 package org.airsonic.player.service;
 
+import com.tesshu.jpsonic.service.MediaFileJPSupport;
+
 import org.airsonic.player.dao.AlbumDao;
 import org.airsonic.player.dao.ArtistDao;
 import org.airsonic.player.dao.MediaFileDao;
@@ -66,6 +68,8 @@ public class MediaScannerService {
     @Autowired
     private AlbumDao albumDao;
     private int scanCount;
+    @Autowired
+    private MediaFileJPSupport mediaFileJPSupport;
 
     @PostConstruct
     public void init() {
@@ -224,6 +228,7 @@ public class MediaScannerService {
             mediaFileService.setMemoryCacheEnabled(true);
             searchService.stopIndexing();
             scanning = false;
+            mediaFileJPSupport.clear();
         }
     }
 
@@ -350,6 +355,8 @@ public class MediaScannerService {
             artist = new Artist();
             artist.setName(file.getAlbumArtist());
         }
+        mediaFileJPSupport.analyzeNameReading(artist);
+        artist.setSort(file.getAlbumArtistSort());
         if (artist.getCoverArtPath() == null) {
             MediaFile parent = mediaFileService.getParentOf(file);
             if (parent != null) {

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -19,6 +19,8 @@
  */
 package org.airsonic.player.service.metadata;
 
+import com.tesshu.jpsonic.tagger.tag.FieldKeyExtension;
+
 import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.service.SettingsService;
 import org.apache.commons.io.FilenameUtils;
@@ -98,6 +100,10 @@ public class JaudiotaggerParser extends MetaDataParser {
                 String albumArtist = getTagField(tag, FieldKey.ALBUM_ARTIST);
                 metaData.setArtist(StringUtils.isBlank(songArtist) ? albumArtist : songArtist);
                 metaData.setAlbumArtist(StringUtils.isBlank(albumArtist) ? songArtist : albumArtist);
+                metaData.setArtistSort(getTagField(tag, FieldKeyExtension.ARTISTSORT));
+                metaData.setAlbumSort(getTagField(tag, FieldKeyExtension.ALBUMSORT));
+                metaData.setTitleSort(getTagField(tag, FieldKeyExtension.TITLESORT));
+                metaData.setAlbumArtistSort(getTagField(tag, FieldKeyExtension.ALBUMARTISTSORT));
             }
 
             AudioHeader audioHeader = audioFile.getAudioHeader();
@@ -118,6 +124,15 @@ public class JaudiotaggerParser extends MetaDataParser {
     private String getTagField(Tag tag, FieldKey fieldKey) {
         try {
             return StringUtils.trimToNull(tag.getFirst(fieldKey));
+        } catch (Exception x) {
+            // Ignored.
+            return null;
+        }
+    }
+
+    private String getTagField(Tag tag, FieldKeyExtension fieldKey) {
+        try {
+            return StringUtils.trimToNull(tag.getFirst(fieldKey.name()));
         } catch (Exception x) {
             // Ignored.
             return null;

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/metadata/MetaData.java
@@ -38,6 +38,10 @@ public class MetaData {
     private Integer durationSeconds;
     private Integer width;
     private Integer height;
+    private String titleSort;
+    private String albumSort;
+    private String artistSort;
+    private String albumArtistSort;
     private String musicBrainzReleaseId;
 
     public Integer getDiscNumber() {
@@ -142,6 +146,38 @@ public class MetaData {
 
     public void setHeight(Integer height) {
         this.height = height;
+    }
+
+    public String getTitleSort() {
+        return titleSort;
+    }
+
+    public void setTitleSort(String titleSort) {
+        this.titleSort = titleSort;
+    }
+
+    public String getAlbumSort() {
+        return albumSort;
+    }
+
+    public void setAlbumSort(String albumSort) {
+        this.albumSort = albumSort;
+    }
+
+    public String getArtistSort() {
+        return artistSort;
+    }
+
+    public void setArtistSort(String artistRort) {
+        this.artistSort = artistRort;
+    }
+
+    public String getAlbumArtistSort() {
+        return albumArtistSort;
+    }
+
+    public void setAlbumArtistSort(String albumArtistSort) {
+        this.albumArtistSort = albumArtistSort;
     }
 
     public String getMusicBrainzReleaseId() {

--- a/jpsonic-main/src/main/resources/applicationContext-service.xml
+++ b/jpsonic-main/src/main/resources/applicationContext-service.xml
@@ -15,7 +15,8 @@
         org.airsonic.player.service, 
         org.airsonic.player.monitor, 
         org.airsonic.player.ajax, 
-        org.airsonic.player.i18n." />
+        org.airsonic.player.i18n.,
+        com.tesshu.jpsonic.service" />
 
     <!-- Services -->
 

--- a/jpsonic-main/src/main/resources/liquibase/db-changelog.xml
+++ b/jpsonic-main/src/main/resources/liquibase/db-changelog.xml
@@ -10,6 +10,10 @@
     <include file="legacy/legacy-changelog.xml" relativeToChangelogFile="true"/>
     <include file="6.2/changelog.xml" relativeToChangelogFile="true"/>
     <include file="6.3/changelog.xml" relativeToChangelogFile="true"/>
+    <include file="jp1.0/changelog.xml" relativeToChangelogFile="true"/>
+    <include file="jp1.2/changelog.xml" relativeToChangelogFile="true"/>
+    <include file="jp1.2.2/changelog.xml" relativeToChangelogFile="true"/>
+    <include file="jp1.3/changelog.xml" relativeToChangelogFile="true"/>
     <include file="6.4/changelog.xml" relativeToChangelogFile="true"/>
     <include file="10.2/changelog.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/jpsonic-main/src/main/resources/liquibase/jp1.0/add-media-file-artist-reading.xml
+++ b/jpsonic-main/src/main/resources/liquibase/jp1.0/add-media-file-artist-reading.xml
@@ -1,0 +1,17 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-media-file-artist-reading_001" author="tesshu">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="media_file" columnName="artist_reading" />
+            </not>
+        </preConditions>
+        <addColumn tableName="media_file">
+            <column name="artist_reading" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/jpsonic-main/src/main/resources/liquibase/jp1.0/changelog.xml
+++ b/jpsonic-main/src/main/resources/liquibase/jp1.0/changelog.xml
@@ -1,0 +1,6 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <include file="add-media-file-artist-reading.xml" relativeToChangelogFile="true"/>
+</databaseChangeLog>

--- a/jpsonic-main/src/main/resources/liquibase/jp1.2.2/add-artist-reading-sort.xml
+++ b/jpsonic-main/src/main/resources/liquibase/jp1.2.2/add-artist-reading-sort.xml
@@ -1,0 +1,29 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-artist-reading-sort_001" author="tesshu">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="artist" columnName="reading" />
+            </not>
+        </preConditions>
+        <addColumn tableName="artist">
+            <column name="reading" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet id="add-artist-reading-sort_002" author="tesshu">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="artist" columnName="sort" />
+            </not>
+        </preConditions>
+        <addColumn tableName="artist">
+            <column name="sort" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/jpsonic-main/src/main/resources/liquibase/jp1.2.2/add-media-file-album_artist_sort.xml
+++ b/jpsonic-main/src/main/resources/liquibase/jp1.2.2/add-media-file-album_artist_sort.xml
@@ -1,0 +1,17 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-media-file-album_artist_sort_001" author="tesshu">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="media_file" columnName="album_artist_sort" />
+            </not>
+        </preConditions>
+        <addColumn tableName="media_file">
+            <column name="album_artist_sort" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/jpsonic-main/src/main/resources/liquibase/jp1.2.2/changelog.xml
+++ b/jpsonic-main/src/main/resources/liquibase/jp1.2.2/changelog.xml
@@ -1,0 +1,7 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <include file="add-artist-reading-sort.xml" relativeToChangelogFile="true"/>
+    <include file="add-media-file-album_artist_sort.xml" relativeToChangelogFile="true"/>
+</databaseChangeLog>

--- a/jpsonic-main/src/main/resources/liquibase/jp1.2/add-media-file-sort.xml
+++ b/jpsonic-main/src/main/resources/liquibase/jp1.2/add-media-file-sort.xml
@@ -1,0 +1,41 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-media-file-artist-sort_001" author="tesshu">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="media_file" columnName="title_sort" />
+            </not>
+        </preConditions>
+        <addColumn tableName="media_file">
+            <column name="title_sort" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet id="add-media-file-artist-sort_002" author="tesshu">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="media_file" columnName="album_sort" />
+            </not>
+        </preConditions>
+        <addColumn tableName="media_file">
+            <column name="album_sort" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet id="add-media-file-artist-sort_003" author="tesshu">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="media_file" columnName="artist_sort" />
+            </not>
+        </preConditions>
+        <addColumn tableName="media_file">
+            <column name="artist_sort" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/jpsonic-main/src/main/resources/liquibase/jp1.2/changelog.xml
+++ b/jpsonic-main/src/main/resources/liquibase/jp1.2/changelog.xml
@@ -1,0 +1,6 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <include file="add-media-file-sort.xml" relativeToChangelogFile="true"/>
+</databaseChangeLog>

--- a/jpsonic-main/src/main/resources/liquibase/jp1.3/add-album-sort.xml
+++ b/jpsonic-main/src/main/resources/liquibase/jp1.3/add-album-sort.xml
@@ -1,0 +1,29 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-album-sort_001" author="tesshu">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="album" columnName="artist_sort" />
+            </not>
+        </preConditions>
+        <addColumn tableName="album">
+            <column name="artist_sort" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet id="add-album-sort_002" author="tesshu">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="album" columnName="name_sort" />
+            </not>
+        </preConditions>
+        <addColumn tableName="album">
+            <column name="name_sort" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/jpsonic-main/src/main/resources/liquibase/jp1.3/add-media-file-album-reading.xml
+++ b/jpsonic-main/src/main/resources/liquibase/jp1.3/add-media-file-album-reading.xml
@@ -1,0 +1,17 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-media-file-album-reading_001" author="tesshu">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="media_file" columnName="album_reading" />
+            </not>
+        </preConditions>
+        <addColumn tableName="media_file">
+            <column name="album_reading" type="${varchar_type}">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/jpsonic-main/src/main/resources/liquibase/jp1.3/changelog.xml
+++ b/jpsonic-main/src/main/resources/liquibase/jp1.3/changelog.xml
@@ -1,0 +1,7 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <include file="add-media-file-album-reading.xml" relativeToChangelogFile="true"/>
+    <include file="add-album-sort.xml" relativeToChangelogFile="true"/>
+</databaseChangeLog>


### PR DESCRIPTION
 - Extension of Database/Metadata necessary for Japanese processing
 - Convert Japanese words read from the file, perform data cleansing, Enter meta in database
 - From the addition of the definition, the input processing to the additional area was added, but this alone does not affect the existing function