### PR TITLE
Change of Mediafile data creation process

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileJPSupport.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileJPSupport.java
@@ -80,8 +80,7 @@ public class MediaFileJPSupport {
 
 	public void analyzeArtistSort(MediaFile mediaFile) {
 		if (StringUtils.isEmpty(mediaFile.getArtistReading())
-				|| StringUtils.isEmpty(mediaFile.getArtistSort())
-				|| mediaFile.getArtistSort().equals(mediaFile.getArtistReading())) {
+				|| mediaFile.getArtistReading().equals(mediaFile.getArtistSort())) {
 			mediaFile.setArtistSort(null);
 			return;
 		}
@@ -98,7 +97,7 @@ public class MediaFileJPSupport {
 	}
 
 	public String createReading(String s) {
-		if (StringUtils.isEmpty(s) || ALPHA.matcher(s.substring(0, 1)).matches()) {
+		if (StringUtils.isEmpty(s)) {
 			return null;
 		}
 		if(readingMap.containsKey(s)) {

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/metadata/JaudiotaggerParser.java
@@ -30,6 +30,9 @@ import org.jaudiotagger.audio.AudioFileIO;
 import org.jaudiotagger.audio.AudioHeader;
 import org.jaudiotagger.tag.FieldKey;
 import org.jaudiotagger.tag.Tag;
+import org.jaudiotagger.tag.id3.AbstractID3Tag;
+import org.jaudiotagger.tag.id3.ID3v24Frames;
+import org.jaudiotagger.tag.id3.ID3v24Tag;
 import org.jaudiotagger.tag.images.Artwork;
 import org.jaudiotagger.tag.reference.GenreTypes;
 import org.slf4j.Logger;
@@ -95,15 +98,96 @@ public class JaudiotaggerParser extends MetaDataParser {
                 metaData.setDiscNumber(parseInteger(getTagField(tag, FieldKey.DISC_NO)));
                 metaData.setTrackNumber(parseTrackNumber(getTagField(tag, FieldKey.TRACK)));
                 metaData.setMusicBrainzReleaseId(getTagField(tag, FieldKey.MUSICBRAINZ_RELEASEID));
-
-                String songArtist = getTagField(tag, FieldKey.ARTIST);
-                String albumArtist = getTagField(tag, FieldKey.ALBUM_ARTIST);
-                metaData.setArtist(StringUtils.isBlank(songArtist) ? albumArtist : songArtist);
-                metaData.setAlbumArtist(StringUtils.isBlank(albumArtist) ? songArtist : albumArtist);
                 metaData.setArtistSort(getTagField(tag, FieldKeyExtension.ARTISTSORT));
                 metaData.setAlbumSort(getTagField(tag, FieldKeyExtension.ALBUMSORT));
                 metaData.setTitleSort(getTagField(tag, FieldKeyExtension.TITLESORT));
                 metaData.setAlbumArtistSort(getTagField(tag, FieldKeyExtension.ALBUMARTISTSORT));
+
+                String songArtist = getTagField(tag, FieldKey.ARTIST);
+                String albumArtist = getTagField(tag, FieldKey.ALBUM_ARTIST);
+
+                if (tag instanceof AbstractID3Tag && 0 < audioFile.getTag().getFieldCount()) {
+
+                    AbstractID3Tag id3Tag = (AbstractID3Tag)tag;
+                    if (ID3v24Tag.RELEASE == id3Tag.getRelease()
+                            && ID3v24Tag.MAJOR_VERSION == id3Tag.getMajorVersion()
+                            && ID3v24Tag.REVISION == id3Tag.getRevision()) {
+
+                        audioFile.getTag().getFields().forEachRemaining(f -> {
+                            switch (f.getId()) {
+                                case ID3v24Frames.FRAME_ID_ALBUM:
+                                    if (null == metaData.getAlbumName()) {
+                                        metaData.setAlbumName(f.toString());
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_TITLE:
+                                    if (null == metaData.getTitle()) {
+                                        metaData.setTitle(f.toString());
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_YEAR:
+                                    if (null == metaData.getYear()) {
+                                        metaData.setYear(parseYear(f.toString()));
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_GENRE:
+                                    if (null == metaData.getGenre()) {
+                                        metaData.setGenre(mapGenre(f.toString()));
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_SET:
+                                    if (null == metaData.getDiscNumber()) {
+                                        metaData.setDiscNumber(parseInteger(f.toString()));
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_TRACK:
+                                    if (null == metaData.getTrackNumber()) {
+                                        metaData.setTrackNumber(parseTrackNumber(f.toString()));
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_ARTIST:
+                                    if (null == metaData.getArtist() && null == songArtist) {
+                                        metaData.setArtist(f.toString());
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_ACCOMPANIMENT:
+                                    if (null == metaData.getAlbumArtist()) {
+                                        metaData.setAlbumArtist(f.toString());
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_ARTIST_SORT_ORDER:
+                                    if (null == metaData.getArtistSort()) {
+                                        metaData.setArtistSort(f.toString());
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_ALBUM_SORT_ORDER:
+                                    if (null == metaData.getAlbumSort()) {
+                                        metaData.setAlbumSort(f.toString());
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_TITLE_SORT_ORDER:
+                                    if (null == metaData.getTitleSort()) {
+                                        metaData.setTitleSort(f.toString());
+                                    }
+                                    break;
+                                case ID3v24Frames.FRAME_ID_ALBUM_ARTIST_SORT_ORDER_ITUNES:
+                                    if (null == metaData.getAlbumArtistSort()) {
+                                        metaData.setAlbumArtistSort(f.toString());
+                                    }
+                                    break;
+                                default:
+                                    break;
+                            }
+                        });
+                    }
+                }
+                if(StringUtils.isBlank(metaData.getArtist())) {
+                    metaData.setArtist(StringUtils.isBlank(songArtist) ? albumArtist : songArtist);
+                }
+                if(StringUtils.isBlank(metaData.getAlbumArtist())) {
+                    metaData.setAlbumArtist(StringUtils.isBlank(albumArtist) ? songArtist : albumArtist);
+                }
+
             }
 
             AudioHeader audioHeader = audioFile.getAudioHeader();
@@ -138,7 +222,7 @@ public class JaudiotaggerParser extends MetaDataParser {
             return null;
         }
     }
-
+    
     /**
      * Returns all tags supported by id3v1.
      */


### PR DESCRIPTION
 - Exclusion rule was set in reading of tag, but it was abolished.
   This is a consideration for creating readings using non-Japanese strings
 - Compatible to ID3v2.4 has been made. Until now, there was data that could not be skipped and read, but it will be improved.

These modifications affect subsequent processing.
There is a improvement about "new creation" of search index.