### PR TITLE
Change of Mediafile data creation process

### DIFF
--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <chameleon.version>1.2.1-RELEASE</chameleon.version>
         <tomcat.server.scope>provided</tomcat.server.scope>
-        <jpsonic.version>101.0.1-RELEASE</jpsonic.version>
+        <jpsonic.version>101.1.0-SNAPSHOT</jpsonic.version>
     </properties>
 
     <dependencies>

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileJPSupport.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileJPSupport.java
@@ -80,8 +80,7 @@ public class MediaFileJPSupport {
 
 	public void analyzeArtistSort(MediaFile mediaFile) {
 		if (StringUtils.isEmpty(mediaFile.getArtistReading())
-				|| StringUtils.isEmpty(mediaFile.getArtistSort())
-				|| mediaFile.getArtistSort().equals(mediaFile.getArtistReading())) {
+				|| mediaFile.getArtistReading().equals(mediaFile.getArtistSort())) {
 			mediaFile.setArtistSort(null);
 			return;
 		}
@@ -98,7 +97,7 @@ public class MediaFileJPSupport {
 	}
 
 	public String createReading(String s) {
-		if (StringUtils.isEmpty(s) || ALPHA.matcher(s.substring(0, 1)).matches()) {
+		if (StringUtils.isEmpty(s)) {
 			return null;
 		}
 		if(readingMap.containsKey(s)) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/AnalyzerFactory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/AnalyzerFactory.java
@@ -20,6 +20,7 @@ package com.tesshu.jpsonic.service.search;
 
 import com.tesshu.jpsonic.service.search.IndexType.FieldNames;
 import com.tesshu.jpsonic.service.search.analysis.HiraganaTermStemFilterFactory;
+import com.tesshu.jpsonic.service.search.analysis.Id3ArtistTokenizerFactory;
 import com.tesshu.jpsonic.service.search.analysis.PunctuationStemFilterFactory;
 import com.tesshu.jpsonic.service.search.analysis.ToHiraganaFilterFactory;
 
@@ -131,8 +132,12 @@ public final class AnalyzerFactory {
         return builder;
     }
 
-    private Builder createToHiraganaAnalyzerBuilder() throws IOException {
-        return createSingleTokenAnalyzerBuilder().addTokenFilter(ToHiraganaFilterFactory.class);
+    private Builder createId3ArtistAnalyzerBuilder() throws IOException {  
+        CustomAnalyzer.Builder builder = CustomAnalyzer.builder().withTokenizer(Id3ArtistTokenizerFactory.class);
+        builder = basicFilters(builder)
+                .addTokenFilter(PunctuationStemFilterFactory.class)
+                .addTokenFilter(ToHiraganaFilterFactory.class);
+        return builder;
     }
 
     /**
@@ -146,8 +151,8 @@ public final class AnalyzerFactory {
 
                 Analyzer path = createPathAnalyzerBuilder().build();
                 Analyzer key = createKeyAnalyzerBuilder().build();
+                Analyzer id3Artist = createId3ArtistAnalyzerBuilder().build();
                 Analyzer multiTerm = createMultiTokenAnalyzerBuilder().build();
-                Analyzer toHiragana = createToHiraganaAnalyzerBuilder().build();
                 Analyzer onlyHiragana = createOnlyHiraganaAnalyzerBuilder().build();
                 Analyzer otherThanHiragana = createOtherThanHiraganaAnalyzerBuilder().build();
 
@@ -155,10 +160,9 @@ public final class AnalyzerFactory {
                 analyzerMap.put(FieldNames.FOLDER, path);
                 analyzerMap.put(FieldNames.GENRE, key);
                 analyzerMap.put(FieldNames.MEDIA_TYPE, key);
-                analyzerMap.put(FieldNames.ARTIST_READING_HIRAGANA, toHiragana);
+                analyzerMap.put(FieldNames.ARTIST_READING, id3Artist);
                 analyzerMap.put(FieldNames.ALBUM_READING_HIRAGANA, onlyHiragana);
                 analyzerMap.put(FieldNames.TITLE_READING_HIRAGANA, onlyHiragana);
-                analyzerMap.put(FieldNames.ARTIST_FULL, otherThanHiragana);
                 analyzerMap.put(FieldNames.ALBUM_FULL, otherThanHiragana);
 
                 this.analyzer = new PerFieldAnalyzerWrapper(multiTerm, analyzerMap);
@@ -181,8 +185,8 @@ public final class AnalyzerFactory {
 
                 Analyzer path = createPathAnalyzerBuilder().build();
                 Analyzer key = createKeyAnalyzerBuilder().build();
+                Analyzer id3Artist = addWildCard(createId3ArtistAnalyzerBuilder()).build();
                 Analyzer multiTerm = addWildCard(createMultiTokenAnalyzerBuilder()).build();
-                Analyzer toHiragana = addWildCard(createToHiraganaAnalyzerBuilder()).build();
                 Analyzer onlyHiragana = addWildCard(createOnlyHiraganaAnalyzerBuilder()).build();
                 Analyzer otherThanHiragana = addWildCard(createOtherThanHiraganaAnalyzerBuilder()).build();
 
@@ -190,10 +194,9 @@ public final class AnalyzerFactory {
                 analyzerMap.put(FieldNames.FOLDER, path);
                 analyzerMap.put(FieldNames.GENRE, key);
                 analyzerMap.put(FieldNames.MEDIA_TYPE, key);
-                analyzerMap.put(FieldNames.ARTIST_READING_HIRAGANA, toHiragana);
+                analyzerMap.put(FieldNames.ARTIST_READING, id3Artist);
                 analyzerMap.put(FieldNames.ALBUM_READING_HIRAGANA, onlyHiragana);
                 analyzerMap.put(FieldNames.TITLE_READING_HIRAGANA, onlyHiragana);
-                analyzerMap.put(FieldNames.ARTIST_FULL, otherThanHiragana);
                 analyzerMap.put(FieldNames.ALBUM_FULL, otherThanHiragana);
 
                 this.queryAnalyzer = new PerFieldAnalyzerWrapper(multiTerm, analyzerMap);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/DocumentFactory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/DocumentFactory.java
@@ -71,11 +71,11 @@ public class DocumentFactory {
         idField.accept(doc, mediaFile.getId());
         termField.accept(doc, FieldNames.ALBUM, mediaFile.getAlbumName());
         termField.accept(doc, FieldNames.ALBUM_FULL, mediaFile.getAlbumName());
+        String reading = isEmpty(mediaFile.getAlbumSort()) ? mediaFile.getAlbumReading() : mediaFile.getAlbumSort();
         termField.accept(doc, FieldNames.ALBUM_READING_HIRAGANA, mediaFile.getAlbumSort());
         termField.accept(doc, FieldNames.ARTIST, mediaFile.getArtist());
-        termField.accept(doc, FieldNames.ARTIST_FULL, mediaFile.getArtist());
-        termField.accept(doc, FieldNames.ARTIST_READING, mediaFile.getArtistSort());
-        termField.accept(doc, FieldNames.ARTIST_READING_HIRAGANA, mediaFile.getArtistSort());
+        reading = isEmpty(mediaFile.getArtistSort()) ? mediaFile.getArtistReading() : mediaFile.getArtistSort();
+        termField.accept(doc, FieldNames.ARTIST_READING, reading);
         pathField.accept(doc, mediaFile.getFolder());
         return doc;
     }
@@ -84,9 +84,8 @@ public class DocumentFactory {
         Document doc = new Document();
         idField.accept(doc, mediaFile.getId());
         termField.accept(doc, FieldNames.ARTIST, mediaFile.getArtist());
-        termField.accept(doc, FieldNames.ARTIST_FULL, mediaFile.getArtist());
-        termField.accept(doc, FieldNames.ARTIST_READING, mediaFile.getArtistSort());
-        termField.accept(doc, FieldNames.ARTIST_READING_HIRAGANA, mediaFile.getArtistSort());
+        String reading = isEmpty(mediaFile.getArtistSort()) ? mediaFile.getArtistReading() : mediaFile.getArtistSort();
+        termField.accept(doc, FieldNames.ARTIST_READING, reading);
         pathField.accept(doc, mediaFile.getFolder());
         return doc;
     }
@@ -98,9 +97,7 @@ public class DocumentFactory {
         termField.accept(doc, FieldNames.ALBUM_FULL, album.getName());
         termField.accept(doc, FieldNames.ALBUM_READING_HIRAGANA, album.getNameSort());
         termField.accept(doc, FieldNames.ARTIST, album.getArtist());
-        termField.accept(doc, FieldNames.ARTIST_FULL, album.getArtist());
         termField.accept(doc, FieldNames.ARTIST_READING, album.getArtistSort());
-        termField.accept(doc, FieldNames.ARTIST_READING_HIRAGANA, album.getArtistSort());
         numberField.accept(doc, FieldNames.FOLDER_ID, album.getFolderId());
         return doc;
     }
@@ -109,10 +106,8 @@ public class DocumentFactory {
         Document doc = new Document();
         idField.accept(doc, artist.getId());
         termField.accept(doc, FieldNames.ARTIST, artist.getName());
-        termField.accept(doc, FieldNames.ARTIST_FULL, artist.getName());
         String reading = isEmpty(artist.getSort()) ? artist.getReading() : artist.getSort();
         termField.accept(doc, FieldNames.ARTIST_READING, reading);
-        termField.accept(doc, FieldNames.ARTIST_READING_HIRAGANA, reading);
         numberField.accept(doc, FieldNames.FOLDER_ID, musicFolder.getId());
         return doc;
     }
@@ -132,10 +127,8 @@ public class DocumentFactory {
         Document doc = new Document();
         idField.accept(doc, mediaFile.getId());
         termField.accept(doc, FieldNames.ARTIST, mediaFile.getArtist());
-        termField.accept(doc, FieldNames.ARTIST_FULL, mediaFile.getArtist());
         String reading = isEmpty(mediaFile.getArtistSort()) ? mediaFile.getArtistReading() : mediaFile.getArtistSort();
         termField.accept(doc, FieldNames.ARTIST_READING, reading);
-        termField.accept(doc, FieldNames.ARTIST_READING_HIRAGANA, reading);
         keyField.accept(doc, FieldNames.MEDIA_TYPE, mediaFile.getMediaType().name());
         termField.accept(doc, FieldNames.TITLE, mediaFile.getTitle());
         termField.accept(doc, FieldNames.TITLE_READING_HIRAGANA, isEmpty(mediaFile.getTitleSort()) ? mediaFile.getTitle() : mediaFile.getTitleSort());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexType.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexType.java
@@ -58,96 +58,56 @@ public enum IndexType {
 
     SONG(
         fieldNames(
-            FieldNames.TITLE,
             FieldNames.TITLE_READING_HIRAGANA,
-            FieldNames.ARTIST,
-            FieldNames.ARTIST_FULL,
+            FieldNames.TITLE,
             FieldNames.ARTIST_READING,
-            FieldNames.ARTIST_READING_HIRAGANA ),
+            FieldNames.ARTIST),
         boosts(
-            entry(FieldNames.TITLE_READING_HIRAGANA, 1.4F),
-            entry(FieldNames.TITLE, 1.3F),
-            entry(FieldNames.ARTIST_READING_HIRAGANA, 1.2F),
-            entry(FieldNames.ARTIST_FULL, 1.1F))),
+            entry(FieldNames.TITLE_READING_HIRAGANA, 2.4F),
+            entry(FieldNames.TITLE, 2.3F),
+            entry(FieldNames.ARTIST_READING, 1.1F))),
 
     ALBUM(
         fieldNames(
-            FieldNames.ALBUM,
-            FieldNames.ALBUM_FULL,
             FieldNames.ALBUM_READING_HIRAGANA,
-            FieldNames.ARTIST,
-            FieldNames.ARTIST_FULL,
+            FieldNames.ALBUM_FULL,
+            FieldNames.ALBUM,
             FieldNames.ARTIST_READING,
-            FieldNames.ARTIST_READING_HIRAGANA,
+            FieldNames.ARTIST,
             FieldNames.FOLDER ),
         boosts(
-            entry(FieldNames.ALBUM_READING_HIRAGANA, 1.4F),
-            entry(FieldNames.ALBUM_FULL, 1.3F),
-            entry(FieldNames.ARTIST_READING_HIRAGANA, 1.2F),
-            entry(FieldNames.ARTIST_FULL, 1.1F))),
+            entry(FieldNames.ALBUM_READING_HIRAGANA, 2.4F),
+            entry(FieldNames.ALBUM_FULL, 2.3F),
+            entry(FieldNames.ALBUM, 2.2F),
+            entry(FieldNames.ARTIST_READING, 1.1F))),
 
     ALBUM_ID3(
         fieldNames(
-            FieldNames.ALBUM,
-            FieldNames.ALBUM_FULL,
             FieldNames.ALBUM_READING_HIRAGANA,
-            FieldNames.ARTIST,
-            FieldNames.ARTIST_FULL,
+            FieldNames.ALBUM_FULL,
+            FieldNames.ALBUM,
             FieldNames.ARTIST_READING,
-            FieldNames.ARTIST_READING_HIRAGANA,
+            FieldNames.ARTIST,
             FieldNames.FOLDER_ID ),
         boosts(
-            entry(FieldNames.ALBUM_READING_HIRAGANA, 1.4F),
-            entry(FieldNames.ALBUM_FULL, 1.3F),
-            entry(FieldNames.ARTIST_READING_HIRAGANA, 1.2F),
-            entry(FieldNames.ARTIST_FULL, 1.1F))),
-
+            entry(FieldNames.ALBUM_READING_HIRAGANA, 2.4F),
+            entry(FieldNames.ALBUM_FULL, 2.3F),
+            entry(FieldNames.ALBUM, 2.2F),
+            entry(FieldNames.ARTIST_READING, 1.1F))),
     ARTIST(
         fieldNames(
-            FieldNames.ARTIST,
-            FieldNames.ARTIST_FULL,
             FieldNames.ARTIST_READING,
-            FieldNames.ARTIST_READING_HIRAGANA,
-            FieldNames.FOLDER ),
+            FieldNames.ARTIST,
+            FieldNames.FOLDER),
         boosts(
-            entry(FieldNames.ARTIST_READING_HIRAGANA, 1.2F),
-            entry(FieldNames.ARTIST_FULL, 1.1F))),
+            entry(FieldNames.ARTIST_READING, 1.1F))),
 
     ARTIST_ID3(
         fieldNames(
-            FieldNames.ARTIST,
-            FieldNames.ARTIST_FULL,
             FieldNames.ARTIST_READING,
-            FieldNames.ARTIST_READING_HIRAGANA ),
+            FieldNames.ARTIST),
         boosts(
-            entry(FieldNames.ARTIST_READING_HIRAGANA, 1.2F),
-            entry(FieldNames.ARTIST_FULL, 1.1F))),
-
-    NAME_TITLE(
-            fieldNames(
-                FieldNames.TITLE_READING_HIRAGANA,
-                FieldNames.TITLE),
-            boosts(
-                entry(FieldNames.TITLE_READING_HIRAGANA, 1.1F))),
-
-    NAME_ALBUM(
-            fieldNames(
-                FieldNames.ALBUM_READING_HIRAGANA,
-                FieldNames.ALBUM_FULL,
-                FieldNames.ALBUM),
-            boosts(
-                entry(FieldNames.ALBUM_READING_HIRAGANA, 1.2F),
-                entry(FieldNames.ALBUM_FULL, 1.1F))),
-
-    NAME_ARTIST(
-            fieldNames(
-                FieldNames.ARTIST_READING_HIRAGANA,
-                FieldNames.ARTIST_READING,
-                FieldNames.ARTIST_FULL,
-                FieldNames.ARTIST),
-            boosts(
-                entry(FieldNames.ARTIST_READING_HIRAGANA, 1.2F),
-                entry(FieldNames.ARTIST_FULL, 1.1F)))
+            entry(FieldNames.ARTIST_READING, 1.1F))),
 
     ;
 
@@ -167,9 +127,7 @@ public enum IndexType {
 
         /* Emphasis on complementation as artists are less data and more important */
         public static final String ARTIST =                  "art";   // * Normal analysis 
-        public static final String ARTIST_FULL =             "artF";  // Registration when other than hiragana (possibility of various character types)
         public static final String ARTIST_READING =          "artR";  // * Sort key (possibility of various character types)
-        public static final String ARTIST_READING_HIRAGANA = "artRH"; // Convert to Hiragana and register
 
         public static final String ALBUM =                   "alb";   // * Normal analysis
         public static final String ALBUM_FULL =              "albF";  // Registration when other than hiragana

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/analysis/Id3ArtistTokenizer.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/analysis/Id3ArtistTokenizer.java
@@ -1,0 +1,71 @@
+package com.tesshu.jpsonic.service.search.analysis;
+
+import org.apache.lucene.analysis.util.CharTokenizer;
+import org.apache.lucene.util.AttributeFactory;
+
+/**
+ * A tokenizer that divides artist text at devide characters defined by id3, or
+ * whitespace and comma.
+ */
+public class Id3ArtistTokenizer extends CharTokenizer {
+
+    /**
+     * Construct a new Id3ArtistTokenizer.
+     */
+    public Id3ArtistTokenizer() {
+    }
+
+    /**
+     * Construct a new Id3ArtistTokenizer using a given
+     * {@link org.apache.lucene.util.AttributeFactory}.
+     *
+     * @param factory the attribute factory to use for this {@link Tokenizer}
+     */
+    public Id3ArtistTokenizer(AttributeFactory factory) {
+        super(factory);
+    }
+
+    /**
+     * Construct a new Id3ArtistTokenizer using a given
+     * {@link org.apache.lucene.util.AttributeFactory}.
+     *
+     * @param factory     the attribute factory to use for this {@link Tokenizer}
+     * @param maxTokenLen maximum token length the tokenizer will emit. Must be
+     *                    greater than 0 and less than MAX_TOKEN_LENGTH_LIMIT
+     *                    (1024*1024)
+     * @throws IllegalArgumentException if maxTokenLen is invalid.
+     */
+    public Id3ArtistTokenizer(AttributeFactory factory, int maxTokenLen) {
+        super(factory, maxTokenLen);
+    }
+
+    /**
+     * Collects only characters which do not satisfy
+     */
+    @Override
+    protected boolean isTokenChar(int c) {
+
+        /*
+         * see http://id3.org/
+         * ; v2.2 
+         * / v2.3
+         * \0 v2.4 (Unnecessary)
+         */
+        int id3delim = ';' | '/';
+
+        if (id3delim == c) {
+            return false;
+        }
+
+        if (Character.SPACE_SEPARATOR == Character.getType(c)) {
+            return false;
+        }
+
+        if (',' == c) {
+            return false;
+        }
+
+        return true;
+    }
+
+}

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/analysis/Id3ArtistTokenizerFactory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/analysis/Id3ArtistTokenizerFactory.java
@@ -1,0 +1,32 @@
+package com.tesshu.jpsonic.service.search.analysis;
+
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.util.CharTokenizer;
+import org.apache.lucene.analysis.util.TokenizerFactory;
+import org.apache.lucene.util.AttributeFactory;
+
+import java.util.Map;
+
+import static org.apache.lucene.analysis.standard.StandardTokenizer.MAX_TOKEN_LENGTH_LIMIT;
+
+public class Id3ArtistTokenizerFactory extends TokenizerFactory {
+
+    private final int maxTokenLen;
+
+    public Id3ArtistTokenizerFactory(Map<String, String> args) {
+        super(args);
+        maxTokenLen = getInt(args, "maxTokenLen", CharTokenizer.DEFAULT_MAX_WORD_LEN);
+        if (maxTokenLen > MAX_TOKEN_LENGTH_LIMIT || maxTokenLen <= 0) {
+            throw new IllegalArgumentException("maxTokenLen must be greater than 0 and less than " + MAX_TOKEN_LENGTH_LIMIT + " passed: " + maxTokenLen);
+        }
+        if (!args.isEmpty()) {
+            throw new IllegalArgumentException("Unknown parameters: " + args);
+        }
+    }
+
+    @Override
+    public Tokenizer create(AttributeFactory factory) {
+        return new Id3ArtistTokenizer(factory, maxTokenLen);
+    }
+
+}

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/analysis/ToHiraganaFilter.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/analysis/ToHiraganaFilter.java
@@ -8,13 +8,10 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 
 import java.io.IOException;
 import java.lang.Character.UnicodeBlock;
-import java.util.regex.Pattern;
 
 public class ToHiraganaFilter extends TokenFilter {
 
     private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
-
-    private static final Pattern ALPHANUMERIC_CHARACTERS = Pattern.compile("^[a-zA-Z0-9]+$");
 
     public ToHiraganaFilter(TokenStream in) {
         super(in);
@@ -32,10 +29,7 @@ public class ToHiraganaFilter extends TokenFilter {
     @Override
     public final boolean incrementToken() throws IOException {
         if (input.incrementToken()) {
-            if (ALPHANUMERIC_CHARACTERS.matcher(termAtt).matches()) {
-                input.end();
-                return false;
-            } else if (containsKatakana(termAtt.buffer())) {
+            if (containsKatakana(termAtt.buffer())) {
                 String s = Transliterator.getInstance("Katakana-Hiragana").transliterate(termAtt.toString());
                 clearAttributes();
                 termAtt.append(s);

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/SearchService.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/SearchService.java
@@ -386,30 +386,16 @@ public class SearchService {
             return result;
         }
 
-        IndexType nameType = null;
-        switch (fieldName) {
-            case FieldNames.ARTIST:
-                nameType = IndexType.NAME_ARTIST;
-                break;
-            case FieldNames.ALBUM:
-                nameType = IndexType.NAME_ALBUM;
-                break;
-            case FieldNames.TITLE:
-                nameType = IndexType.NAME_TITLE;
-                break;
-            default:
-                break;
-        }
-
-        Query query = queryFactory.searchByName(name, folderList, nameType);
+        Query query = queryFactory.searchByName(name, folderList, indexType);
         IndexSearcher searcher = getSearcher(indexType);
         if(isEmpty(searcher)) {
             return result;
         }
 
         try {
-            SortField[] sortFields = Arrays.stream(nameType.getFields())
+            SortField[] sortFields = Arrays.stream(indexType.getFields())
                     .map(n -> new SortField(n, SortField.Type.STRING))
+                    .filter(n -> !FieldNames.FOLDER.equals(n.toString()) && !FieldNames.FOLDER_ID.equals(n.toString()))
                     .toArray(i -> new SortField[i]);
             Sort sort = new Sort(sortFields);
             TopDocs topDocs = searcher.search(query, offset + count, sort);

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -30,6 +30,9 @@ import org.jaudiotagger.audio.AudioFileIO;
 import org.jaudiotagger.audio.AudioHeader;
 import org.jaudiotagger.tag.FieldKey;
 import org.jaudiotagger.tag.Tag;
+import org.jaudiotagger.tag.id3.AbstractID3Tag;
+import org.jaudiotagger.tag.id3.ID3v24Frames;
+import org.jaudiotagger.tag.id3.ID3v24Tag;
 import org.jaudiotagger.tag.images.Artwork;
 import org.jaudiotagger.tag.reference.GenreTypes;
 import org.slf4j.Logger;
@@ -95,15 +98,96 @@ public class JaudiotaggerParser extends MetaDataParser {
                 metaData.setDiscNumber(parseInteger(getTagField(tag, FieldKey.DISC_NO)));
                 metaData.setTrackNumber(parseTrackNumber(getTagField(tag, FieldKey.TRACK)));
                 metaData.setMusicBrainzReleaseId(getTagField(tag, FieldKey.MUSICBRAINZ_RELEASEID));
-
-                String songArtist = getTagField(tag, FieldKey.ARTIST);
-                String albumArtist = getTagField(tag, FieldKey.ALBUM_ARTIST);
-                metaData.setArtist(StringUtils.isBlank(songArtist) ? albumArtist : songArtist);
-                metaData.setAlbumArtist(StringUtils.isBlank(albumArtist) ? songArtist : albumArtist);
                 metaData.setArtistSort(getTagField(tag, FieldKeyExtension.ARTISTSORT));
                 metaData.setAlbumSort(getTagField(tag, FieldKeyExtension.ALBUMSORT));
                 metaData.setTitleSort(getTagField(tag, FieldKeyExtension.TITLESORT));
                 metaData.setAlbumArtistSort(getTagField(tag, FieldKeyExtension.ALBUMARTISTSORT));
+
+                String songArtist = getTagField(tag, FieldKey.ARTIST);
+                String albumArtist = getTagField(tag, FieldKey.ALBUM_ARTIST);
+
+                if (tag instanceof AbstractID3Tag && 0 < audioFile.getTag().getFieldCount()) {
+
+                    AbstractID3Tag id3Tag = (AbstractID3Tag)tag;
+                    if (ID3v24Tag.RELEASE == id3Tag.getRelease()
+                            && ID3v24Tag.MAJOR_VERSION == id3Tag.getMajorVersion()
+                            && ID3v24Tag.REVISION == id3Tag.getRevision()) {
+
+                        audioFile.getTag().getFields().forEachRemaining(f -> {
+                            switch (f.getId()) {
+                                case ID3v24Frames.FRAME_ID_ALBUM:
+                                    if (null == metaData.getAlbumName()) {
+                                        metaData.setAlbumName(f.toString());
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_TITLE:
+                                    if (null == metaData.getTitle()) {
+                                        metaData.setTitle(f.toString());
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_YEAR:
+                                    if (null == metaData.getYear()) {
+                                        metaData.setYear(parseYear(f.toString()));
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_GENRE:
+                                    if (null == metaData.getGenre()) {
+                                        metaData.setGenre(mapGenre(f.toString()));
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_SET:
+                                    if (null == metaData.getDiscNumber()) {
+                                        metaData.setDiscNumber(parseInteger(f.toString()));
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_TRACK:
+                                    if (null == metaData.getTrackNumber()) {
+                                        metaData.setTrackNumber(parseTrackNumber(f.toString()));
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_ARTIST:
+                                    if (null == metaData.getArtist() && null == songArtist) {
+                                        metaData.setArtist(f.toString());
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_ACCOMPANIMENT:
+                                    if (null == metaData.getAlbumArtist()) {
+                                        metaData.setAlbumArtist(f.toString());
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_ARTIST_SORT_ORDER:
+                                    if (null == metaData.getArtistSort()) {
+                                        metaData.setArtistSort(f.toString());
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_ALBUM_SORT_ORDER:
+                                    if (null == metaData.getAlbumSort()) {
+                                        metaData.setAlbumSort(f.toString());
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_TITLE_SORT_ORDER:
+                                    if (null == metaData.getTitleSort()) {
+                                        metaData.setTitleSort(f.toString());
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_ALBUM_ARTIST_SORT_ORDER_ITUNES:
+                                    if (null == metaData.getAlbumArtistSort()) {
+                                        metaData.setAlbumArtistSort(f.toString());
+                                    }
+                                    break;
+                                default:
+                                    break;
+                            }
+                        });
+                    }
+                }
+                if(StringUtils.isBlank(metaData.getArtist())) {
+                    metaData.setArtist(StringUtils.isBlank(songArtist) ? albumArtist : songArtist);
+                }
+                if(StringUtils.isBlank(metaData.getAlbumArtist())) {
+                    metaData.setAlbumArtist(StringUtils.isBlank(albumArtist) ? songArtist : albumArtist);
+                }
+
             }
 
             AudioHeader audioHeader = audioFile.getAudioHeader();
@@ -138,7 +222,7 @@ public class JaudiotaggerParser extends MetaDataParser {
             return null;
         }
     }
-
+    
     /**
      * Returns all tags supported by id3v1.
      */

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/SearchServiceTestCase.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/SearchServiceTestCase.java
@@ -209,7 +209,8 @@ public class SearchServiceTestCase {
         "02 - Gaspard de la Nuit - ii. Le Gibet", result.getMediaFiles().get(1).getTitle());
 
     //  testSearchByName()
-    String albumName = "Sackcloth 'n' Ashes";
+    //String albumName = "Sackcloth 'n' Ashes"; hit n !
+    String albumName = "Sackcloth";
     ParamSearchResult<Album> albumResult = searchService.searchByName(albumName, 0, Integer.MAX_VALUE, allMusicFolders, Album.class);
     Assert.assertEquals(
         "(17) Specify album name '" + albumName + "' as the name, and get an album.", 1, albumResult.getItems().size());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/AnalyzerFactoryTestCase.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/AnalyzerFactoryTestCase.java
@@ -66,7 +66,6 @@ public class AnalyzerFactoryTestCase extends TestCase {
         });
 
         String[] oneTokenOtherthanHiraFields = {
-                FieldNames.ARTIST_FULL,
                 FieldNames.ALBUM_FULL, };
         Arrays.stream(oneTokenOtherthanHiraFields).forEach(n -> {
             List<String> terms = toTermString(n, queryEng);
@@ -81,8 +80,7 @@ public class AnalyzerFactoryTestCase extends TestCase {
 
         String[] oneTokenHiraFields = {
                 FieldNames.ALBUM_READING_HIRAGANA,
-                FieldNames.TITLE_READING_HIRAGANA,
-                FieldNames.ARTIST_READING_HIRAGANA, };
+                FieldNames.TITLE_READING_HIRAGANA };
         Arrays.stream(oneTokenHiraFields).forEach(n -> {
             List<String> terms = toTermString(n, queryEng);
             assertEquals("oneTokenHira(Eng) : " + n, 0, terms.size());
@@ -106,18 +104,6 @@ public class AnalyzerFactoryTestCase extends TestCase {
             List<String> terms = toTermString(n, queryMix);
             assertEquals("oneTokenHira(Mix) : " + n, 0, terms.size());
         });
-
-        /*
-         * Hiragana is expected because of the analysis result or the item that contains
-         * the data of CDDB, but (currently) accept all non-alphanumeric characters.
-         * They are not necessarily Hiragana.
-         */
-        List<String> terms = toTermString(FieldNames.ARTIST_READING_HIRAGANA, queryMix);
-        assertEquals("oneTokenHira(Mix) : " + FieldNames.ARTIST_READING_HIRAGANA, 1, terms.size());
-        terms = toTermString(FieldNames.ARTIST_READING_HIRAGANA, queryHira);
-        assertEquals("oneTokenHira(Hira) : " + FieldNames.ARTIST_READING_HIRAGANA, 1, terms.size());
-        terms = toTermString(FieldNames.ARTIST_READING_HIRAGANA, queryEng);
-        assertEquals("oneTokenHira(Eng) : " + FieldNames.ARTIST_READING_HIRAGANA, 0, terms.size());
 
     }
 
@@ -143,17 +129,15 @@ public class AnalyzerFactoryTestCase extends TestCase {
                     assertEquals("through : " + n, 1, terms.size());
                     assertEquals("through : " + n, query, terms.get(0));
                     break;
-                case FieldNames.ARTIST_FULL:
                 case FieldNames.ALBUM_FULL:
                     assertEquals("apply : " + n, 1, terms.size());
                     assertEquals("apply : " + n, apply1, terms.get(0));
                     break;
-                case FieldNames.ARTIST_READING_HIRAGANA:
+                case FieldNames.ARTIST_READING:
                     assertEquals("apply : " + n, 1, terms.size());
                     assertEquals("apply : " + n, apply2, terms.get(0));
                     break;
                 case FieldNames.ARTIST:
-                case FieldNames.ARTIST_READING:
                 case FieldNames.ALBUM:
                 case FieldNames.TITLE:
                     assertEquals("apply : " + n, 2, terms.size());
@@ -222,13 +206,6 @@ public class AnalyzerFactoryTestCase extends TestCase {
             List<String> noStopTerms = toTermString(n, queryNoStop);
             List<String> jpStopTerms = toTermString(n, queryJpStop);
             switch (n) {
-                case FieldNames.ARTIST_READING_HIRAGANA:
-                    assertEquals("no case : " + n, 0, articleTerms.size());
-                    assertEquals("no case : " + n, 0, indexArticleTerms.size());
-                    assertEquals("no case : " + n, 0, noStopTerms.size());
-                    assertEquals("through : " + n, 1, jpStopTerms.size());
-                    assertEquals("through : " + n, throughJpStop, jpStopTerms.get(0));
-                    break;
                 case FieldNames.TITLE_READING_HIRAGANA:
                 case FieldNames.ALBUM_READING_HIRAGANA:
                     assertEquals("no case : " + n, 0, articleTerms.size());
@@ -248,7 +225,6 @@ public class AnalyzerFactoryTestCase extends TestCase {
                     assertEquals("through : " + n, 1, jpStopTerms.size());
                     assertEquals("through : " + n, queryJpStop, jpStopTerms.get(0));
                     break;
-                case FieldNames.ARTIST_FULL:
                 case FieldNames.ALBUM_FULL:
                     assertEquals("through : " + n, 1, articleTerms.size());
                     assertEquals("through : " + n, throughArticle, articleTerms.get(0));
@@ -326,17 +302,15 @@ public class AnalyzerFactoryTestCase extends TestCase {
                     assertEquals("through : " + n, 1, terms.size());
                     assertEquals("through : " + n, query, terms.get(0));
                     break;
-                case FieldNames.ARTIST_FULL:
                 case FieldNames.ALBUM_FULL:
                     assertEquals("apply : " + n, 1, terms.size());
                     assertEquals("apply : " + n, expected1, terms.get(0));
                     break;
-                case FieldNames.ARTIST_READING_HIRAGANA:
+                case FieldNames.ARTIST_READING:
                     assertEquals("apply : " + n, 1, terms.size());
                     assertEquals("apply : " + n, expected2, terms.get(0));
                     break;
                 case FieldNames.ARTIST:
-                case FieldNames.ARTIST_READING:
                 case FieldNames.ALBUM:
                 case FieldNames.TITLE:
                     assertEquals("apply : " + n, 2, terms.size());
@@ -374,14 +348,12 @@ public class AnalyzerFactoryTestCase extends TestCase {
                     assertEquals("through : " + n, 1, terms.size());
                     assertEquals("through : " + n, query, terms.get(0));
                     break;
-                case FieldNames.ARTIST_FULL:
                 case FieldNames.ALBUM_FULL:
-                case FieldNames.ARTIST_READING_HIRAGANA:
+                case FieldNames.ARTIST_READING:
                     assertEquals("apply : " + n, 1, terms.size());
                     assertEquals("apply : " + n, expected1, terms.get(0));
                     break;
                 case FieldNames.ARTIST:
-                case FieldNames.ARTIST_READING:
                 case FieldNames.ALBUM:
                 case FieldNames.TITLE:
                     assertEquals("apply : " + n, 2, terms.size());
@@ -417,29 +389,23 @@ public class AnalyzerFactoryTestCase extends TestCase {
                     assertEquals("through : " + n, 1, terms.size());
                     assertEquals("through : " + n, query, terms.get(0));
                     break;
-                case FieldNames.ARTIST_FULL:
                 case FieldNames.ALBUM_FULL:
-                    assertEquals("apply : " + n, 1, terms.size());
-                    assertEquals("apply : " + n, expected2, terms.get(0));
+                case FieldNames.ARTIST_READING:
+                    assertEquals("token through filtered : " + n, 1, terms.size());
+                    assertEquals("token through filtered : " + n, expected2, terms.get(0));
                     break;
                 case FieldNames.ARTIST:
-                case FieldNames.ARTIST_READING:
                 case FieldNames.ALBUM:
                 case FieldNames.TITLE:
-                    assertEquals("apply : " + n, 2, terms.size());
-                    assertEquals("apply : " + n, expected2a, terms.get(0));
-                    assertEquals("apply : " + n, expected2b, terms.get(1));
-                    break;
-                case FieldNames.ARTIST_READING_HIRAGANA:
-                    terms = toTermString(n, queryJp);
-                    assertEquals("apply : " + n, 1, terms.size());
-                    assertEquals("apply : " + n, expectedJp, terms.get(0));
+                    assertEquals("tokend : " + n, 2, terms.size());
+                    assertEquals("tokend : " + n, expected2a, terms.get(0));
+                    assertEquals("tokend : " + n, expected2b, terms.get(1));
                     break;
                 case FieldNames.TITLE_READING_HIRAGANA:
                 case FieldNames.ALBUM_READING_HIRAGANA:
                     terms = toTermString(n, queryJp);
-                    assertEquals("apply : " + n, 1, terms.size());
-                    assertEquals("apply : " + n, expectedJp, terms.get(0));
+                    assertEquals("token through filtered : " + n, 1, terms.size());
+                    assertEquals("token through filtered : " + n, expectedJp, terms.get(0));
                     break;
                 default:
                     break;
@@ -461,7 +427,7 @@ public class AnalyzerFactoryTestCase extends TestCase {
         String expected3 = "abc123あいう";
         String notPass = "あいう";
 
-        String[] otherThanHiraganaFields = { FieldNames.ARTIST_FULL, FieldNames.ALBUM_FULL };
+        String[] otherThanHiraganaFields = { FieldNames.ALBUM_FULL };
         Arrays.stream(otherThanHiraganaFields).forEach(n -> {
             List<String> terms = toTermString(n, passable1);
             assertEquals("all Alpha : " + n, 1, terms.size());
@@ -507,8 +473,6 @@ public class AnalyzerFactoryTestCase extends TestCase {
     }
 
     /*
-     * ARTIST_READING_HIRAGANA rejects alphanumeric input only.
-     * They are supported by other fields.
      * Katakana is converted to hiragana.
      * This is primarily intended for CDDB input.
      * (It is not decided whether to register in CDDB with Katakana/Hiragana)
@@ -522,12 +486,14 @@ public class AnalyzerFactoryTestCase extends TestCase {
         String passable2 = "ABC123アイウ";
         String expected2 = "abc123あいう";
 
-        String n = FieldNames.ARTIST_READING_HIRAGANA;
+        String n = FieldNames.ARTIST_READING;
 
         List<String> terms = toTermString(n, notChange1);
-        assertEquals("all Alpha : " + n, 0, terms.size());
+        assertEquals("all Alpha : " + n, 2, terms.size());
+        assertEquals("all Alpha : " + n, "blue", terms.get(0));
+        assertEquals("all Alpha : " + n, "hearts", terms.get(1));
         terms = toTermString(n, notChange2);
-        assertEquals("AlphaNum : " + n, 0, terms.size());
+        assertEquals("AlphaNum : " + n, 1, terms.size());
         terms = toTermString(n, passable1);
         assertEquals("AlphaNumHiragana : " + n, 1, terms.size());
         assertEquals("AlphaNumHiragana : " + n, expected1, terms.get(0));
@@ -586,7 +552,6 @@ public class AnalyzerFactoryTestCase extends TestCase {
                     assertEquals("normal : " + n, 1, queryTerms.size());
                     assertEquals("normal : " + n, terms.get(0), queryTerms.get(0));
                     break;
-                case FieldNames.ARTIST_FULL:
                 case FieldNames.ALBUM_FULL:
                     assertEquals("normal : " + n, 1, terms.size());
                     assertEquals("normal : " + n, expected1, terms.get(0));
@@ -604,7 +569,6 @@ public class AnalyzerFactoryTestCase extends TestCase {
                     assertEquals("wild : " + n, expected2aWild, queryTerms.get(0));
                     assertEquals("wild : " + n, expected2bWild, queryTerms.get(1));
                     break;
-                case FieldNames.ARTIST_READING_HIRAGANA:
                 case FieldNames.TITLE_READING_HIRAGANA:
                 case FieldNames.ALBUM_READING_HIRAGANA:
                     assertEquals("trancate : " + n, 0, terms.size());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/DocumentFactoryTestCase.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/DocumentFactoryTestCase.java
@@ -69,9 +69,7 @@ public class DocumentFactoryTestCase {
         assertEquals("FieldNames.ALBUM_FULL", "name", document.get(FieldNames.ALBUM_FULL));
         assertEquals("FieldNames.ALBUM_READING_HIRAGANA", "nameSort", document.get(FieldNames.ALBUM_READING_HIRAGANA));
         assertEquals("FieldNames.ARTIST", "artist", document.get(FieldNames.ARTIST));
-        assertEquals("FieldNames.ARTIST_FULL", "artist", document.get(FieldNames.ARTIST_FULL));
         assertEquals("FieldNames.ARTIST_READING", "artistSort", document.get(FieldNames.ARTIST_READING));
-        assertEquals("FieldNames.ARTIST_READING_HIRAGANA", "artistSort", document.get(FieldNames.ARTIST_READING_HIRAGANA));
         assertEquals("FieldNames.FOLDER_ID", "10", document.get(FieldNames.FOLDER_ID));
     }
 
@@ -88,9 +86,7 @@ public class DocumentFactoryTestCase {
         Document document = documentFactory.createDocument(artist, musicFolder);
         assertEquals("FieldNames.ID", "1", document.get(FieldNames.ID));
         assertEquals("FieldNames.ARTIST", "name", document.get(FieldNames.ARTIST));
-        assertEquals("FieldNames.ARTIST_FULL", "name", document.get(FieldNames.ARTIST_FULL));
         assertEquals("FieldNames.ARTIST_READING", "sort", document.get(FieldNames.ARTIST_READING));
-        assertEquals("FieldNames.ARTIST_READING_HIRAGANA", "sort", document.get(FieldNames.ARTIST_READING_HIRAGANA));
         assertNotEquals("FieldNames.FOLDER_ID", "10", document.get(FieldNames.FOLDER_ID));
         assertEquals("FieldNames.FOLDER_ID", "100", document.get(FieldNames.FOLDER_ID));
     }
@@ -115,9 +111,7 @@ public class DocumentFactoryTestCase {
         assertEquals("FieldNames.ALBUM_FULL", "albumName", document.get(FieldNames.ALBUM_FULL));
         assertEquals("FieldNames.ALBUM_READING_HIRAGANA", "albumSort", document.get(FieldNames.ALBUM_READING_HIRAGANA));
         assertEquals("FieldNames.ARTIST", "artist", document.get(FieldNames.ARTIST));
-        assertEquals("FieldNames.ARTIST_FULL", "artist", document.get(FieldNames.ARTIST_FULL));
         assertEquals("FieldNames.ARTIST_READING", "artistSort", document.get(FieldNames.ARTIST_READING));
-        assertEquals("FieldNames.ARTIST_READING_HIRAGANA", "artistSort", document.get(FieldNames.ARTIST_READING_HIRAGANA));
         assertEquals("FieldNames.FOLDER_ID", "folder", document.get(FieldNames.FOLDER));
     }
 
@@ -131,9 +125,7 @@ public class DocumentFactoryTestCase {
         Document document = documentFactory.createDocument(IndexType.ARTIST, artist);
         assertEquals("FieldNames.ID", "1", document.get(FieldNames.ID));
         assertEquals("FieldNames.ARTIST", "artist", document.get(FieldNames.ARTIST));
-        assertEquals("FieldNames.ARTIST_FULL", "artist", document.get(FieldNames.ARTIST_FULL));
         assertEquals("FieldNames.ARTIST_READING", "artistSort", document.get(FieldNames.ARTIST_READING));
-        assertEquals("FieldNames.ARTIST_READING_HIRAGANA", "artistSort", document.get(FieldNames.ARTIST_READING_HIRAGANA));
         assertEquals("FieldNames.FOLDER_ID", "folder", document.get(FieldNames.FOLDER));
     }
 
@@ -152,9 +144,7 @@ public class DocumentFactoryTestCase {
         Document document = documentFactory.createDocument(IndexType.SONG, song);
         assertEquals("FieldNames.ID", "1", document.get(FieldNames.ID));
         assertEquals("FieldNames.ARTIST", "artist", document.get(FieldNames.ARTIST));
-        assertEquals("FieldNames.ARTIST_FULL", "artist", document.get(FieldNames.ARTIST_FULL));
         assertEquals("FieldNames.ARTIST_READING", "artistSort", document.get(FieldNames.ARTIST_READING));
-        assertEquals("FieldNames.ARTIST_READING_HIRAGANA", "artistSort", document.get(FieldNames.ARTIST_READING_HIRAGANA));
         assertEquals("FieldNames.TITLE", "title", document.get(FieldNames.TITLE));
         assertEquals("FieldNames.TITLE_READING_HIRAGANA", "titleSort", document.get(FieldNames.TITLE_READING_HIRAGANA));
         assertEquals("FieldNames.MEDIA_TYPE", "MUSIC", document.get(FieldNames.MEDIA_TYPE));
@@ -171,9 +161,7 @@ public class DocumentFactoryTestCase {
         assertNull("FieldNames.ALBUM_FULL", document.get(FieldNames.ALBUM_FULL));
         assertNull("FieldNames.ALBUM_READING_HIRAGANA", document.get(FieldNames.ALBUM_READING_HIRAGANA));
         assertNull("FieldNames.ARTIST", document.get(FieldNames.ARTIST));
-        assertNull("FieldNames.ARTIST_FULL", document.get(FieldNames.ARTIST_FULL));
         assertNull("FieldNames.ARTIST_READING", document.get(FieldNames.ARTIST_READING));
-        assertNull("FieldNames.ARTIST_READING_HIRAGANA", document.get(FieldNames.ARTIST_READING_HIRAGANA));
         assertNull("FieldNames.FOLDER_ID", document.get(FieldNames.FOLDER_ID));
     }
 
@@ -184,9 +172,7 @@ public class DocumentFactoryTestCase {
         Document document = documentFactory.createDocument(new Artist(), musicFolder);
         assertEquals("FieldNames.ID", "0", document.get(FieldNames.ID)); // Because domain getter is int type
         assertNull("FieldNames.ARTIST", document.get(FieldNames.ARTIST));
-        assertNull("FieldNames.ARTIST_FULL", document.get(FieldNames.ARTIST_FULL));
         assertNull("FieldNames.ARTIST_READING", document.get(FieldNames.ARTIST_READING));
-        assertNull("FieldNames.ARTIST_READING_HIRAGANA", document.get(FieldNames.ARTIST_READING_HIRAGANA));
         assertNotEquals("FieldNames.FOLDER_ID", "10", document.get(FieldNames.FOLDER_ID));
         assertEquals("FieldNames.FOLDER_ID", "100", document.get(FieldNames.FOLDER_ID));
     }
@@ -202,9 +188,7 @@ public class DocumentFactoryTestCase {
         assertNull("FieldNames.ALBUM_FULL", document.get(FieldNames.ALBUM_FULL));
         assertNull("FieldNames.ALBUM_READING_HIRAGANA", document.get(FieldNames.ALBUM_READING_HIRAGANA));
         assertNull("FieldNames.ARTIST", document.get(FieldNames.ARTIST));
-        assertNull("FieldNames.ARTIST_FULL", document.get(FieldNames.ARTIST_FULL));
         assertNull("FieldNames.ARTIST_READING", document.get(FieldNames.ARTIST_READING));
-        assertNull("FieldNames.ARTIST_READING_HIRAGANA", document.get(FieldNames.ARTIST_READING_HIRAGANA));
     }
 
     @Test
@@ -215,9 +199,7 @@ public class DocumentFactoryTestCase {
         Document document = documentFactory.createDocument(IndexType.ARTIST, mediaFile);
         assertEquals("FieldNames.ID", "0", document.get(FieldNames.ID)); // Because domain getter is int type
         assertNull("FieldNames.ARTIST", document.get(FieldNames.ARTIST));
-        assertNull("FieldNames.ARTIST_FULL", document.get(FieldNames.ARTIST_FULL));
         assertNull("FieldNames.ARTIST_READING", document.get(FieldNames.ARTIST_READING));
-        assertNull("FieldNames.ARTIST_READING_HIRAGANA", document.get(FieldNames.ARTIST_READING_HIRAGANA));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -257,9 +239,7 @@ public class DocumentFactoryTestCase {
         Document document = documentFactory.createDocument(IndexType.SONG, song);
         assertEquals("FieldNames.ID", "0", document.get(FieldNames.ID)); // Because domain getter is int type
         assertNull("FieldNames.ARTIST", document.get(FieldNames.ARTIST));
-        assertNull("FieldNames.ARTIST_FULL", document.get(FieldNames.ARTIST_FULL));
         assertNull("FieldNames.ARTIST_READING", document.get(FieldNames.ARTIST_READING));
-        assertNull("FieldNames.ARTIST_READING_HIRAGANA", document.get(FieldNames.ARTIST_READING_HIRAGANA));
         assertNull("FieldNames.TITLE", document.get(FieldNames.TITLE));
         assertNull("FieldNames.TITLE_READING_HIRAGANA", document.get(FieldNames.TITLE_READING_HIRAGANA));
         assertNull("FieldNames.GENRE", document.get(FieldNames.GENRE));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexTypeTestCase.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexTypeTestCase.java
@@ -34,99 +34,86 @@ public class IndexTypeTestCase extends TestCase {
     @Test
     public void testAlbumBoosts() {
         assertEquals(4, IndexType.ALBUM.getBoosts().size());
-        assertEquals(IndexType.ALBUM.getBoosts().get(FieldNames.ALBUM_READING_HIRAGANA), 1.4F);
-        assertEquals(IndexType.ALBUM.getBoosts().get(FieldNames.ALBUM_FULL), 1.3F);
-        assertEquals(IndexType.ALBUM.getBoosts().get(FieldNames.ARTIST_READING_HIRAGANA), 1.2F);
-        assertEquals(IndexType.ALBUM.getBoosts().get(FieldNames.ARTIST_FULL), 1.1F);
+        assertEquals(IndexType.ALBUM.getBoosts().get(FieldNames.ALBUM_READING_HIRAGANA), 2.4F);
+        assertEquals(IndexType.ALBUM.getBoosts().get(FieldNames.ALBUM_FULL), 2.3F);
+        assertEquals(IndexType.ALBUM.getBoosts().get(FieldNames.ALBUM), 2.2F);
+        assertEquals(IndexType.ALBUM.getBoosts().get(FieldNames.ARTIST_READING), 1.1F);
     }
 
     @Test
     public void testAlbumFields() {
-        assertEquals(8, IndexType.ALBUM.getFields().length);
+        assertEquals(6, IndexType.ALBUM.getFields().length);
         assertEquals(0, Arrays.stream(IndexType.ALBUM.getFields())
                 .filter(f -> FieldNames.ALBUM.equals(f))
                 .filter(f -> FieldNames.ALBUM_FULL.equals(f))
                 .filter(f -> FieldNames.ALBUM_READING_HIRAGANA.equals(f))
                 .filter(f -> FieldNames.ARTIST.equals(f))
-                .filter(f -> FieldNames.ARTIST_FULL.equals(f))
                 .filter(f -> FieldNames.ARTIST_READING.equals(f))
-                .filter(f -> FieldNames.ARTIST_READING_HIRAGANA.equals(f))
                 .filter(f -> FieldNames.FOLDER.equals(f)).count());
     }
     
     @Test
     public void testAlbumId3Boosts() {
         assertEquals(4, IndexType.ALBUM_ID3.getBoosts().size());
-        assertEquals(IndexType.ALBUM_ID3.getBoosts().get(FieldNames.ALBUM_READING_HIRAGANA), 1.4F);
-        assertEquals(IndexType.ALBUM_ID3.getBoosts().get(FieldNames.ALBUM_FULL), 1.3F);
-        assertEquals(IndexType.ALBUM_ID3.getBoosts().get(FieldNames.ARTIST_READING_HIRAGANA), 1.2F);
-        assertEquals(IndexType.ALBUM_ID3.getBoosts().get(FieldNames.ARTIST_FULL), 1.1F);
+        assertEquals(IndexType.ALBUM_ID3.getBoosts().get(FieldNames.ALBUM_READING_HIRAGANA), 2.4F);
+        assertEquals(IndexType.ALBUM_ID3.getBoosts().get(FieldNames.ALBUM_FULL), 2.3F);
+        assertEquals(IndexType.ALBUM_ID3.getBoosts().get(FieldNames.ALBUM), 2.2F);
+        assertEquals(IndexType.ALBUM_ID3.getBoosts().get(FieldNames.ARTIST_READING), 1.1F);
     }
 
     @Test
     public void testAlbumId3Fields() {
-        assertEquals(8, IndexType.ALBUM_ID3.getFields().length);
+        assertEquals(6, IndexType.ALBUM_ID3.getFields().length);
         assertEquals(0, Arrays.stream(IndexType.ALBUM_ID3.getFields())
             .filter(f -> FieldNames.ARTIST.equals(f))
-            .filter(f -> FieldNames.ARTIST_FULL.equals(f))
-            .filter(f -> FieldNames.ARTIST_READING.equals(f))
-            .filter(f -> FieldNames.ARTIST_READING_HIRAGANA.equals(f)).count());
+            .filter(f -> FieldNames.ARTIST_READING.equals(f)).count());
     }
 
     @Test
     public void testArtistBoosts() {
-        assertEquals(2, IndexType.ARTIST.getBoosts().size());
-        assertEquals(IndexType.ARTIST.getBoosts().get(FieldNames.ARTIST_READING_HIRAGANA), 1.2F);
-        assertEquals(IndexType.ARTIST.getBoosts().get(FieldNames.ARTIST_FULL), 1.1F);
+        assertEquals(1, IndexType.ARTIST.getBoosts().size());
+        assertEquals(IndexType.ARTIST.getBoosts().get(FieldNames.ARTIST_READING), 1.1F);
     }
 
     @Test
     public void testArtistFields() {
-        assertEquals(5, IndexType.ARTIST.getFields().length);
+        assertEquals(3, IndexType.ARTIST.getFields().length);
         assertEquals(0, Arrays.stream(IndexType.ARTIST.getFields())
             .filter(f -> FieldNames.ARTIST.equals(f))
-            .filter(f -> FieldNames.ARTIST_FULL.equals(f))
             .filter(f -> FieldNames.ARTIST_READING.equals(f))
-            .filter(f -> FieldNames.ARTIST_READING_HIRAGANA.equals(f))
             .filter(f -> FieldNames.FOLDER.equals(f)).count());
     }
 
     @Test
     public void testArtistId3Boosts() {
-        assertEquals(2, IndexType.ARTIST_ID3.getBoosts().size());
-        assertEquals(IndexType.ARTIST_ID3.getBoosts().get(FieldNames.ARTIST_READING_HIRAGANA), 1.2F);
-        assertEquals(IndexType.ARTIST_ID3.getBoosts().get(FieldNames.ARTIST_FULL), 1.1F);
+        assertEquals(1, IndexType.ARTIST_ID3.getBoosts().size());
+        assertEquals(IndexType.ARTIST_ID3.getBoosts().get(FieldNames.ARTIST_READING), 1.1F);
     }
 
     @Test
     public void testArtistId3Fields() {
-        assertEquals(4, IndexType.ARTIST_ID3.getFields().length);
+        assertEquals(2, IndexType.ARTIST_ID3.getFields().length);
         assertEquals(0, Arrays.stream(IndexType.ARTIST_ID3.getFields())
                 .filter(f -> FieldNames.ARTIST.equals(f))
-                .filter(f -> FieldNames.ARTIST_FULL.equals(f))
-                .filter(f -> FieldNames.ARTIST_READING.equals(f))
-                .filter(f -> FieldNames.ARTIST_READING_HIRAGANA.equals(f)).count());
+                .filter(f -> FieldNames.ARTIST_READING.equals(f)).count());
     }
     
     @Test
     public void testSongBoosts() {
-        assertEquals(4, IndexType.SONG.getBoosts().size());
-        assertEquals(IndexType.SONG.getBoosts().get(FieldNames.TITLE_READING_HIRAGANA), 1.4F);
-        assertEquals(IndexType.SONG.getBoosts().get(FieldNames.TITLE), 1.3F);
-        assertEquals(IndexType.SONG.getBoosts().get(FieldNames.ARTIST_READING_HIRAGANA), 1.2F);
-        assertEquals(IndexType.SONG.getBoosts().get(FieldNames.ARTIST_FULL), 1.1F);
+        assertEquals(3, IndexType.SONG.getBoosts().size());
+        assertEquals(IndexType.SONG.getBoosts().get(FieldNames.TITLE_READING_HIRAGANA), 2.4F);
+        assertEquals(IndexType.SONG.getBoosts().get(FieldNames.TITLE), 2.3F);
+        assertEquals(IndexType.SONG.getBoosts().get(FieldNames.ARTIST_READING), 1.1F);
     }
 
     @Test
     public void testSongFields() {
-        assertEquals(6, IndexType.SONG.getFields().length);
+        assertEquals(4, IndexType.SONG.getFields().length);
         assertEquals(0, Arrays.stream(IndexType.SONG.getFields())
                 .filter(f -> FieldNames.TITLE.equals(f))
                 .filter(f -> FieldNames.TITLE_READING_HIRAGANA.equals(f))
                 .filter(f -> FieldNames.ARTIST.equals(f))
-                .filter(f -> FieldNames.ARTIST_FULL.equals(f))
-                .filter(f -> FieldNames.ARTIST_READING.equals(f))
-                .filter(f -> FieldNames.ARTIST_READING_HIRAGANA.equals(f)).count());
+                .filter(f -> FieldNames.ARTIST_READING.equals(f)).count());
     }
     
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/QueryFactoryTestCase.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/QueryFactoryTestCase.java
@@ -77,18 +77,18 @@ public class QueryFactoryTestCase extends TestCase {
         criteria.setCount(Integer.MAX_VALUE);
         criteria.setQuery(QUERY_PATTERN_INCLUDING_KATAKANA);
         Query query = queryFactory.search(criteria, SINGLE_FOLDERS, IndexType.ARTIST);
-        assertEquals(QUERY_PATTERN_INCLUDING_KATAKANA, "+(art:ネコ* art:abc* (artF:ネコabc*)^1.1 artR:ネコ* artR:abc* (artRH:ねこabc*)^1.2) +(f:" + PATH1 + ")", query.toString());
+        assertEquals(QUERY_PATTERN_INCLUDING_KATAKANA, "+((artR:ねこ*)^1.1 (artR:abc*)^1.1 art:ネコ* art:abc*) +(f:" + PATH1 + ")", query.toString());
         query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.ARTIST);
-        assertEquals(QUERY_PATTERN_INCLUDING_KATAKANA, "+(art:ネコ* art:abc* (artF:ネコabc*)^1.1 artR:ネコ* artR:abc* (artRH:ねこabc*)^1.2) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
+        assertEquals(QUERY_PATTERN_INCLUDING_KATAKANA, "+((artR:ねこ*)^1.1 (artR:abc*)^1.1 art:ネコ* art:abc*) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
         criteria.setQuery(QUERY_PATTERN_ALPHANUMERIC_ONLY);
         query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.ARTIST);
-        assertEquals(QUERY_PATTERN_ALPHANUMERIC_ONLY, "+(art:abc* art:123* (artF:abc123*)^1.1 artR:abc* artR:123*) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
+        assertEquals(QUERY_PATTERN_ALPHANUMERIC_ONLY, "+((artR:abc*)^1.1 (artR:123*)^1.1 art:abc* art:123*) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
         criteria.setQuery(QUERY_PATTERN_HIRAGANA_ONLY);
         query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.ARTIST);
-        assertEquals(QUERY_PATTERN_HIRAGANA_ONLY, "+(art:ねこ* art:いぬ* artR:ねこ* artR:いぬ* (artRH:ねこいぬ*)^1.2) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
+        assertEquals(QUERY_PATTERN_HIRAGANA_ONLY, "+((artR:ねこ*)^1.1 (artR:いぬ*)^1.1 art:ねこ* art:いぬ*) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
         criteria.setQuery(QUERY_PATTERN_OTHERS);
         query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.ARTIST);
-        assertEquals(QUERY_PATTERN_OTHERS, "+(art:abc* art:ねこ* (artF:abcねこ*)^1.1 artR:abc* artR:ねこ* (artRH:abcねこ*)^1.2) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
+        assertEquals(QUERY_PATTERN_OTHERS, "+((artR:abc*)^1.1 (artR:ねこ*)^1.1 art:abc* art:ねこ*) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
     }
 
     @Test
@@ -99,17 +99,17 @@ public class QueryFactoryTestCase extends TestCase {
         criteria.setQuery(QUERY_PATTERN_INCLUDING_KATAKANA);
         Query query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.ALBUM);
         assertEquals(QUERY_PATTERN_INCLUDING_KATAKANA,
-                "+(alb:ネコ* alb:abc* (albF:ネコabc*)^1.3 art:ネコ* art:abc* (artF:ネコabc*)^1.1 artR:ネコ* artR:abc* (artRH:ねこabc*)^1.2) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
+                "+((albF:ネコabc*)^2.3 (alb:ネコ*)^2.2 (alb:abc*)^2.2 (artR:ねこ*)^1.1 (artR:abc*)^1.1 art:ネコ* art:abc*) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
         criteria.setQuery(QUERY_PATTERN_ALPHANUMERIC_ONLY);
         query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.ALBUM);
-        assertEquals(QUERY_PATTERN_ALPHANUMERIC_ONLY, "+(alb:abc* alb:123* (albF:abc123*)^1.3 art:abc* art:123* (artF:abc123*)^1.1 artR:abc* artR:123*) +(f:" + PATH1 + " f:" + PATH2 + ")",
+        assertEquals(QUERY_PATTERN_ALPHANUMERIC_ONLY, "+((albF:abc123*)^2.3 (alb:abc*)^2.2 (alb:123*)^2.2 (artR:abc*)^1.1 (artR:123*)^1.1 art:abc* art:123*) +(f:" + PATH1 + " f:" + PATH2 + ")",
                 query.toString());
         criteria.setQuery(QUERY_PATTERN_HIRAGANA_ONLY);
         query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.ALBUM);
-        assertEquals(QUERY_PATTERN_HIRAGANA_ONLY, "+(alb:ねこ* alb:いぬ* (albRH:ねこいぬ*)^1.4 art:ねこ* art:いぬ* artR:ねこ* artR:いぬ* (artRH:ねこいぬ*)^1.2) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
+        assertEquals(QUERY_PATTERN_HIRAGANA_ONLY, "+((albRH:ねこいぬ*)^2.4 (alb:ねこ*)^2.2 (alb:いぬ*)^2.2 (artR:ねこ*)^1.1 (artR:いぬ*)^1.1 art:ねこ* art:いぬ*) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
         criteria.setQuery(QUERY_PATTERN_OTHERS);
         query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.ALBUM);
-        assertEquals(QUERY_PATTERN_OTHERS, "+(alb:abc* alb:ねこ* (albF:abcねこ*)^1.3 art:abc* art:ねこ* (artF:abcねこ*)^1.1 artR:abc* artR:ねこ* (artRH:abcねこ*)^1.2) +(f:" + PATH1 + " f:" + PATH2 + ")",
+        assertEquals(QUERY_PATTERN_OTHERS, "+((albF:abcねこ*)^2.3 (alb:abc*)^2.2 (alb:ねこ*)^2.2 (artR:abc*)^1.1 (artR:ねこ*)^1.1 art:abc* art:ねこ*) +(f:" + PATH1 + " f:" + PATH2 + ")",
                 query.toString());
     }
 
@@ -120,18 +120,18 @@ public class QueryFactoryTestCase extends TestCase {
         criteria.setCount(Integer.MAX_VALUE);
         criteria.setQuery(QUERY_PATTERN_INCLUDING_KATAKANA);
         Query query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.SONG);
-        assertEquals(QUERY_PATTERN_INCLUDING_KATAKANA, "+((tit:ネコ*)^1.3 (tit:abc*)^1.3 art:ネコ* art:abc* (artF:ネコabc*)^1.1 artR:ネコ* artR:abc* (artRH:ねこabc*)^1.2) +(f:" + PATH1 + " f:" + PATH2 + ")",
+        assertEquals(QUERY_PATTERN_INCLUDING_KATAKANA, "+((tit:ネコ*)^2.3 (tit:abc*)^2.3 (artR:ねこ*)^1.1 (artR:abc*)^1.1 art:ネコ* art:abc*) +(f:" + PATH1 + " f:" + PATH2 + ")",
                 query.toString());
         criteria.setQuery(QUERY_PATTERN_ALPHANUMERIC_ONLY);
         query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.SONG);
-        assertEquals(QUERY_PATTERN_ALPHANUMERIC_ONLY, "+((tit:abc*)^1.3 (tit:123*)^1.3 art:abc* art:123* (artF:abc123*)^1.1 artR:abc* artR:123*) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
+        assertEquals(QUERY_PATTERN_ALPHANUMERIC_ONLY, "+((tit:abc*)^2.3 (tit:123*)^2.3 (artR:abc*)^1.1 (artR:123*)^1.1 art:abc* art:123*) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
         criteria.setQuery(QUERY_PATTERN_HIRAGANA_ONLY);
         query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.SONG);
-        assertEquals(QUERY_PATTERN_HIRAGANA_ONLY, "+((tit:ねこ*)^1.3 (tit:いぬ*)^1.3 (titRH:ねこいぬ*)^1.4 art:ねこ* art:いぬ* artR:ねこ* artR:いぬ* (artRH:ねこいぬ*)^1.2) +(f:" + PATH1 + " f:" + PATH2 + ")",
+        assertEquals(QUERY_PATTERN_HIRAGANA_ONLY, "+((titRH:ねこいぬ*)^2.4 (tit:ねこ*)^2.3 (tit:いぬ*)^2.3 (artR:ねこ*)^1.1 (artR:いぬ*)^1.1 art:ねこ* art:いぬ*) +(f:" + PATH1 + " f:" + PATH2 + ")",
                 query.toString());
         criteria.setQuery(QUERY_PATTERN_OTHERS);
         query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.SONG);
-        assertEquals(QUERY_PATTERN_OTHERS, "+((tit:abc*)^1.3 (tit:ねこ*)^1.3 art:abc* art:ねこ* (artF:abcねこ*)^1.1 artR:abc* artR:ねこ* (artRH:abcねこ*)^1.2) +(f:" + PATH1 + " f:" + PATH2 + ")",
+        assertEquals(QUERY_PATTERN_OTHERS, "+((tit:abc*)^2.3 (tit:ねこ*)^2.3 (artR:abc*)^1.1 (artR:ねこ*)^1.1 art:abc* art:ねこ*) +(f:" + PATH1 + " f:" + PATH2 + ")",
                 query.toString());
     }
 
@@ -142,16 +142,16 @@ public class QueryFactoryTestCase extends TestCase {
         criteria.setCount(Integer.MAX_VALUE);
         criteria.setQuery(QUERY_PATTERN_INCLUDING_KATAKANA);
         Query query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.ARTIST_ID3);
-        assertEquals(QUERY_PATTERN_INCLUDING_KATAKANA, "+(art:ネコ* art:abc* (artF:ネコabc*)^1.1 artR:ネコ* artR:abc* (artRH:ねこabc*)^1.2) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
+        assertEquals(QUERY_PATTERN_INCLUDING_KATAKANA, "+((artR:ねこ*)^1.1 (artR:abc*)^1.1 art:ネコ* art:abc*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
         criteria.setQuery(QUERY_PATTERN_ALPHANUMERIC_ONLY);
         query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.ARTIST_ID3);
-        assertEquals(QUERY_PATTERN_ALPHANUMERIC_ONLY, "+(art:abc* art:123* (artF:abc123*)^1.1 artR:abc* artR:123*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
+        assertEquals(QUERY_PATTERN_ALPHANUMERIC_ONLY, "+((artR:abc*)^1.1 (artR:123*)^1.1 art:abc* art:123*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
         criteria.setQuery(QUERY_PATTERN_HIRAGANA_ONLY);
         query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.ARTIST_ID3);
-        assertEquals(QUERY_PATTERN_HIRAGANA_ONLY, "+(art:ねこ* art:いぬ* artR:ねこ* artR:いぬ* (artRH:ねこいぬ*)^1.2) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
+        assertEquals(QUERY_PATTERN_HIRAGANA_ONLY, "+((artR:ねこ*)^1.1 (artR:いぬ*)^1.1 art:ねこ* art:いぬ*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
         criteria.setQuery(QUERY_PATTERN_OTHERS);
         query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.ARTIST_ID3);
-        assertEquals(QUERY_PATTERN_OTHERS, "+(art:abc* art:ねこ* (artF:abcねこ*)^1.1 artR:abc* artR:ねこ* (artRH:abcねこ*)^1.2) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
+        assertEquals(QUERY_PATTERN_OTHERS, "+((artR:abc*)^1.1 (artR:ねこ*)^1.1 art:abc* art:ねこ*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
     }
 
     @Test
@@ -161,55 +161,54 @@ public class QueryFactoryTestCase extends TestCase {
         criteria.setCount(Integer.MAX_VALUE);
         criteria.setQuery(QUERY_PATTERN_INCLUDING_KATAKANA);
         Query query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.ALBUM_ID3);
-        assertEquals(QUERY_PATTERN_INCLUDING_KATAKANA,
-                "+(alb:ネコ* alb:abc* (albF:ネコabc*)^1.3 art:ネコ* art:abc* (artF:ネコabc*)^1.1 artR:ネコ* artR:abc* (artRH:ねこabc*)^1.2) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
+        assertEquals(QUERY_PATTERN_INCLUDING_KATAKANA, "+((albF:ネコabc*)^2.3 (alb:ネコ*)^2.2 (alb:abc*)^2.2 (artR:ねこ*)^1.1 (artR:abc*)^1.1 art:ネコ* art:abc*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
         criteria.setQuery(QUERY_PATTERN_ALPHANUMERIC_ONLY);
         query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.ALBUM_ID3);
-        assertEquals(QUERY_PATTERN_ALPHANUMERIC_ONLY, "+(alb:abc* alb:123* (albF:abc123*)^1.3 art:abc* art:123* (artF:abc123*)^1.1 artR:abc* artR:123*) +(fId:" + FID1 + " fId:" + FID2 + ")",
+        assertEquals(QUERY_PATTERN_ALPHANUMERIC_ONLY, "+((albF:abc123*)^2.3 (alb:abc*)^2.2 (alb:123*)^2.2 (artR:abc*)^1.1 (artR:123*)^1.1 art:abc* art:123*) +(fId:" + FID1 + " fId:" + FID2 + ")",
                 query.toString());
         criteria.setQuery(QUERY_PATTERN_HIRAGANA_ONLY);
         query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.ALBUM_ID3);
-        assertEquals(QUERY_PATTERN_HIRAGANA_ONLY, "+(alb:ねこ* alb:いぬ* (albRH:ねこいぬ*)^1.4 art:ねこ* art:いぬ* artR:ねこ* artR:いぬ* (artRH:ねこいぬ*)^1.2) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
+        assertEquals(QUERY_PATTERN_HIRAGANA_ONLY, "+((albRH:ねこいぬ*)^2.4 (alb:ねこ*)^2.2 (alb:いぬ*)^2.2 (artR:ねこ*)^1.1 (artR:いぬ*)^1.1 art:ねこ* art:いぬ*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
         criteria.setQuery(QUERY_PATTERN_OTHERS);
         query = queryFactory.search(criteria, MULTI_FOLDERS, IndexType.ALBUM_ID3);
-        assertEquals(QUERY_PATTERN_OTHERS, "+(alb:abc* alb:ねこ* (albF:abcねこ*)^1.3 art:abc* art:ねこ* (artF:abcねこ*)^1.1 artR:abc* artR:ねこ* (artRH:abcねこ*)^1.2) +(fId:" + FID1 + " fId:" + FID2 + ")",
+        assertEquals(QUERY_PATTERN_OTHERS, "+((albF:abcねこ*)^2.3 (alb:abc*)^2.2 (alb:ねこ*)^2.2 (artR:abc*)^1.1 (artR:ねこ*)^1.1 art:abc* art:ねこ*) +(fId:" + FID1 + " fId:" + FID2 + ")",
                 query.toString());
     }
 
     @Test
     public void testSearchByNameArtist() {
-        Query query = queryFactory.searchByName(QUERY_PATTERN_INCLUDING_KATAKANA, MULTI_FOLDERS, IndexType.NAME_ARTIST);
-        assertEquals(QUERY_PATTERN_INCLUDING_KATAKANA, "+((artRH:ねこabc*)^1.2 artR:ネコ* artR:abc* (artF:ネコabc*)^1.1 art:ネコ* art:abc*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
-        query = queryFactory.searchByName(QUERY_PATTERN_ALPHANUMERIC_ONLY, MULTI_FOLDERS, IndexType.NAME_ARTIST);
-        assertEquals(QUERY_PATTERN_ALPHANUMERIC_ONLY, "+(artR:abc* artR:123* (artF:abc123*)^1.1 art:abc* art:123*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
-        query = queryFactory.searchByName(QUERY_PATTERN_HIRAGANA_ONLY, MULTI_FOLDERS, IndexType.NAME_ARTIST);
-        assertEquals(QUERY_PATTERN_HIRAGANA_ONLY, "+((artRH:ねこいぬ*)^1.2 artR:ねこ* artR:いぬ* art:ねこ* art:いぬ*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
-        query = queryFactory.searchByName(QUERY_PATTERN_OTHERS, MULTI_FOLDERS, IndexType.NAME_ARTIST);
-        assertEquals(QUERY_PATTERN_OTHERS, "+((artRH:abcねこ*)^1.2 artR:abc* artR:ねこ* (artF:abcねこ*)^1.1 art:abc* art:ねこ*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
+        Query query = queryFactory.searchByName(QUERY_PATTERN_INCLUDING_KATAKANA, MULTI_FOLDERS, IndexType.ARTIST_ID3);
+        assertEquals(QUERY_PATTERN_INCLUDING_KATAKANA, "+((artR:ねこ*)^1.1 (artR:abc*)^1.1 art:ネコ* art:abc*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
+        query = queryFactory.searchByName(QUERY_PATTERN_ALPHANUMERIC_ONLY, MULTI_FOLDERS, IndexType.ARTIST_ID3);
+        assertEquals(QUERY_PATTERN_ALPHANUMERIC_ONLY, "+((artR:abc*)^1.1 (artR:123*)^1.1 art:abc* art:123*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
+        query = queryFactory.searchByName(QUERY_PATTERN_HIRAGANA_ONLY, MULTI_FOLDERS, IndexType.ARTIST_ID3);
+        assertEquals(QUERY_PATTERN_HIRAGANA_ONLY, "+((artR:ねこ*)^1.1 (artR:いぬ*)^1.1 art:ねこ* art:いぬ*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
+        query = queryFactory.searchByName(QUERY_PATTERN_OTHERS, MULTI_FOLDERS, IndexType.ARTIST_ID3);
+        assertEquals(QUERY_PATTERN_OTHERS, "+((artR:abc*)^1.1 (artR:ねこ*)^1.1 art:abc* art:ねこ*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
     }
 
     @Test
     public void testSearchByNameAlbum() {
-        Query query = queryFactory.searchByName(QUERY_PATTERN_INCLUDING_KATAKANA, MULTI_FOLDERS, IndexType.NAME_ALBUM);
-        assertEquals(QUERY_PATTERN_INCLUDING_KATAKANA, "+((albF:ネコabc*)^1.1 alb:ネコ* alb:abc*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
-        query = queryFactory.searchByName(QUERY_PATTERN_ALPHANUMERIC_ONLY, MULTI_FOLDERS, IndexType.NAME_ALBUM);
-        assertEquals(QUERY_PATTERN_ALPHANUMERIC_ONLY, "+((albF:abc123*)^1.1 alb:abc* alb:123*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
-        query = queryFactory.searchByName(QUERY_PATTERN_HIRAGANA_ONLY, MULTI_FOLDERS, IndexType.NAME_ALBUM);
-        assertEquals(QUERY_PATTERN_HIRAGANA_ONLY, "+((albRH:ねこいぬ*)^1.2 alb:ねこ* alb:いぬ*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
-        query = queryFactory.searchByName(QUERY_PATTERN_OTHERS, MULTI_FOLDERS, IndexType.NAME_ALBUM);
-        assertEquals(QUERY_PATTERN_OTHERS, "+((albF:abcねこ*)^1.1 alb:abc* alb:ねこ*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
+        Query query = queryFactory.searchByName(QUERY_PATTERN_INCLUDING_KATAKANA, MULTI_FOLDERS, IndexType.ALBUM_ID3);
+        assertEquals(QUERY_PATTERN_INCLUDING_KATAKANA, "+((albF:ネコabc*)^2.3 (alb:ネコ*)^2.2 (alb:abc*)^2.2 (artR:ねこ*)^1.1 (artR:abc*)^1.1 art:ネコ* art:abc*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
+        query = queryFactory.searchByName(QUERY_PATTERN_ALPHANUMERIC_ONLY, MULTI_FOLDERS, IndexType.ALBUM_ID3);
+        assertEquals(QUERY_PATTERN_ALPHANUMERIC_ONLY, "+((albF:abc123*)^2.3 (alb:abc*)^2.2 (alb:123*)^2.2 (artR:abc*)^1.1 (artR:123*)^1.1 art:abc* art:123*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
+        query = queryFactory.searchByName(QUERY_PATTERN_HIRAGANA_ONLY, MULTI_FOLDERS, IndexType.ALBUM_ID3);
+        assertEquals(QUERY_PATTERN_HIRAGANA_ONLY, "+((albRH:ねこいぬ*)^2.4 (alb:ねこ*)^2.2 (alb:いぬ*)^2.2 (artR:ねこ*)^1.1 (artR:いぬ*)^1.1 art:ねこ* art:いぬ*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
+        query = queryFactory.searchByName(QUERY_PATTERN_OTHERS, MULTI_FOLDERS, IndexType.ALBUM_ID3);
+        assertEquals(QUERY_PATTERN_OTHERS, "+((albF:abcねこ*)^2.3 (alb:abc*)^2.2 (alb:ねこ*)^2.2 (artR:abc*)^1.1 (artR:ねこ*)^1.1 art:abc* art:ねこ*) +(fId:" + FID1 + " fId:" + FID2 + ")", query.toString());
     }
 
     @Test
     public void testSearchByNameTitle() {
-        Query query = queryFactory.searchByName(QUERY_PATTERN_INCLUDING_KATAKANA, MULTI_FOLDERS, IndexType.NAME_TITLE);
-        assertEquals(QUERY_PATTERN_INCLUDING_KATAKANA, "+(tit:ネコ* tit:abc*) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
-        query = queryFactory.searchByName(QUERY_PATTERN_ALPHANUMERIC_ONLY, MULTI_FOLDERS, IndexType.NAME_TITLE);
-        assertEquals(QUERY_PATTERN_ALPHANUMERIC_ONLY, "+(tit:abc* tit:123*) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
-        query = queryFactory.searchByName(QUERY_PATTERN_HIRAGANA_ONLY, MULTI_FOLDERS, IndexType.NAME_TITLE);
-        assertEquals(QUERY_PATTERN_HIRAGANA_ONLY, "+((titRH:ねこいぬ*)^1.1 tit:ねこ* tit:いぬ*) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
-        query = queryFactory.searchByName(QUERY_PATTERN_OTHERS, MULTI_FOLDERS, IndexType.NAME_TITLE);
-        assertEquals(QUERY_PATTERN_OTHERS, "+(tit:abc* tit:ねこ*) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
+        Query query = queryFactory.searchByName(QUERY_PATTERN_INCLUDING_KATAKANA, MULTI_FOLDERS, IndexType.SONG);
+        assertEquals(QUERY_PATTERN_INCLUDING_KATAKANA, "+((tit:ネコ*)^2.3 (tit:abc*)^2.3 (artR:ねこ*)^1.1 (artR:abc*)^1.1 art:ネコ* art:abc*) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
+        query = queryFactory.searchByName(QUERY_PATTERN_ALPHANUMERIC_ONLY, MULTI_FOLDERS, IndexType.SONG);
+        assertEquals(QUERY_PATTERN_ALPHANUMERIC_ONLY, "+((tit:abc*)^2.3 (tit:123*)^2.3 (artR:abc*)^1.1 (artR:123*)^1.1 art:abc* art:123*) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
+        query = queryFactory.searchByName(QUERY_PATTERN_HIRAGANA_ONLY, MULTI_FOLDERS, IndexType.SONG);
+        assertEquals(QUERY_PATTERN_HIRAGANA_ONLY, "+((titRH:ねこいぬ*)^2.4 (tit:ねこ*)^2.3 (tit:いぬ*)^2.3 (artR:ねこ*)^1.1 (artR:いぬ*)^1.1 art:ねこ* art:いぬ*) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
+        query = queryFactory.searchByName(QUERY_PATTERN_OTHERS, MULTI_FOLDERS, IndexType.SONG);
+        assertEquals(QUERY_PATTERN_OTHERS, "+((tit:abc*)^2.3 (tit:ねこ*)^2.3 (artR:abc*)^1.1 (artR:ねこ*)^1.1 art:abc* art:ねこ*) +(f:" + PATH1 + " f:" + PATH2 + ")", query.toString());
     }
 
     @Test


### PR DESCRIPTION
 - Exclusion rule was set in reading of tag, but it was abolished.
   This is a consideration for creating readings using non-Japanese strings
 - Compatible to ID3v2.4 has been made. Until now, there was data that could not be skipped and read, but it will be improved.

These modifications affect subsequent processing.
There is a improvement about "new creation" of search index.