### PR TITLE
Update to Lucene 7.7.1 (#121)

### DIFF
--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -134,17 +134,17 @@
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
-            <version>7.4.0</version>
+            <version>7.7.1</version>
         </dependency>
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-analyzers-common</artifactId>
-			<version>7.4.0</version>
+			<version>7.7.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-queryparser</artifactId>
-			<version>7.4.0</version>
+			<version>7.7.1</version>
 		</dependency>
 
         <dependency>
@@ -561,7 +561,7 @@
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-analyzers-kuromoji</artifactId>
-			<version>7.4.0</version>
+			<version>7.7.1</version>
 		</dependency>
     </dependencies>
 


### PR DESCRIPTION
In 7.4 to 7.7.1, there was no effect on the specification API grammar.