### PR TITLE
Add PMD rulesets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 -->
 
 [![Build Status](https://travis-ci.org/tesshucom/jpsonic.svg?branch=master)](https://travis-ci.org/tesshucom/jpsonic) 
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/tesshucom/jpsonic.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/tesshucom/jpsonic/alerts/) 
 [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/tesshucom/jpsonic.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/tesshucom/jpsonic/context:javascript) 
 [![Language grade: Java](https://img.shields.io/lgtm/grade/java/g/tesshucom/jpsonic.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/tesshucom/jpsonic/context:java)
 

--- a/jpsonic-main/pmd-rulesets.xml
+++ b/jpsonic-main/pmd-rulesets.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<ruleset name="PMD ruleset for Checkstyle"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0
+                             http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
+    <description>
+        PMD 6.24.0 rulesets for Jpsonic.
+        In v109.1.1, follow blocker/critical (priority2).
+
+        A third-party implementation avoids some false positives in Java.
+        The following suppressions are used :
+            // NOPMD ******
+            @SuppressWarnings("PMD.******")
+
+		Only two rule is suppressed in the JSP and is described in this XML.
+    </description>
+
+    <include-pattern>.*/src/main/java/.*.java</include-pattern>
+    <include-pattern>.*/src/main/webapp/WEB-INF/jsp/.*.jsp</include-pattern>
+    <exclude-pattern>.*/.*Test*.java</exclude-pattern>
+    <exclude-pattern>.*/.*TestCase*.java</exclude-pattern>
+    <exclude-pattern>.*/.*DaoTestCaseBean2.java</exclude-pattern>
+    <exclude-pattern>.*/.*TestData*.java</exclude-pattern>
+    <exclude-pattern>.*/.*TestUtils*.java</exclude-pattern>
+
+    <!-- for Java 6.24.0 -->
+    <rule ref="category/java/bestpractices.xml"/>
+    <rule ref="category/java/codestyle.xml"/>
+    <rule ref="category/java/design.xml"/>
+    <rule ref="category/java/documentation.xml"/>
+    <rule ref="category/java/errorprone.xml"/>
+    <rule ref="category/java/multithreading.xml"/>
+    <rule ref="category/java/performance.xml"/>
+    <rule ref="category/java/security.xml"/>
+
+    <!-- for JSP 6.24.0 -->
+    <rule ref="category/jsp/bestpractices.xml"/>
+    <rule ref="category/jsp/bestpractices.xml/NoClassAttribute">
+        <!-- 
+        Violation : Do not use an attribute called ‘class’. Use "styleclass" for CSS styles.
+        If apply this, the style will collapse.
+         -->
+        <properties>
+            <property name="violationSuppressXPath"
+                value="//Attribute[ upper-case(@Name)='CLASS' ]" />
+        </properties>
+    </rule>
+
+    <rule ref="category/jsp/codestyle.xml"/>
+
+    <rule ref="category/jsp/design.xml"/>
+    <rule ref="category/jsp/design.xml/NoLongScripts">
+        <!-- 
+        Violation : Avoid having long scripts (e.g. Javascript) inside a JSP file.
+        Most Scripts have JSTL variables.
+        It can be managed by TagLib, but it is suppressed
+        because it is expected to become more complicated and difficult to maintain.
+         -->
+        <properties>
+            <property name="violationSuppressXPath"
+                value="//HtmlScript[(@EndLine - @BeginLine > 10)]" />
+        </properties>
+    </rule>
+    <rule ref="category/jsp/documentation.xml"/>
+    <rule ref="category/jsp/errorprone.xml"/>
+    <rule ref="category/jsp/multithreading.xml"/>
+    <rule ref="category/jsp/performance.xml"/>
+    <rule ref="category/jsp/security.xml"/>
+
+</ruleset>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -679,18 +679,29 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
                 <configuration>
-                    <language>jsp</language>
-                    <rulesets>
-                        <ruleset>/category/jsp/codestyle.xml</ruleset>
-                        <ruleset>/category/jsp/errorprone.xml</ruleset>
-                    </rulesets>
+                    <analysisCache>true</analysisCache>
+                    <targetJdk>${compile.version}</targetJdk>
+                    <skipEmptyReport>false</skipEmptyReport>
+                    <failOnViolation>true</failOnViolation>
+                    <minimumPriority>2</minimumPriority>
+                    <printFailingErrors>true</printFailingErrors>
+                    <includeTests>true</includeTests>
+                    <verbose>false</verbose>
+                    <compileSourceRoots>
+                        <compileSourceRoot>${basedir}/src/main/java</compileSourceRoot>
+                        <compileSourceRoot>${basedir}/src/main/webapp/WEB-INF/jsp</compileSourceRoot>
+                    </compileSourceRoots>
+                    <excludeRoots>
+                        <excludeRoot>${basedir}/target</excludeRoot>
+                    </excludeRoots>
                     <includes>
+                        <include>**/*.java</include>
                         <include>**/*.jsp</include>
                         <include>**/*.jspf</include>
                     </includes>
-                    <compileSourceRoots>
-                        <compileSourceRoot>${basedir}/src/main/webapp/WEB-INF/jsp</compileSourceRoot>
-                    </compileSourceRoots>
+                    <rulesets>
+                        <ruleset>pmd-rulesets.xml</ruleset>
+                    </rulesets>
                 </configuration>
             </plugin>
             <plugin>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -638,7 +638,7 @@
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>2.6.0</version>
+            <version>2.6.1</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/analysis/ComplementaryFilter.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/analysis/ComplementaryFilter.java
@@ -22,7 +22,7 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 public final class ComplementaryFilter extends TokenFilter {
 
-    private static Pattern ONLY_STOP_WORDS;
+    private static Pattern onlyStopWords;
 
     private Reader getReafer(Class<?> clazz) {
         return IOUtils.getDecodingReader(clazz.getResourceAsStream("/".concat(stopwards)), UTF_8);
@@ -69,7 +69,7 @@ public final class ComplementaryFilter extends TokenFilter {
 
     @Override
     public final boolean incrementToken() throws IOException {
-        if (Mode.HIRA_KATA_ONLY != mode && null == ONLY_STOP_WORDS) {
+        if (Mode.HIRA_KATA_ONLY != mode && null == onlyStopWords) {
             try (Reader reader = getReafer(getClass())) {
                 CharArraySet stops = WordlistLoader.getWordSet(reader, "#", new CharArraySet(16, true));
                 StringBuffer buffer = new StringBuffer();
@@ -77,7 +77,7 @@ public final class ComplementaryFilter extends TokenFilter {
                     buffer.append((char[]) s);
                     buffer.append("|");
                 });
-                ONLY_STOP_WORDS = Pattern.compile("^(" + buffer.toString().replaceAll("^\\||\\|$", "") + ")*$");
+                onlyStopWords = Pattern.compile("^(" + buffer.toString().replaceAll("^\\||\\|$", "") + ")*$");
             } catch (IOException e) {
                 LoggerFactory.getLogger(ComplementaryFilter.class).error("Initialization error.", e);
             }
@@ -86,7 +86,7 @@ public final class ComplementaryFilter extends TokenFilter {
         if (input.incrementToken()) {
             String term = termAtt.toString();
 
-            if ((Mode.HIRA_KATA_ONLY != mode && ONLY_STOP_WORDS.matcher(term).matches())) {
+            if ((Mode.HIRA_KATA_ONLY != mode && onlyStopWords.matcher(term).matches())) {
                 return true;
             }
             if (Mode.STOP_WORDS_ONLY != mode && isHiraKataOnly(term)) {

--- a/jpsonic-main/src/main/java/org/airsonic/player/Application.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/Application.java
@@ -203,7 +203,7 @@ public class Application extends SpringBootServletInitializer implements WebServ
                     LOG.debug("Attempting to optimize tomcat");
                 }
                 Object tomcatESCFInstance = tomcatESCF.cast(container);
-                Class<?> tomcatApplicationClass = Class.forName("org.airsonic.player.TomcatApplication");
+                Class<?> tomcatApplicationClass = Class.forName("org.airsonic.player.TomcatApplicationHelper");
                 Method configure = ReflectionUtils.findMethod(tomcatApplicationClass, "configure", tomcatESCF);
                 configure.invoke(null, tomcatESCFInstance);
                 if (LOG.isDebugEnabled()) {

--- a/jpsonic-main/src/main/java/org/airsonic/player/TomcatApplicationHelper.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/TomcatApplicationHelper.java
@@ -6,7 +6,7 @@ import org.apache.catalina.webresources.StandardRoot;
 import org.apache.tomcat.util.scan.StandardJarScanFilter;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 
-public class TomcatApplication {
+public class TomcatApplicationHelper {
 
     public static void configure(TomcatServletWebServerFactory tomcatFactory) {
 

--- a/jpsonic-main/src/main/java/org/airsonic/player/command/DatabaseSettingsCommand.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/command/DatabaseSettingsCommand.java
@@ -12,7 +12,7 @@ public class DatabaseSettingsCommand {
     private String embedPassword;
     private String embedUrl;
     private String embedUsername;
-    private String JNDIName;
+    private String jndiName;
     private int mysqlVarcharMaxlength;
     private String usertableQuote;
 
@@ -57,11 +57,11 @@ public class DatabaseSettingsCommand {
     }
 
     public String getJNDIName() {
-        return JNDIName;
+        return jndiName;
     }
 
-    public void setJNDIName(String JNDIName) {
-        this.JNDIName = JNDIName;
+    public void setJNDIName(String jndiName) {
+        this.jndiName = jndiName;
     }
 
     public int getMysqlVarcharMaxlength() {

--- a/jpsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/controller/CoverArtController.java
@@ -92,7 +92,7 @@ public class CoverArtController implements LastModified {
     @Autowired
     private CoverArtLogic logic;
 
-    private final static Map<String, Object> locks = new ConcurrentHashMap<>();
+    private final static Map<String, Object> LOCKS = new ConcurrentHashMap<>();
 
     @PostConstruct
     public void init() {
@@ -250,9 +250,9 @@ public class CoverArtController implements LastModified {
         Object lock = new Object();
         synchronized (lock) {
 
-            locks.putIfAbsent(hash, lock);
+            LOCKS.putIfAbsent(hash, lock);
 
-            if (lock.equals(locks.get(hash))
+            if (lock.equals(LOCKS.get(hash))
                     && (!cachedImage.exists() || request.lastModified() > cachedImage.lastModified())) {
                 OutputStream out = null;
                 try {
@@ -274,7 +274,7 @@ public class CoverArtController implements LastModified {
                 } finally {
                     semaphore.release();
                     FileUtil.closeQuietly(out);
-                    locks.remove(hash, lock);
+                    LOCKS.remove(hash, lock);
                 }
             }
             return cachedImage;

--- a/jpsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
@@ -24,7 +24,7 @@ import org.airsonic.player.io.RangeOutputStream;
 import org.airsonic.player.service.*;
 import org.airsonic.player.util.FileUtil;
 import org.airsonic.player.util.HttpRange;
-import org.airsonic.player.util.Util;
+import org.airsonic.player.util.PlayerUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -176,7 +176,7 @@ public class DownloadController implements LastModified {
         response.setContentType("application/x-download");
         response.setHeader("Content-Disposition", "attachment; filename*=UTF-8''" + encodeAsRFC5987(file.getName()));
         if (range == null) {
-            Util.setContentLength(response, file.length());
+            PlayerUtils.setContentLength(response, file.length());
         }
 
         copyFileToStream(file, RangeOutputStream.wrap(response.getOutputStream(), range), status, range);

--- a/jpsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/controller/DownloadController.java
@@ -215,7 +215,7 @@ public class DownloadController implements LastModified {
      * @param zipFileName  The name of the resulting zip file.   @throws IOException If an I/O error occurs.
      */
     private void downloadFiles(HttpServletResponse response, TransferStatus status, List<MediaFile> files, int[] indexes, File coverArtFile, HttpRange range, String zipFileName) throws IOException {
-        boolean cover_embedded = false;
+        boolean coverEmbedded = false;
 
         if (indexes != null && indexes.length == 1) {
             downloadFile(response, status, files.get(indexes[0]).getFile(), range);
@@ -246,11 +246,11 @@ public class DownloadController implements LastModified {
             zip(out, mediaFile.getParentFile(), mediaFile.getFile(), status, range);
             if (coverArtFile != null && coverArtFile.exists()) {
                 if (mediaFile.getFile().getCanonicalPath().equals(coverArtFile.getCanonicalPath())) {
-                    cover_embedded = true;
+                    coverEmbedded = true;
                 }
             }
         }
-        if (coverArtFile != null && coverArtFile.exists() && !cover_embedded) {
+        if (coverArtFile != null && coverArtFile.exists() && !coverEmbedded) {
             zip(out, coverArtFile.getParentFile(), coverArtFile, status, range);
         }
 

--- a/jpsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
@@ -27,8 +27,8 @@ import org.airsonic.player.security.JWTAuthenticationToken;
 import org.airsonic.player.service.*;
 import org.airsonic.player.service.sonos.SonosHelper;
 import org.airsonic.player.util.HttpRange;
+import org.airsonic.player.util.PlayerUtils;
 import org.airsonic.player.util.StringUtil;
-import org.airsonic.player.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -105,7 +105,7 @@ public class StreamController {
                 PlayQueue playQueue = new PlayQueue();
                 playQueue.addFiles(false, playlistService.getFilesInPlaylist(playlistId));
                 player.setPlayQueue(playQueue);
-                Util.setContentLength(response, playQueue.length());
+                PlayerUtils.setContentLength(response, playQueue.length());
                 if (LOG.isInfoEnabled()) {
                     LOG.info("{}: Incoming Podcast request for playlist {}", request.getRemoteAddr(), playlistId);
                 }
@@ -189,7 +189,7 @@ public class StreamController {
                     }
 
                     response.setIntHeader("ETag", file.getId());
-                    Util.setContentLength(response, contentLength);
+                    PlayerUtils.setContentLength(response, contentLength);
                 }
 
                 // Set content type of response
@@ -278,12 +278,12 @@ public class StreamController {
             // This happens often and outside of the control of the server, so
             // we catch Tomcat/Jetty "connection aborted by client" exceptions
             // and display a short error message.
-            boolean shouldCatch = Util.isInstanceOfClassName(e, "org.apache.catalina.connector.ClientAbortException");
+            boolean shouldCatch = PlayerUtils.isInstanceOfClassName(e, "org.apache.catalina.connector.ClientAbortException");
             if (shouldCatch) {
                 if (LOG.isInfoEnabled()) {
                     LOG.info("{}: Client unexpectedly closed connection while loading {} ({})",
                             request.getRemoteAddr(),
-                            Util.getAnonymizedURLForRequest(request),
+                            PlayerUtils.getAnonymizedURLForRequest(request),
                             e.getCause().toString());
                 }
                 return;

--- a/jpsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java
@@ -62,6 +62,8 @@ public class StreamController {
 
     private static final Logger LOG = LoggerFactory.getLogger(StreamController.class);
 
+    private static final int BUFFER_SIZE = 2048;
+
     @Autowired
     private StatusService statusService;
     @Autowired
@@ -234,7 +236,6 @@ public class StreamController {
                         transcodingService, audioScrobblerService, mediaFileService, searchService);
                 OutputStream out = makeOutputStream(request, response, range, isSingleFile, player, settingsService)
             ) {
-                final int BUFFER_SIZE = 2048;
                 byte[] buf = new byte[BUFFER_SIZE];
                 long bytesWritten = 0;
 

--- a/jpsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java
@@ -36,8 +36,8 @@ import org.airsonic.player.service.*;
 import org.airsonic.player.service.search.IndexType;
 import org.airsonic.player.service.search.SearchCriteria;
 import org.airsonic.player.service.search.SearchCriteriaDirector;
+import org.airsonic.player.util.PlayerUtils;
 import org.airsonic.player.util.StringUtil;
-import org.airsonic.player.util.Util;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
@@ -1814,7 +1814,7 @@ public class SubsonicRESTController {
     public void savePlayQueue(HttpServletRequest req, HttpServletResponse response) throws Exception {
         HttpServletRequest request = wrapRequest(req);
         String username = securityService.getCurrentUsername(request);
-        List<Integer> mediaFileIds = Util.toIntegerList(getIntParameters(request, "id"));
+        List<Integer> mediaFileIds = PlayerUtils.toIntegerList(getIntParameters(request, "id"));
         Integer current = getIntParameter(request, "current");
         Long position = getLongParameter(request, "position");
         Date changed = new Date();
@@ -2093,7 +2093,7 @@ public class SubsonicRESTController {
 
         int[] folderIds = ServletRequestUtils.getIntParameters(request, "musicFolderId");
         if (folderIds.length == 0) {
-            folderIds = Util.toIntArray(org.airsonic.player.domain.MusicFolder.toIdList(settingsService.getAllMusicFolders()));
+            folderIds = PlayerUtils.toIntArray(org.airsonic.player.domain.MusicFolder.toIdList(settingsService.getAllMusicFolders()));
         }
         command.setAllowedMusicFolderIds(folderIds);
 
@@ -2153,7 +2153,7 @@ public class SubsonicRESTController {
 
         int[] folderIds = ServletRequestUtils.getIntParameters(request, "musicFolderId");
         if (folderIds.length == 0) {
-            folderIds = Util.toIntArray(org.airsonic.player.domain.MusicFolder.toIdList(settingsService.getMusicFoldersForUser(username)));
+            folderIds = PlayerUtils.toIntArray(org.airsonic.player.domain.MusicFolder.toIdList(settingsService.getMusicFoldersForUser(username)));
         }
         command.setAllowedMusicFolderIds(folderIds);
 

--- a/jpsonic-main/src/main/java/org/airsonic/player/controller/UserSettingsController.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/controller/UserSettingsController.java
@@ -27,7 +27,7 @@ import org.airsonic.player.domain.UserSettings;
 import org.airsonic.player.service.SecurityService;
 import org.airsonic.player.service.SettingsService;
 import org.airsonic.player.service.TranscodingService;
-import org.airsonic.player.util.Util;
+import org.airsonic.player.util.PlayerUtils;
 import org.airsonic.player.validator.UserSettingsValidator;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -84,7 +84,7 @@ public class UserSettingsController {
                 command.setEmail(user.getEmail());
                 UserSettings userSettings = settingsService.getUserSettings(user.getUsername());
                 command.setTranscodeSchemeName(userSettings.getTranscodeScheme().name());
-                command.setAllowedMusicFolderIds(Util.toIntArray(getAllowedMusicFolderIds(user)));
+                command.setAllowedMusicFolderIds(PlayerUtils.toIntArray(getAllowedMusicFolderIds(user)));
                 command.setCurrentUser(securityService.getCurrentUser(request).getUsername().equals(user.getUsername()));
             } else {
                 command.setNewUser(true);
@@ -197,7 +197,7 @@ public class UserSettingsController {
         userSettings.setChanged(new Date());
         settingsService.updateUserSettings(userSettings);
 
-        List<Integer> allowedMusicFolderIds = Util.toIntegerList(command.getAllowedMusicFolderIds());
+        List<Integer> allowedMusicFolderIds = PlayerUtils.toIntegerList(command.getAllowedMusicFolderIds());
         settingsService.setMusicFoldersForUser(command.getUsername(), allowedMusicFolderIds);
     }
 

--- a/jpsonic-main/src/main/java/org/airsonic/player/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/dao/MediaFileDao.java
@@ -23,7 +23,7 @@ import org.airsonic.player.domain.Genre;
 import org.airsonic.player.domain.MediaFile;
 import org.airsonic.player.domain.MusicFolder;
 import org.airsonic.player.domain.RandomSearchCriteria;
-import org.airsonic.player.util.Util;
+import org.airsonic.player.util.PlayerUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -192,7 +192,7 @@ public class MediaFileDao extends AbstractDao {
                      // <<<< JP
                      "where path=?";
 
-        LOG.trace("Updating media file {}", Util.debugObject(file));
+        LOG.trace("Updating media file {}", PlayerUtils.debugObject(file));
 
         int n = update(sql,
                        file.getFolder(), file.getMediaType().name(), file.getFormat(), file.getTitle(), file.getAlbumName(), file.getArtist(),

--- a/jpsonic-main/src/main/java/org/airsonic/player/io/ShoutCastOutputStream.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/io/ShoutCastOutputStream.java
@@ -80,6 +80,7 @@ public class ShoutCastOutputStream extends OutputStream {
     /**
      * Writes the given byte array to the underlying stream, adding SHOUTcast meta-data as necessary.
      */
+    @SuppressWarnings("lgtm")
     public void write(byte[] b, int off, int len) throws IOException {
 
         int bytesWritten = 0;
@@ -88,6 +89,16 @@ public class ShoutCastOutputStream extends OutputStream {
             // 'n' is the number of bytes to write before the next potential meta-data block.
             int n = Math.min(len - bytesWritten, ShoutCastOutputStream.META_DATA_INTERVAL - byteCount);
 
+            /*
+             * False positive for cross-site scripting at LGTM.com.
+             * (Directly writing user input to a web page, without properly sanitizing the input first.)
+             * In general, some podcast functions inherently require such processing.
+             * In this case 'client' is the Jpsonic server, not the user.
+             *
+             *  - Users can configure trusted podcast resources.
+             *  - Users can choose not to use podcast.
+             *  - Users can also use virus check tool to monitor the directory where audio files are stored.
+             */
             out.write(b, off + bytesWritten, n);
             bytesWritten += n;
             byteCount += n;

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/JukeboxJavaService.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/JukeboxJavaService.java
@@ -19,7 +19,7 @@ import java.util.*;
 @Service
 public class JukeboxJavaService {
 
-    private static final org.slf4j.Logger log = LoggerFactory.getLogger(JukeboxJavaService.class);
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(JukeboxJavaService.class);
 
     private static final float DEFAULT_GAIN = 0.75f;
 
@@ -81,15 +81,15 @@ public class JukeboxJavaService {
             throw new IllegalArgumentException("The player " + airsonicPlayer.getName() + " is not a java jukebox player");
         }
 
-        log.info("begin initAudioPlayer");
+        LOG.info("begin initAudioPlayer");
 
         com.github.biconou.AudioPlayer.api.Player audioPlayer;
 
         if (StringUtils.isNotBlank(airsonicPlayer.getJavaJukeboxMixer())) {
-            log.info("use mixer : {}", airsonicPlayer.getJavaJukeboxMixer());
+            LOG.info("use mixer : {}", airsonicPlayer.getJavaJukeboxMixer());
             audioPlayer = javaPlayerFactory.createJavaPlayer(airsonicPlayer.getJavaJukeboxMixer());
         } else {
-            log.info("use default mixer");
+            LOG.info("use default mixer");
             audioPlayer = javaPlayerFactory.createJavaPlayer();
         }
         if (audioPlayer != null) {
@@ -120,7 +120,7 @@ public class JukeboxJavaService {
                     // Nothing to do here
                 }
             });
-            log.info("New audio player {} has been initialized.", audioPlayer.toString());
+            LOG.info("New audio player {} has been initialized.", audioPlayer.toString());
         } else {
             throw new IllegalStateException("AudioPlayer has not been initialized properly");
         }
@@ -166,7 +166,7 @@ public class JukeboxJavaService {
             throw new IllegalArgumentException("The player " + airsonicPlayer.getName() + " is not a java jukebox player");
         }
         com.github.biconou.AudioPlayer.api.Player audioPlayer = retrieveAudioPlayerForAirsonicPlayer(airsonicPlayer);
-        log.debug("setGain : gain={}", gain);
+        LOG.debug("setGain : gain={}", gain);
         if (audioPlayer != null) {
             audioPlayer.setGain(gain);
         } else {
@@ -177,7 +177,7 @@ public class JukeboxJavaService {
 
     private void onSongStart(Player player) {
         MediaFile file = player.getPlayQueue().getCurrentFile();
-        log.info("[onSongStart] {} starting jukebox for \"{}\"", player.getUsername(), FileUtil.getShortPath(file.getFile()));
+        LOG.info("[onSongStart] {} starting jukebox for \"{}\"", player.getUsername(), FileUtil.getShortPath(file.getFile()));
         if (status != null) {
             statusService.removeStreamStatus(status);
             status = null;
@@ -191,7 +191,7 @@ public class JukeboxJavaService {
 
     private void onSongEnd(Player player) {
         MediaFile file = player.getPlayQueue().getCurrentFile();
-        log.info("[onSongEnd] {} stopping jukebox for \"{}\"", player.getUsername(), FileUtil.getShortPath(file.getFile()));
+        LOG.info("[onSongEnd] {} stopping jukebox for \"{}\"", player.getUsername(), FileUtil.getShortPath(file.getFile()));
         if (status != null) {
             statusService.removeStreamStatus(status);
             status = null;
@@ -209,18 +209,18 @@ public class JukeboxJavaService {
      * Plays the playqueue of a jukebox player starting at the beginning.
      */
     public void play(Player airsonicPlayer) {
-        log.debug("begin play jukebox : player = id:{};name:{}", airsonicPlayer.getId(), airsonicPlayer.getName());
+        LOG.debug("begin play jukebox : player = id:{};name:{}", airsonicPlayer.getId(), airsonicPlayer.getName());
 
         com.github.biconou.AudioPlayer.api.Player audioPlayer = retrieveAudioPlayerForAirsonicPlayer(airsonicPlayer);
 
         // Control user authorizations
         User user = securityService.getUserByName(airsonicPlayer.getUsername());
         if (!user.isJukeboxRole()) {
-            log.warn("{} is not authorized for jukebox playback.", user.getUsername());
+            LOG.warn("{} is not authorized for jukebox playback.", user.getUsername());
             return;
         }
 
-        log.debug("Different file to play -> start a new play list");
+        LOG.debug("Different file to play -> start a new play list");
         if (airsonicPlayer.getPlayQueue().getCurrentFile() != null) {
             audioPlayer.setPlayList(new PlayList() {
 
@@ -272,30 +272,30 @@ public class JukeboxJavaService {
     }
 
     public void stop(Player airsonicPlayer) {
-        log.debug("begin stop jukebox : player = id:{};name:{}", airsonicPlayer.getId(), airsonicPlayer.getName());
+        LOG.debug("begin stop jukebox : player = id:{};name:{}", airsonicPlayer.getId(), airsonicPlayer.getName());
 
         com.github.biconou.AudioPlayer.api.Player audioPlayer = retrieveAudioPlayerForAirsonicPlayer(airsonicPlayer);
 
         // Control user authorizations
         User user = securityService.getUserByName(airsonicPlayer.getUsername());
         if (!user.isJukeboxRole()) {
-            log.warn("{} is not authorized for jukebox playback.", user.getUsername());
+            LOG.warn("{} is not authorized for jukebox playback.", user.getUsername());
             return;
         }
 
-        log.debug("PlayQueue.Status is {}", airsonicPlayer.getPlayQueue().getStatus());
+        LOG.debug("PlayQueue.Status is {}", airsonicPlayer.getPlayQueue().getStatus());
         audioPlayer.pause();
     }
 
     public void skip(Player airsonicPlayer, int index, int offset) {
-        log.debug("begin skip jukebox : player = id:{};name:{}", airsonicPlayer.getId(), airsonicPlayer.getName());
+        LOG.debug("begin skip jukebox : player = id:{};name:{}", airsonicPlayer.getId(), airsonicPlayer.getName());
 
         com.github.biconou.AudioPlayer.api.Player audioPlayer = retrieveAudioPlayerForAirsonicPlayer(airsonicPlayer);
 
         // Control user authorizations
         User user = securityService.getUserByName(airsonicPlayer.getUsername());
         if (!user.isJukeboxRole()) {
-            log.warn("{} is not authorized for jukebox playback.", user.getUsername());
+            LOG.warn("{} is not authorized for jukebox playback.", user.getUsername());
             return;
         }
 

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/SearchService.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/SearchService.java
@@ -107,7 +107,7 @@ public interface SearchService {
      * @param musicFolders Only return albums from these folders.
      * @return List of random albums.
      */
-    List<MediaFile> getRandomSongsByArtist(Artist Artist, int count, int offset, int casheMax, List<MusicFolder> musicFolders);
+    List<MediaFile> getRandomSongsByArtist(Artist artist, int count, int offset, int casheMax, List<MusicFolder> musicFolders);
 
     /**
      * Returns a number of random albums.

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/SecurityService.java
@@ -56,7 +56,7 @@ public class SecurityService implements UserDetailsService {
 
     private static final Logger LOG = LoggerFactory.getLogger(SecurityService.class);
 
-    private static final Pattern noTraversal = Pattern.compile("^(?!.*(\\.\\./|\\.\\.\\\\)).*$");
+    private static final Pattern NO_TRAVERSAL = Pattern.compile("^(?!.*(\\.\\./|\\.\\.\\\\)).*$");
 
     @Autowired
     private UserDao userDao;
@@ -261,7 +261,7 @@ public class SecurityService implements UserDetailsService {
     }
 
     public boolean isNoTraversal(String path) {
-        return noTraversal.matcher(path).matches();
+        return NO_TRAVERSAL.matcher(path).matches();
     }
 
     /**

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/SettingsService.java
@@ -32,8 +32,8 @@ import org.airsonic.player.domain.Theme;
 import org.airsonic.player.domain.UserSettings;
 import org.airsonic.player.spring.DataSourceConfigType;
 import org.airsonic.player.util.FileUtil;
+import org.airsonic.player.util.PlayerUtils;
 import org.airsonic.player.util.StringUtil;
-import org.airsonic.player.util.Util;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -185,7 +185,7 @@ public class SettingsService {
     private static final String DEFAULT_INDEX_STRING = "A B C D E F G H I J K L M N O P Q R S T U V W X-Z(XYZ) \u3042(\u30A2\u30A4\u30A6\u30A8\u30AA) \u304B(\u30AB\u30AD\u30AF\u30B1\u30B3) \u3055(\u30B5\u30B7\u30B9\u30BB\u30BD) \u305F(\u30BF\u30C1\u30C4\u30C6\u30C8) \u306A(\u30CA\u30CB\u30CC\u30CD\u30CE) \u306F(\u30CF\u30D2\u30D5\u30D8\u30DB) \u307E(\u30DE\u30DF\u30E0\u30E1\u30E2) \u3084(\u30E4\u30E6\u30E8) \u3089(\u30E9\u30EA\u30EB\u30EC\u30ED) \u308F(\u30EF\u30F2\u30F3)";
     private static final String DEFAULT_IGNORED_ARTICLES = "The El La Las Le Les";
     private static final String DEFAULT_SHORTCUTS = "New Incoming Podcast";
-    private static final String DEFAULT_PLAYLIST_FOLDER = Util.getDefaultPlaylistFolder();
+    private static final String DEFAULT_PLAYLIST_FOLDER = PlayerUtils.getDefaultPlaylistFolder();
     private static final String DEFAULT_MUSIC_FILE_TYPES = "mp3 ogg oga aac m4a m4b flac wav wma aif aiff ape mpc shn mka opus";
     private static final String DEFAULT_VIDEO_FILE_TYPES = "flv avi mpg mpeg mp4 m4v mkv mov wmv ogv divx m2ts webm";
     private static final String DEFAULT_COVER_ART_FILE_TYPES = "cover.jpg cover.png cover.gif folder.jpg jpg jpeg gif png";
@@ -203,7 +203,7 @@ public class SettingsService {
     private static final boolean DEFAULT_FAST_CACHE_ENABLED = false;
     private static final boolean DEFAULT_IGNORE_FILE_TIMESTAMPS = false;
     private static final int DEFAULT_PODCAST_UPDATE_INTERVAL = 24;
-    private static final String DEFAULT_PODCAST_FOLDER = Util.getDefaultPodcastFolder();
+    private static final String DEFAULT_PODCAST_FOLDER = PlayerUtils.getDefaultPodcastFolder();
     private static final int DEFAULT_PODCAST_EPISODE_RETENTION_COUNT = 10;
     private static final int DEFAULT_PODCAST_EPISODE_DOWNLOAD_COUNT = 1;
     private static final long DEFAULT_DOWNLOAD_BITRATE_LIMIT = 0;

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/TranscodingService.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/TranscodingService.java
@@ -23,8 +23,8 @@ import org.airsonic.player.controller.VideoPlayerController;
 import org.airsonic.player.dao.TranscodingDao;
 import org.airsonic.player.domain.*;
 import org.airsonic.player.io.TranscodeInputStream;
+import org.airsonic.player.util.PlayerUtils;
 import org.airsonic.player.util.StringUtil;
-import org.airsonic.player.util.Util;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.filefilter.PrefixFileFilter;
@@ -392,7 +392,7 @@ public class TranscodingService {
                 // Work-around for filename character encoding problem on Windows.
                 // Create temporary file, and feed this to the transcoder.
                 String path = mediaFile.getFile().getAbsolutePath();
-                if (Util.isWindows() && !mediaFile.isVideo() && !StringUtils.isAsciiPrintable(path)) {
+                if (PlayerUtils.isWindows() && !mediaFile.isVideo() && !StringUtils.isAsciiPrintable(path)) {
                     tmpFile = File.createTempFile("airsonic", "." + FilenameUtils.getExtension(path));
                     tmpFile.deleteOnExit();
                     FileUtils.copyFile(new File(path), tmpFile);

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/VersionService.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/VersionService.java
@@ -226,8 +226,7 @@ public class VersionService {
         }
     }
 
-    private final static String JSON_PATH = "$..tag_name";
-    private final Pattern VERSION_REGEX = Pattern.compile("^v(.*)");
+    private static final Pattern VERSION_REGEX = Pattern.compile("^v(.*)");
     private static final String VERSION_URL = "https://api.github.com/repos/jpsonic/jpsonic/releases";
 
     /**

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/metadata/FFmpegParser.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/metadata/FFmpegParser.java
@@ -48,7 +48,7 @@ import java.util.List;
 public class FFmpegParser extends MetaDataParser {
 
     private static final Logger LOG = LoggerFactory.getLogger(FFmpegParser.class);
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String[] FFPROBE_OPTIONS = {
         "-v", "quiet", "-print_format", "json", "-show_format", "-show_streams"
     };
@@ -86,7 +86,7 @@ public class FFmpegParser extends MetaDataParser {
             command.add(file.getAbsolutePath());
 
             Process process = Runtime.getRuntime().exec(command.toArray(new String[0]));
-            final JsonNode result = objectMapper.readTree(process.getInputStream());
+            final JsonNode result = OBJECT_MAPPER.readTree(process.getInputStream());
 
             metaData.setDurationSeconds(result.at("/format/duration").asInt());
             // Bitrate is in Kb/s

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/scrobbler/ListenBrainzScrobbler.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/scrobbler/ListenBrainzScrobbler.java
@@ -131,22 +131,22 @@ public class ListenBrainzScrobbler {
      * Returns if submission succeeds.
      */
     private boolean submit(RegistrationData registrationData) throws ClientProtocolException, IOException {
-        Map<String, Object> additional_info = new HashMap<String, Object>();
-        additional_info.computeIfAbsent("release_mbid", k -> registrationData.musicBrainzReleaseId);
-        additional_info.computeIfAbsent("recording_mbid", k -> registrationData.musicBrainzRecordingId);
-        additional_info.computeIfAbsent("tracknumber", k -> registrationData.trackNumber);
+        Map<String, Object> additionalInfo = new HashMap<String, Object>();
+        additionalInfo.computeIfAbsent("release_mbid", k -> registrationData.musicBrainzReleaseId);
+        additionalInfo.computeIfAbsent("recording_mbid", k -> registrationData.musicBrainzRecordingId);
+        additionalInfo.computeIfAbsent("tracknumber", k -> registrationData.trackNumber);
 
-        Map<String, Object> track_metadata = new HashMap<String, Object>();
-        if (additional_info.size() > 0) {
-            track_metadata.put("additional_info", additional_info);
+        Map<String, Object> trackMetadata = new HashMap<String, Object>();
+        if (additionalInfo.size() > 0) {
+            trackMetadata.put("additional_info", additionalInfo);
         }
-        track_metadata.computeIfAbsent("artist_name", k -> registrationData.artist);
-        track_metadata.computeIfAbsent("track_name", k -> registrationData.title);
-        track_metadata.computeIfAbsent("release_name", k -> registrationData.album);
+        trackMetadata.computeIfAbsent("artist_name", k -> registrationData.artist);
+        trackMetadata.computeIfAbsent("track_name", k -> registrationData.title);
+        trackMetadata.computeIfAbsent("release_name", k -> registrationData.album);
 
         Map<String, Object> payload = new HashMap<String, Object>();
-        if (track_metadata.size() > 0) {
-            payload.put("track_metadata", track_metadata);
+        if (trackMetadata.size() > 0) {
+            payload.put("track_metadata", trackMetadata);
         }
 
         Map<String, Object> content = new HashMap<String, Object>();

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/search/AnalyzerFactory.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/search/AnalyzerFactory.java
@@ -291,15 +291,15 @@ public final class AnalyzerFactory {
                 Analyzer artistEx = createExAnalyzer(true);
 
                 Map<String, Analyzer> analyzerMap = new HashMap<String, Analyzer>();
-                analyzerMap.put(FieldNames.GENRE_KEY, createKeywordAnalyzerBuilder().build());
-                analyzerMap.put(FieldNames.ARTIST, artist);
-                analyzerMap.put(FieldNames.COMPOSER, artist);
-                analyzerMap.put(FieldNames.ARTIST_READING, reading);
-                analyzerMap.put(FieldNames.COMPOSER_READING, reading);
-                analyzerMap.put(FieldNames.ALBUM_EX, exceptional);
-                analyzerMap.put(FieldNames.TITLE_EX, exceptional);
-                analyzerMap.put(FieldNames.ARTIST_EX, artistEx);
-                analyzerMap.put(FieldNames.GENRE, createGenreAnalyzer());
+                analyzerMap.put(FieldNamesConstants.GENRE_KEY, createKeywordAnalyzerBuilder().build());
+                analyzerMap.put(FieldNamesConstants.ARTIST, artist);
+                analyzerMap.put(FieldNamesConstants.COMPOSER, artist);
+                analyzerMap.put(FieldNamesConstants.ARTIST_READING, reading);
+                analyzerMap.put(FieldNamesConstants.COMPOSER_READING, reading);
+                analyzerMap.put(FieldNamesConstants.ALBUM_EX, exceptional);
+                analyzerMap.put(FieldNamesConstants.TITLE_EX, exceptional);
+                analyzerMap.put(FieldNamesConstants.ARTIST_EX, artistEx);
+                analyzerMap.put(FieldNamesConstants.GENRE, createGenreAnalyzer());
 
                 this.analyzer = new PerFieldAnalyzerWrapper(createDefaultAnalyzerBuilder(false).build(), analyzerMap);
 

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/search/AnalyzerFactory.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/search/AnalyzerFactory.java
@@ -84,11 +84,11 @@ public final class AnalyzerFactory {
 
     private Analyzer queryAnalyzer;
 
-    private String STOP_TAGS;
+    private String stopTags;
 
     private static final String STOP_WARDS_FOR_ARTIST = "com/tesshu/jpsonic/service/stopwords4artist.txt";
 
-    private String STOP_WARDS;
+    private String stopWords;
 
     boolean isSearchMethodLegacy;
 
@@ -96,11 +96,11 @@ public final class AnalyzerFactory {
     void setSearchMethodLegacy(boolean isSearchMethodLegacy) {
         this.isSearchMethodLegacy = isSearchMethodLegacy;
         if (!isSearchMethodLegacy) {
-            STOP_WARDS = "com/tesshu/jpsonic/service/stopwords4phrase.txt";
-            STOP_TAGS = "com/tesshu/jpsonic/service/stoptags4phrase.txt";
+            stopWords = "com/tesshu/jpsonic/service/stopwords4phrase.txt";
+            stopTags = "com/tesshu/jpsonic/service/stoptags4phrase.txt";
         } else {
-            STOP_WARDS = "com/tesshu/jpsonic/service/stopwords.txt";
-            STOP_TAGS = "org/apache/lucene/analysis/ja/stoptags.txt";
+            stopWords = "com/tesshu/jpsonic/service/stopwords.txt";
+            stopTags = "org/apache/lucene/analysis/ja/stoptags.txt";
         }
         analyzer = null;
         queryAnalyzer = null;
@@ -158,8 +158,8 @@ public final class AnalyzerFactory {
         builder.addTokenFilter(CJKWidthFilterFactory.class)
                 .addTokenFilter(ASCIIFoldingFilterFactory.class, "preserveOriginal", "false")
                 .addTokenFilter(LowerCaseFilterFactory.class)
-                .addTokenFilter(StopFilterFactory.class, "words", isArtist ? STOP_WARDS_FOR_ARTIST : STOP_WARDS, "ignoreCase", "true")
-                .addTokenFilter(JapanesePartOfSpeechStopFilterFactory.class, "tags", STOP_TAGS);
+                .addTokenFilter(StopFilterFactory.class, "words", isArtist ? STOP_WARDS_FOR_ARTIST : stopWords, "ignoreCase", "true")
+                .addTokenFilter(JapanesePartOfSpeechStopFilterFactory.class, "tags", stopTags);
                 // .addTokenFilter(EnglishPossessiveFilterFactory.class); XXX airsonic -> jpsonic : possession(issues#290)
         addTokenFilterForUnderscoreRemovalAroundToken(builder);
         return builder;
@@ -188,7 +188,7 @@ public final class AnalyzerFactory {
     private Builder createExceptionalAnalyzerBuilder() throws IOException {
         return createKeywordAnalyzerBuilder()
             .addTokenFilter(CJKWidthFilterFactory.class)
-            .addTokenFilter(JapanesePartOfSpeechStopFilterFactory.class, "tags", STOP_TAGS)
+            .addTokenFilter(JapanesePartOfSpeechStopFilterFactory.class, "tags", stopTags)
             .addTokenFilter(ASCIIFoldingFilterFactory.class, "preserveOriginal", "false")
             .addTokenFilter(LowerCaseFilterFactory.class)
             .addTokenFilter(PunctuationStemFilterFactory.class);
@@ -204,7 +204,7 @@ public final class AnalyzerFactory {
         } 
 
         CharArraySet stopWords4Artist = getWords(STOP_WARDS_FOR_ARTIST);
-        Set<String> stopTags = loadStopTags();
+        Set<String> stopTagset = loadStopTags();
         return new StopwordAnalyzerBase() {
 
             @Override
@@ -214,7 +214,7 @@ public final class AnalyzerFactory {
                 result = new ASCIIFoldingFilter(result, false);
                 result = new LowerCaseFilter(result);
                 result = new StopFilter(result, stopWords4Artist);
-                result = new JapanesePartOfSpeechStopFilter(result, stopTags);
+                result = new JapanesePartOfSpeechStopFilter(result, stopTagset);
                 result = new PunctuationStemFilter(result);
                 result = new CJKBigramFilter(result);
                 result = new ToHiraganaFilter(result);
@@ -235,11 +235,11 @@ public final class AnalyzerFactory {
         if (isSearchMethodLegacy) {
             ComplementaryFilter.Mode mode = isArtist ? Mode.STOP_WORDS_ONLY : Mode.STOP_WORDS_ONLY_AND_HIRA_KATA_ONLY;
             return createExceptionalAnalyzerBuilder()
-                    .addTokenFilter(ComplementaryFilterFactory.class, "mode", mode.value(), "stopwards", STOP_WARDS)
+                    .addTokenFilter(ComplementaryFilterFactory.class, "mode", mode.value(), "stopwards", stopWords)
                     .build();
         }
 
-        Set<String> stopTags = loadStopTags();
+        Set<String> stopTagset = loadStopTags();
 
         return new StopwordAnalyzerBase() {
 
@@ -250,7 +250,7 @@ public final class AnalyzerFactory {
                 result = new ASCIIFoldingFilter(result, false);
                 result = new LowerCaseFilter(result);
                 result = new PunctuationStemFilter(result);
-                result = new JapanesePartOfSpeechStopFilter(result, stopTags);
+                result = new JapanesePartOfSpeechStopFilter(result, stopTagset);
                 result = new ComplementaryFilter(result, Mode.HIRA_KATA_ONLY, null);
                 result = new ToHiraganaFilter(result);
                 result = new CJKBigramFilter(result);
@@ -270,15 +270,15 @@ public final class AnalyzerFactory {
     }
 
     private Set<String> loadStopTags() throws IOException {
-        Set<String> stopTags = new HashSet<>();
-        CharArraySet cas = getWords(STOP_TAGS);
+        Set<String> stopTagset = new HashSet<>();
+        CharArraySet cas = getWords(stopTags);
         if (cas != null) {
             for (Object element : cas) {
                 char chars[] = (char[]) element;
-                stopTags.add(new String(chars));
+                stopTagset.add(new String(chars));
             }
         }
-        return stopTags;
+        return stopTagset;
     }
 
     public Analyzer getAnalyzer() throws IOException {

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/search/DocumentFactory.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/search/DocumentFactory.java
@@ -104,11 +104,11 @@ public class DocumentFactory {
     }
 
     private BiConsumer<@NonNull Document, @NonNull Integer> fieldId = (doc, value) -> {
-        doc.add(new StoredField(FieldNames.ID, Integer.toString(value), TYPE_ID));
+        doc.add(new StoredField(FieldNamesConstants.ID, Integer.toString(value), TYPE_ID));
     };
 
     private BiConsumer<@NonNull Document, @NonNull Integer> fieldFolderId = (doc, value) -> {
-        doc.add(new StoredField(FieldNames.FOLDER_ID, Integer.toString(value), TYPE_ID_NO_STORE));
+        doc.add(new StoredField(FieldNamesConstants.FOLDER_ID, Integer.toString(value), TYPE_ID_NO_STORE));
     };
 
     private Consumer<@NonNull Document, @NonNull String, @NonNull String> fieldKey = (doc, field, value) -> {
@@ -116,10 +116,10 @@ public class DocumentFactory {
     };
 
     private BiConsumer<@NonNull Document, @NonNull String> fieldMediatype = (doc, value) ->
-        fieldKey.accept(doc, FieldNames.MEDIA_TYPE, value);
+        fieldKey.accept(doc, FieldNamesConstants.MEDIA_TYPE, value);
 
     private BiConsumer<@NonNull Document, @NonNull String> fieldFolderPath = (doc, value) ->
-        fieldKey.accept(doc, FieldNames.FOLDER, value);
+        fieldKey.accept(doc, FieldNamesConstants.FOLDER, value);
 
     public BiFunction<@NonNull String, @Nullable String, List<Field>> createWordsFields = (fieldName, value) ->
         Arrays.asList(new TextField(fieldName, value, Store.NO), new SortedDocValuesField(fieldName, new BytesRef(value)));
@@ -135,7 +135,7 @@ public class DocumentFactory {
         if (isEmpty(value)) {
             return;
         }
-        fieldWords.accept(doc, FieldNames.GENRE, value);
+        fieldWords.accept(doc, FieldNamesConstants.GENRE, value);
     };
 
     private Consumer<Document, String, String> fieldGenreKey = (doc, fieldName, value) -> {
@@ -151,7 +151,7 @@ public class DocumentFactory {
 
 
     public final Term createPrimarykey(Integer id) {
-        return new Term(FieldNames.ID, Integer.toString(id));
+        return new Term(FieldNamesConstants.ID, Integer.toString(id));
     }
 
     public final Term createPrimarykey(Album album) {
@@ -176,11 +176,11 @@ public class DocumentFactory {
     public Document createAlbumDocument(MediaFile mediaFile) {
         Document doc = new Document();
         fieldId.accept(doc, mediaFile.getId());
-        fieldWords.accept(doc, FieldNames.ARTIST, mediaFile.getArtist());
+        fieldWords.accept(doc, FieldNamesConstants.ARTIST, mediaFile.getArtist());
         acceptArtistReading(doc, mediaFile);
         fieldGenre.accept(doc, mediaFile.getGenre());
-        fieldWords.accept(doc, FieldNames.ALBUM, mediaFile.getAlbumName());
-        fieldWords.accept(doc, FieldNames.ALBUM_EX, mediaFile.getAlbumName());
+        fieldWords.accept(doc, FieldNamesConstants.ALBUM, mediaFile.getAlbumName());
+        fieldWords.accept(doc, FieldNamesConstants.ALBUM_EX, mediaFile.getAlbumName());
         fieldFolderPath.accept(doc, mediaFile.getFolder());
         return doc;
     }
@@ -195,7 +195,7 @@ public class DocumentFactory {
     public Document createArtistDocument(MediaFile mediaFile) {
         Document doc = new Document();
         fieldId.accept(doc, mediaFile.getId());
-        fieldWords.accept(doc, FieldNames.ARTIST, mediaFile.getArtist());
+        fieldWords.accept(doc, FieldNamesConstants.ARTIST, mediaFile.getArtist());
         acceptArtistReading(doc, mediaFile);
         fieldFolderPath.accept(doc, mediaFile.getFolder());
         return doc;
@@ -211,11 +211,11 @@ public class DocumentFactory {
     public Document createAlbumId3Document(Album album) {
         Document doc = new Document();
         fieldId.accept(doc, album.getId());
-        fieldWords.accept(doc, FieldNames.ARTIST, album.getArtist());
+        fieldWords.accept(doc, FieldNamesConstants.ARTIST, album.getArtist());
         acceptArtistReading(doc, album);
         fieldGenre.accept(doc, album.getGenre());
-        fieldWords.accept(doc, FieldNames.ALBUM, album.getName());
-        fieldWords.accept(doc, FieldNames.ALBUM_EX, album.getName());
+        fieldWords.accept(doc, FieldNamesConstants.ALBUM, album.getName());
+        fieldWords.accept(doc, FieldNamesConstants.ALBUM_EX, album.getName());
         fieldFolderId.accept(doc, album.getFolderId());
         return doc;
     }
@@ -242,7 +242,7 @@ public class DocumentFactory {
     public Document createArtistId3Document(Artist artist, MusicFolder musicFolder) {
         Document doc = new Document();
         fieldId.accept(doc, artist.getId());
-        fieldWords.accept(doc, FieldNames.ARTIST, artist.getName());
+        fieldWords.accept(doc, FieldNamesConstants.ARTIST, artist.getName());
         acceptArtistReading(doc, artist);
         fieldFolderId.accept(doc, musicFolder.getId());
         return doc;
@@ -259,21 +259,21 @@ public class DocumentFactory {
         Document doc = new Document();
         fieldId.accept(doc, mediaFile.getId());
         fieldMediatype.accept(doc, mediaFile.getMediaType().name());
-        fieldWords.accept(doc, FieldNames.TITLE, mediaFile.getTitle());
-        fieldWords.accept(doc, FieldNames.TITLE_EX, mediaFile.getTitle());
-        fieldWords.accept(doc, FieldNames.ARTIST, mediaFile.getArtist());
+        fieldWords.accept(doc, FieldNamesConstants.TITLE, mediaFile.getTitle());
+        fieldWords.accept(doc, FieldNamesConstants.TITLE_EX, mediaFile.getTitle());
+        fieldWords.accept(doc, FieldNamesConstants.ARTIST, mediaFile.getArtist());
         acceptArtistReading(doc, mediaFile);
-        fieldWords.accept(doc, FieldNames.COMPOSER, mediaFile.getComposer());
+        fieldWords.accept(doc, FieldNamesConstants.COMPOSER, mediaFile.getComposer());
         acceptComposerReading(doc, mediaFile);
         fieldGenre.accept(doc, mediaFile.getGenre());
-        fieldYear.accept(doc, FieldNames.YEAR, mediaFile.getYear());
+        fieldYear.accept(doc, FieldNamesConstants.YEAR, mediaFile.getYear());
         fieldFolderPath.accept(doc, mediaFile.getFolder());
         return doc;
     }
 
     public Document createGenreDocument(MediaFile mediaFile) {
         Document doc = new Document();
-        fieldGenreKey.accept(doc, FieldNames.GENRE_KEY, mediaFile.getGenre());
+        fieldGenreKey.accept(doc, FieldNamesConstants.GENRE_KEY, mediaFile.getGenre());
         fieldGenre.accept(doc, mediaFile.getGenre());
         return doc;
     }
@@ -281,12 +281,12 @@ public class DocumentFactory {
     private void acceptArtistReading(Document doc, String artist, String sort, String reading) {
         String result = defaultIfEmpty(sort, reading);
         if (!isEmpty(artist) && !artist.equals(result)) {
-            fieldWords.accept(doc, FieldNames.ARTIST_READING,
+            fieldWords.accept(doc, FieldNamesConstants.ARTIST_READING,
                     settingsService.isSearchMethodLegacy()
                         ? result
                         : readingUtils.removePunctuationFromJapaneseReading(result));
         }
-        fieldWords.accept(doc, FieldNames.ARTIST_EX, artist);
+        fieldWords.accept(doc, FieldNamesConstants.ARTIST_EX, artist);
     }
 
     private void acceptArtistReading(Document doc, MediaFile mediaFile) {
@@ -303,10 +303,10 @@ public class DocumentFactory {
 
     private void acceptComposerReading(Document doc, MediaFile mediaFile) {
         if (settingsService.isSearchMethodLegacy()) {
-            fieldWords.accept(doc, FieldNames.COMPOSER_READING, mediaFile.getComposerSort());
+            fieldWords.accept(doc, FieldNamesConstants.COMPOSER_READING, mediaFile.getComposerSort());
         } else {
             if (!isEmpty(mediaFile.getComposer()) && !mediaFile.getComposer().equals(mediaFile.getComposerSort())) {
-                fieldWords.accept(doc, FieldNames.COMPOSER_READING, mediaFile.getComposerSort());
+                fieldWords.accept(doc, FieldNamesConstants.COMPOSER_READING, mediaFile.getComposerSort());
             }
         }
     }

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/search/FieldNamesConstants.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/search/FieldNamesConstants.java
@@ -24,9 +24,9 @@ package org.airsonic.player.service.search;
  * Enum that symbolizes the field name used for lucene index.
  * This class is a division of what was once part of SearchService and added functionality.
  */
-public final class FieldNames {
+public final class FieldNamesConstants {
 
-    private FieldNames() {
+    private FieldNamesConstants() {
     }
 
     /**

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/search/IndexManager.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/search/IndexManager.java
@@ -32,7 +32,7 @@ import org.airsonic.player.domain.MediaLibraryStatistics;
 import org.airsonic.player.domain.MusicFolder;
 import org.airsonic.player.service.SettingsService;
 import org.airsonic.player.util.FileUtil;
-import org.airsonic.player.util.Util;
+import org.airsonic.player.util.PlayerUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
@@ -299,7 +299,7 @@ public class IndexManager {
         boolean isUpdate = false;
         // close
         try (IndexWriter writer = writers.get(type)) {
-            Map<String,String> userData = Util.objectToStringMap(statistics);
+            Map<String,String> userData = PlayerUtils.objectToStringMap(statistics);
             writer.setLiveCommitData(userData.entrySet());
             isUpdate = -1 != writers.get(type).commit();
             writer.close();
@@ -352,7 +352,7 @@ public class IndexManager {
             }
             try {
                 Map<String, String> userData = ((DirectoryReader) indexReader).getIndexCommit().getUserData();
-                MediaLibraryStatistics currentStats = Util.stringMapToValidObject(MediaLibraryStatistics.class,
+                MediaLibraryStatistics currentStats = PlayerUtils.stringMapToValidObject(MediaLibraryStatistics.class,
                         userData);
                 if (stats == null) {
                     stats = currentStats;
@@ -545,7 +545,7 @@ public class IndexManager {
             TopDocs topDocs = searcher.search(query, Integer.MAX_VALUE);
             int totalHits = util.round.apply(topDocs.totalHits.value);
             for (int i = 0; i < totalHits; i++) {
-                IndexableField[] fields = searcher.doc(topDocs.scoreDocs[i].doc).getFields(FieldNames.GENRE_KEY);
+                IndexableField[] fields = searcher.doc(topDocs.scoreDocs[i].doc).getFields(FieldNamesConstants.GENRE_KEY);
                 if (!isEmpty(fields)) {
                     List<String> fieldValues = Arrays.stream(fields).map(f -> f.stringValue()).collect(Collectors.toList());
                     fieldValues.forEach(v -> {
@@ -623,7 +623,7 @@ public class IndexManager {
                     Comparator<TermStats> c = new HighFreqTerms.DocFreqComparator();
                     TermStats[] stats = null;
                     try {
-                        stats = HighFreqTerms.getHighFreqTerms(genreSearcher.getIndexReader(), numTerms, FieldNames.GENRE, c);
+                        stats = HighFreqTerms.getHighFreqTerms(genreSearcher.getIndexReader(), numTerms, FieldNamesConstants.GENRE, c);
                     } catch (Exception e) {
                         LOG.error("The genre field may not exist. This is an expected error before scan or using library without genre. : ", e);
                         break mayBeInit;

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/search/IndexManager.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/search/IndexManager.java
@@ -204,8 +204,8 @@ public class IndexManager {
 
     public final void startIndexing() {
         try {
-            for (IndexType IndexType : IndexType.values()) {
-                writers.put(IndexType, createIndexWriter(IndexType));
+            for (IndexType indexType : IndexType.values()) {
+                writers.put(indexType, createIndexWriter(indexType));
             }
             clearGenreMaster();
         } catch (IOException e) {

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/search/IndexType.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/search/IndexType.java
@@ -36,67 +36,67 @@ public enum IndexType {
 
     SONG(
         fieldNames(
-            FieldNames.TITLE_EX,
-            FieldNames.TITLE,
-            FieldNames.ARTIST_READING,
-            FieldNames.ARTIST_EX,
-            FieldNames.ARTIST,
-            FieldNames.COMPOSER_READING,
-            FieldNames.COMPOSER),
+            FieldNamesConstants.TITLE_EX,
+            FieldNamesConstants.TITLE,
+            FieldNamesConstants.ARTIST_READING,
+            FieldNamesConstants.ARTIST_EX,
+            FieldNamesConstants.ARTIST,
+            FieldNamesConstants.COMPOSER_READING,
+            FieldNamesConstants.COMPOSER),
         boosts(
-            entry(FieldNames.TITLE_EX, 2.3F),
-            entry(FieldNames.TITLE, 2.2F),
-            entry(FieldNames.ARTIST_READING, 1.4F),
-            entry(FieldNames.ARTIST_EX, 1.3F),
-            entry(FieldNames.ARTIST, 1.2F),
-            entry(FieldNames.COMPOSER_READING, 1.1F))),
+            entry(FieldNamesConstants.TITLE_EX, 2.3F),
+            entry(FieldNamesConstants.TITLE, 2.2F),
+            entry(FieldNamesConstants.ARTIST_READING, 1.4F),
+            entry(FieldNamesConstants.ARTIST_EX, 1.3F),
+            entry(FieldNamesConstants.ARTIST, 1.2F),
+            entry(FieldNamesConstants.COMPOSER_READING, 1.1F))),
 
     ALBUM(
         fieldNames(
-            FieldNames.ALBUM_EX,
-            FieldNames.ALBUM,
-            FieldNames.ARTIST_READING,
-            FieldNames.ARTIST_EX,
-            FieldNames.ARTIST),
+            FieldNamesConstants.ALBUM_EX,
+            FieldNamesConstants.ALBUM,
+            FieldNamesConstants.ARTIST_READING,
+            FieldNamesConstants.ARTIST_EX,
+            FieldNamesConstants.ARTIST),
         boosts(
-            entry(FieldNames.ALBUM_EX, 2.3F),
-            entry(FieldNames.ALBUM, 2.3F),
-            entry(FieldNames.ARTIST_READING, 1.1F))),
+            entry(FieldNamesConstants.ALBUM_EX, 2.3F),
+            entry(FieldNamesConstants.ALBUM, 2.3F),
+            entry(FieldNamesConstants.ARTIST_READING, 1.1F))),
 
     ALBUM_ID3(
         fieldNames(
-            FieldNames.ALBUM_EX,
-            FieldNames.ALBUM,
-            FieldNames.ARTIST_READING,
-            FieldNames.ARTIST_EX,
-            FieldNames.ARTIST),
+            FieldNamesConstants.ALBUM_EX,
+            FieldNamesConstants.ALBUM,
+            FieldNamesConstants.ARTIST_READING,
+            FieldNamesConstants.ARTIST_EX,
+            FieldNamesConstants.ARTIST),
         boosts(
-            entry(FieldNames.ALBUM_EX, 2.3F),
-            entry(FieldNames.ALBUM, 2.3F),
-            entry(FieldNames.ARTIST_READING, 1.1F))),
+            entry(FieldNamesConstants.ALBUM_EX, 2.3F),
+            entry(FieldNamesConstants.ALBUM, 2.3F),
+            entry(FieldNamesConstants.ARTIST_READING, 1.1F))),
 
     ARTIST(
         fieldNames(
-            FieldNames.ARTIST_READING,
-            FieldNames.ARTIST_EX,
-            FieldNames.ARTIST),
+            FieldNamesConstants.ARTIST_READING,
+            FieldNamesConstants.ARTIST_EX,
+            FieldNamesConstants.ARTIST),
         boosts(
-            entry(FieldNames.ARTIST_READING, 1.1F))),
+            entry(FieldNamesConstants.ARTIST_READING, 1.1F))),
 
     ARTIST_ID3(
         fieldNames(
-            FieldNames.ARTIST_READING,
-            FieldNames.ARTIST_EX,
-            FieldNames.ARTIST),
+            FieldNamesConstants.ARTIST_READING,
+            FieldNamesConstants.ARTIST_EX,
+            FieldNamesConstants.ARTIST),
         boosts(
-            entry(FieldNames.ARTIST_READING, 1.1F))),
+            entry(FieldNamesConstants.ARTIST_READING, 1.1F))),
 
     GENRE(
         fieldNames(
-            FieldNames.GENRE_KEY,
-            FieldNames.GENRE),
+            FieldNamesConstants.GENRE_KEY,
+            FieldNamesConstants.GENRE),
         boosts(
-            entry(FieldNames.GENRE_KEY, 1.1F))),
+            entry(FieldNamesConstants.GENRE_KEY, 1.1F))),
     
     ;
 

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/search/QueryFactory.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/search/QueryFactory.java
@@ -71,12 +71,12 @@ public class QueryFactory {
 
     private final Function<MusicFolder, Query> toFolderIdQuery = (folder) -> {
         // Unanalyzed field
-        return new TermQuery(new Term(FieldNames.FOLDER_ID, folder.getId().toString()));
+        return new TermQuery(new Term(FieldNamesConstants.FOLDER_ID, folder.getId().toString()));
     };
 
     private final Function<MusicFolder, Query> toFolderPathQuery = (folder) -> {
         // Unanalyzed field
-        return new TermQuery(new Term(FieldNames.FOLDER, folder.getPath().getPath()));
+        return new TermQuery(new Term(FieldNamesConstants.FOLDER, folder.getPath().getPath()));
     };
 
     /*
@@ -191,7 +191,7 @@ public class QueryFactory {
      */
     private final BiFunction<@Nullable Integer, @Nullable Integer, @NonNull Query> toYearRangeQuery =
         (from, to) -> {
-            return IntPoint.newRangeQuery(FieldNames.YEAR,
+            return IntPoint.newRangeQuery(FieldNamesConstants.YEAR,
                 isEmpty(from) ? Integer.MIN_VALUE : from,
                 isEmpty(to) ? Integer.MAX_VALUE : to);
         };
@@ -248,7 +248,7 @@ public class QueryFactory {
         BooleanQuery.Builder query = new BooleanQuery.Builder();
         
         // Unanalyzed field
-        query.add(new TermQuery(new Term(FieldNames.MEDIA_TYPE, MediaType.MUSIC.name())), Occur.MUST);
+        query.add(new TermQuery(new Term(FieldNamesConstants.MEDIA_TYPE, MediaType.MUSIC.name())), Occur.MUST);
 
         BooleanQuery.Builder genreQuery = new BooleanQuery.Builder();
         Analyzer queryAnalyzer = analyzerFactory.getQueryAnalyzer();
@@ -256,11 +256,11 @@ public class QueryFactory {
             for (String genre : criteria.getGenres()) {
                 if (!isEmpty(criteria.getGenres())) {
                     if (!isEmpty(genre)) {
-                        try (TokenStream stream = queryAnalyzer.tokenStream(FieldNames.GENRE, genre)) {
+                        try (TokenStream stream = queryAnalyzer.tokenStream(FieldNamesConstants.GENRE, genre)) {
                             stream.reset();
                             while (stream.incrementToken()) {
                                 String token = stream.getAttribute(CharTermAttribute.class).toString();
-                                genreQuery.add(new TermQuery(new Term(FieldNames.GENRE, token)), Occur.SHOULD);
+                                genreQuery.add(new TermQuery(new Term(FieldNamesConstants.GENRE, token)), Occur.SHOULD);
                             }
                         }
                     }
@@ -287,7 +287,7 @@ public class QueryFactory {
      */
     public Query getRandomSongs(List<MusicFolder> musicFolders) {
         return new BooleanQuery.Builder()
-                .add(new TermQuery(new Term(FieldNames.MEDIA_TYPE, MediaType.MUSIC.name())), Occur.MUST)
+                .add(new TermQuery(new Term(FieldNamesConstants.MEDIA_TYPE, MediaType.MUSIC.name())), Occur.MUST)
                 .add(toFolderQuery.apply(false, musicFolders), Occur.MUST)
                 .build();
     }
@@ -374,10 +374,10 @@ public class QueryFactory {
         // sub - genre
         if (!isEmpty(genres)) {
             BooleanQuery.Builder genreQuery = new BooleanQuery.Builder();
-            TokenStream stream = analyzerFactory.getQueryAnalyzer().tokenStream(FieldNames.GENRE, genres);
+            TokenStream stream = analyzerFactory.getQueryAnalyzer().tokenStream(FieldNamesConstants.GENRE, genres);
             stream.reset();
             while (stream.incrementToken()) {
-                genreQuery.add(new TermQuery(new Term(FieldNames.GENRE, stream.getAttribute(CharTermAttribute.class).toString())), Occur.SHOULD);
+                genreQuery.add(new TermQuery(new Term(FieldNamesConstants.GENRE, stream.getAttribute(CharTermAttribute.class).toString())), Occur.SHOULD);
             }
             stream.close();
             query.add(genreQuery.build(), Occur.MUST);
@@ -385,7 +385,7 @@ public class QueryFactory {
 
         // sub - folder
         BooleanQuery.Builder folderQuery = new BooleanQuery.Builder();
-        musicFolders.forEach(musicFolder -> folderQuery.add(new TermQuery(new Term(FieldNames.FOLDER_ID, musicFolder.getId().toString())), Occur.SHOULD));
+        musicFolders.forEach(musicFolder -> folderQuery.add(new TermQuery(new Term(FieldNamesConstants.FOLDER_ID, musicFolder.getId().toString())), Occur.SHOULD));
         query.add(folderQuery.build(), Occur.MUST);
 
         return query.build();
@@ -406,10 +406,10 @@ public class QueryFactory {
         // sub - genre
         if (!isEmpty(genres)) {
             BooleanQuery.Builder genreQuery = new BooleanQuery.Builder();
-            TokenStream stream = analyzerFactory.getQueryAnalyzer().tokenStream(FieldNames.GENRE, genres);
+            TokenStream stream = analyzerFactory.getQueryAnalyzer().tokenStream(FieldNamesConstants.GENRE, genres);
             stream.reset();
             while (stream.incrementToken()) {
-                genreQuery.add(new TermQuery(new Term(FieldNames.GENRE, stream.getAttribute(CharTermAttribute.class).toString())), Occur.SHOULD);
+                genreQuery.add(new TermQuery(new Term(FieldNamesConstants.GENRE, stream.getAttribute(CharTermAttribute.class).toString())), Occur.SHOULD);
             }
             stream.close();
             query.add(genreQuery.build(), Occur.MUST);
@@ -417,7 +417,7 @@ public class QueryFactory {
 
         // sub - folder
         BooleanQuery.Builder folderQuery = new BooleanQuery.Builder();
-        musicFolders.forEach(musicFolder -> folderQuery.add(new TermQuery(new Term(FieldNames.FOLDER, musicFolder.getPath().getPath())), Occur.SHOULD));
+        musicFolders.forEach(musicFolder -> folderQuery.add(new TermQuery(new Term(FieldNamesConstants.FOLDER, musicFolder.getPath().getPath())), Occur.SHOULD));
         query.add(folderQuery.build(), Occur.MUST);
 
         return query.build();
@@ -434,10 +434,10 @@ public class QueryFactory {
 
         for (String genre : genres) {
             if (!isEmpty(genre)) {
-                TokenStream stream = analyzerFactory.getQueryAnalyzer().tokenStream(FieldNames.GENRE, genre);
+                TokenStream stream = analyzerFactory.getQueryAnalyzer().tokenStream(FieldNamesConstants.GENRE, genre);
                 stream.reset();
                 while (stream.incrementToken()) {
-                    genreQuery.add(new TermQuery(new Term(FieldNames.GENRE, stream.getAttribute(CharTermAttribute.class).toString())), Occur.SHOULD);
+                    genreQuery.add(new TermQuery(new Term(FieldNamesConstants.GENRE, stream.getAttribute(CharTermAttribute.class).toString())), Occur.SHOULD);
                 }
                 stream.close();
             }
@@ -448,7 +448,7 @@ public class QueryFactory {
     }
 
     public Query getGenre(String genre) throws IOException {
-        return new BooleanQuery.Builder().add(new TermQuery(new Term(FieldNames.GENRE, genre)), Occur.SHOULD).build();
+        return new BooleanQuery.Builder().add(new TermQuery(new Term(FieldNamesConstants.GENRE, genre)), Occur.SHOULD).build();
     }
 
 }

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/search/SearchServiceUtilities.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/search/SearchServiceUtilities.java
@@ -219,8 +219,8 @@ public class SearchServiceUtilities {
         }
     }
 
-    public final String[] filterComposer(String[] Fields, boolean includeComposer) {
-        return Arrays.asList(Fields).stream()
+    public final String[] filterComposer(String[] fields, boolean includeComposer) {
+        return Arrays.asList(fields).stream()
                 .filter(f -> includeComposer ? true : !(FieldNamesConstants.COMPOSER.equals(f) || FieldNamesConstants.COMPOSER_READING.equals(f)))
                 .collect(Collectors.toList()).toArray(new String[0]);
     }

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/search/SearchServiceUtilities.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/search/SearchServiceUtilities.java
@@ -123,7 +123,7 @@ public class SearchServiceUtilities {
     };
 
     public final Function<Document, Integer> getId = d -> {
-        return Integer.valueOf(d.get(FieldNames.ID));
+        return Integer.valueOf(d.get(FieldNamesConstants.ID));
     };
 
     public final BiConsumer<List<MediaFile>, Integer> addMediaFileIfAnyMatch = (dist, id) -> {
@@ -159,11 +159,11 @@ public class SearchServiceUtilities {
     public final Function<Class<?>, @Nullable String> getFieldName = (assignableClass) -> {
         String fieldName = null;
         if (assignableClass.isAssignableFrom(Album.class)) {
-            fieldName = FieldNames.ALBUM;
+            fieldName = FieldNamesConstants.ALBUM;
         } else if (assignableClass.isAssignableFrom(Artist.class)) {
-            fieldName = FieldNames.ARTIST;
+            fieldName = FieldNamesConstants.ARTIST;
         } else if (assignableClass.isAssignableFrom(MediaFile.class)) {
-            fieldName = FieldNames.TITLE;
+            fieldName = FieldNamesConstants.TITLE;
         }
         return fieldName;
     };
@@ -221,7 +221,7 @@ public class SearchServiceUtilities {
 
     public final String[] filterComposer(String[] Fields, boolean includeComposer) {
         return Arrays.asList(Fields).stream()
-                .filter(f -> includeComposer ? true : !(FieldNames.COMPOSER.equals(f) || FieldNames.COMPOSER_READING.equals(f)))
+                .filter(f -> includeComposer ? true : !(FieldNamesConstants.COMPOSER.equals(f) || FieldNamesConstants.COMPOSER_READING.equals(f)))
                 .collect(Collectors.toList()).toArray(new String[0]);
     }
 

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/search/UPnPSearchCriteriaDirector.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/search/UPnPSearchCriteriaDirector.java
@@ -127,7 +127,7 @@ public class UPnPSearchCriteriaDirector implements UPnPSearchCriteriaListener {
             LOG.warn("The entered query may have a grammatical error. Reason:{}", message);
     };
 
-    private final List<String> UNSUPPORTED_CLASS = Arrays.asList(
+    private static final List<String> UNSUPPORTED_CLASS = Arrays.asList(
             "object.container.album.photoAlbum",
             "object.container.playlistContainer",
             "object.container.genre",

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/search/UPnPSearchCriteriaDirector.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/search/UPnPSearchCriteriaDirector.java
@@ -183,22 +183,22 @@ public class UPnPSearchCriteriaDirector implements UPnPSearchCriteriaListener {
     public void enterClassRelExp(ClassRelExpContext ctx) {
         List<ParseTree> children = ctx.children.stream().filter(p -> !isBlank(p.getText())).collect(toList());
         notice.accept(3 != children.size(), "The number of child elements of ClassRelExp is incorrect.");
-        final String S = children.get(0).getText();
-        final String V = children.get(1).getText();
-        final String C = children.get(2).getText();
+        final String subject = children.get(0).getText();
+        final String verb = children.get(1).getText();
+        final String complement = children.get(2).getText();
 
-        if (UNSUPPORTED_CLASS.contains(C)) {
+        if (UNSUPPORTED_CLASS.contains(complement)) {
             mediaTypeQueryBuilder = null;
-            throw createIllegal("The current version does not support searching for this class.", S, V, C);
+            throw createIllegal("The current version does not support searching for this class.", subject, verb, complement);
         }
 
-        if (C.startsWith("object.item.audioItem") || C.startsWith("object.item.videoItem")) {
+        if (complement.startsWith("object.item.audioItem") || complement.startsWith("object.item.videoItem")) {
             mediaTypeQueryBuilder = new BooleanQuery.Builder();
         }
 
-        switch (V) {
+        switch (verb) {
             case "derivedfrom":
-                switch (C) {
+                switch (complement) {
 
                     // artist
                     case "object.container.person":
@@ -232,12 +232,12 @@ public class UPnPSearchCriteriaDirector implements UPnPSearchCriteriaListener {
 
                     default:
                         mediaTypeQueryBuilder = null;
-                        throw createIllegal("An unknown class was specified.", S, V, C);
+                        throw createIllegal("An unknown class was specified.", subject, verb, complement);
 
                 }
                 break;
             case "=":
-                switch (C) {
+                switch (complement) {
     
                     // artist
                     case "object.container.person.musicArtist":
@@ -281,7 +281,7 @@ public class UPnPSearchCriteriaDirector implements UPnPSearchCriteriaListener {
 
                     default:
                         mediaTypeQueryBuilder = null;
-                        throw createIllegal("An insufficient class hierarchy from derivedfrom or a class not supported by the server was specified.", S, V, C);
+                        throw createIllegal("An insufficient class hierarchy from derivedfrom or a class not supported by the server was specified.", subject, verb, complement);
 
                 }
                 break;
@@ -363,12 +363,11 @@ public class UPnPSearchCriteriaDirector implements UPnPSearchCriteriaListener {
 
         List<ParseTree> children = ctx.children.stream().filter(p -> !isBlank(p.getText())).collect(toList());
         notice.accept(3 != children.size(), "The number of child elements of ClassRelExp is incorrect.");
-        final String S = children.get(0).getText();
-        final String C = children.get(2).getText();
-
+        final String subject = children.get(0).getText();
+        final String complement = children.get(2).getText();
         List<String> fieldName = new ArrayList<String>();
 
-        if ("dc:title".equals(S)) {
+        if ("dc:title".equals(subject)) {
             if (Album.class == assignableClass) {
                 fieldName.add(FieldNamesConstants.ALBUM_EX);
                 fieldName.add(FieldNamesConstants.ALBUM);
@@ -380,18 +379,18 @@ public class UPnPSearchCriteriaDirector implements UPnPSearchCriteriaListener {
                 fieldName.add(FieldNamesConstants.TITLE_EX);
                 fieldName.add(FieldNamesConstants.TITLE);
             }
-        } else if ("dc:creator".equals(S)) {
+        } else if ("dc:creator".equals(subject)) {
             fieldName.add(FieldNamesConstants.COMPOSER_READING);
             fieldName.add(FieldNamesConstants.COMPOSER);
-        } else if ("upnp:artist".equals(S)) {
+        } else if ("upnp:artist".equals(subject)) {
             fieldName.add(FieldNamesConstants.ARTIST_READING);
             fieldName.add(FieldNamesConstants.ARTIST_EX);
             fieldName.add(FieldNamesConstants.ARTIST);
         }
-        notice.accept(0 == fieldName.size(), "Unexpected PropertyExpContext. -> " + S);
+        notice.accept(0 == fieldName.size(), "Unexpected PropertyExpContext. -> " + subject);
 
         try {
-            Query query = createMultiFieldQuery(fieldName.toArray(new String[fieldName.size()]), C);
+            Query query = createMultiFieldQuery(fieldName.toArray(new String[fieldName.size()]), complement);
             if (!isEmpty(query)) {
                 propExpQueryBuilder.add(query, isEmpty(lastLogOp) ? Occur.SHOULD : lastLogOp);
             }
@@ -586,8 +585,8 @@ public class UPnPSearchCriteriaDirector implements UPnPSearchCriteriaListener {
     public void visitTerminal(TerminalNode node) {
     }
 
-    private IllegalArgumentException createIllegal(String message, String S, String V, String C) {
-        return new IllegalArgumentException(message.concat(" : ").concat(S).concat(SPACE).concat(V).concat(SPACE).concat(C));
+    private IllegalArgumentException createIllegal(String message, String subject, String verb, String complement) {
+        return new IllegalArgumentException(message.concat(" : ").concat(subject).concat(SPACE).concat(verb).concat(SPACE).concat(complement));
     }
 
     private Query createMultiFieldQuery(final String[] fields, final String query) throws IOException {

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/search/UPnPSearchCriteriaDirector.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/search/UPnPSearchCriteriaDirector.java
@@ -216,9 +216,9 @@ public class UPnPSearchCriteriaDirector implements UPnPSearchCriteriaListener {
                     case "object.item.audioItem":
                         assignableClass = MediaFile.class;
                         if (!isEmpty(mediaTypeQueryBuilder)) {
-                            mediaTypeQueryBuilder.add(new TermQuery(new Term(FieldNames.MEDIA_TYPE, MediaType.MUSIC.name())), Occur.SHOULD);
-                            mediaTypeQueryBuilder.add(new TermQuery(new Term(FieldNames.MEDIA_TYPE, MediaType.PODCAST.name())), Occur.SHOULD);
-                            mediaTypeQueryBuilder.add(new TermQuery(new Term(FieldNames.MEDIA_TYPE, MediaType.AUDIOBOOK.name())), Occur.SHOULD);
+                            mediaTypeQueryBuilder.add(new TermQuery(new Term(FieldNamesConstants.MEDIA_TYPE, MediaType.MUSIC.name())), Occur.SHOULD);
+                            mediaTypeQueryBuilder.add(new TermQuery(new Term(FieldNamesConstants.MEDIA_TYPE, MediaType.PODCAST.name())), Occur.SHOULD);
+                            mediaTypeQueryBuilder.add(new TermQuery(new Term(FieldNamesConstants.MEDIA_TYPE, MediaType.AUDIOBOOK.name())), Occur.SHOULD);
                         }
                         break;
 
@@ -226,7 +226,7 @@ public class UPnPSearchCriteriaDirector implements UPnPSearchCriteriaListener {
                     case "object.item.videoItem":
                         assignableClass = MediaFile.class;
                         if (!isEmpty(mediaTypeQueryBuilder)) {
-                            mediaTypeQueryBuilder.add(new TermQuery(new Term(FieldNames.MEDIA_TYPE, MediaType.VIDEO.name())), Occur.MUST);
+                            mediaTypeQueryBuilder.add(new TermQuery(new Term(FieldNamesConstants.MEDIA_TYPE, MediaType.VIDEO.name())), Occur.MUST);
                         }
                         break;
 
@@ -253,19 +253,19 @@ public class UPnPSearchCriteriaDirector implements UPnPSearchCriteriaListener {
                     case "object.item.audioItem.musicTrack":
                         assignableClass = MediaFile.class;
                         if (!isEmpty(mediaTypeQueryBuilder)) {
-                            mediaTypeQueryBuilder.add(new TermQuery(new Term(FieldNames.MEDIA_TYPE, MediaType.MUSIC.name())), Occur.SHOULD);
+                            mediaTypeQueryBuilder.add(new TermQuery(new Term(FieldNamesConstants.MEDIA_TYPE, MediaType.MUSIC.name())), Occur.SHOULD);
                         }
                         break;
                     case "object.item.audioItem.audioBroadcast":
                         assignableClass = MediaFile.class;
                         if (!isEmpty(mediaTypeQueryBuilder)) {
-                            mediaTypeQueryBuilder.add(new TermQuery(new Term(FieldNames.MEDIA_TYPE, MediaType.PODCAST.name())), Occur.SHOULD);
+                            mediaTypeQueryBuilder.add(new TermQuery(new Term(FieldNamesConstants.MEDIA_TYPE, MediaType.PODCAST.name())), Occur.SHOULD);
                         }
                         break;
                     case "object.item.audioItem.audioBook":
                         assignableClass = MediaFile.class;
                         if (!isEmpty(mediaTypeQueryBuilder)) {
-                            mediaTypeQueryBuilder.add(new TermQuery(new Term(FieldNames.MEDIA_TYPE, MediaType.AUDIOBOOK.name())), Occur.SHOULD);
+                            mediaTypeQueryBuilder.add(new TermQuery(new Term(FieldNamesConstants.MEDIA_TYPE, MediaType.AUDIOBOOK.name())), Occur.SHOULD);
                         }
                         break;
 
@@ -275,7 +275,7 @@ public class UPnPSearchCriteriaDirector implements UPnPSearchCriteriaListener {
                     case "object.item.videoItem.musicVideoClip":
                         assignableClass = MediaFile.class;
                         if (!isEmpty(mediaTypeQueryBuilder)) {
-                            mediaTypeQueryBuilder.add(new TermQuery(new Term(FieldNames.MEDIA_TYPE, MediaType.VIDEO.name())), Occur.MUST);
+                            mediaTypeQueryBuilder.add(new TermQuery(new Term(FieldNamesConstants.MEDIA_TYPE, MediaType.VIDEO.name())), Occur.MUST);
                         }
                         break;
 
@@ -370,23 +370,23 @@ public class UPnPSearchCriteriaDirector implements UPnPSearchCriteriaListener {
 
         if ("dc:title".equals(S)) {
             if (Album.class == assignableClass) {
-                fieldName.add(FieldNames.ALBUM_EX);
-                fieldName.add(FieldNames.ALBUM);
+                fieldName.add(FieldNamesConstants.ALBUM_EX);
+                fieldName.add(FieldNamesConstants.ALBUM);
             } else if (Artist.class == assignableClass) {
-                fieldName.add(FieldNames.ARTIST_READING);
-                fieldName.add(FieldNames.ARTIST_EX);
-                fieldName.add(FieldNames.ARTIST);
+                fieldName.add(FieldNamesConstants.ARTIST_READING);
+                fieldName.add(FieldNamesConstants.ARTIST_EX);
+                fieldName.add(FieldNamesConstants.ARTIST);
             } else {
-                fieldName.add(FieldNames.TITLE_EX);
-                fieldName.add(FieldNames.TITLE);
+                fieldName.add(FieldNamesConstants.TITLE_EX);
+                fieldName.add(FieldNamesConstants.TITLE);
             }
         } else if ("dc:creator".equals(S)) {
-            fieldName.add(FieldNames.COMPOSER_READING);
-            fieldName.add(FieldNames.COMPOSER);
+            fieldName.add(FieldNamesConstants.COMPOSER_READING);
+            fieldName.add(FieldNamesConstants.COMPOSER);
         } else if ("upnp:artist".equals(S)) {
-            fieldName.add(FieldNames.ARTIST_READING);
-            fieldName.add(FieldNames.ARTIST_EX);
-            fieldName.add(FieldNames.ARTIST);
+            fieldName.add(FieldNamesConstants.ARTIST_READING);
+            fieldName.add(FieldNamesConstants.ARTIST_EX);
+            fieldName.add(FieldNamesConstants.ARTIST);
         }
         notice.accept(0 == fieldName.size(), "Unexpected PropertyExpContext. -> " + S);
 

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/sonos/SonosHelper.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/sonos/SonosHelper.java
@@ -29,8 +29,8 @@ import org.airsonic.player.service.*;
 import org.airsonic.player.service.search.IndexType;
 import org.airsonic.player.service.search.SearchCriteria;
 import org.airsonic.player.service.search.SearchCriteriaDirector;
+import org.airsonic.player.util.PlayerUtils;
 import org.airsonic.player.util.StringUtil;
-import org.airsonic.player.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -629,7 +629,7 @@ public class SonosHelper {
 
     public static MediaList createSubList(int index, int count, List<? extends AbstractMedia> mediaCollections) {
         MediaList result = new MediaList();
-        List<? extends AbstractMedia> selectedMediaCollections = Util.subList(mediaCollections, index, count);
+        List<? extends AbstractMedia> selectedMediaCollections = PlayerUtils.subList(mediaCollections, index, count);
 
         result.setIndex(index);
         result.setCount(selectedMediaCollections.size());

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/upnp/DispatchingContentDirectory.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/upnp/DispatchingContentDirectory.java
@@ -62,7 +62,7 @@ public class DispatchingContentDirectory extends CustomContentDirectory implemen
 
     private static final Logger LOG = LoggerFactory.getLogger(DispatchingContentDirectory.class);
 
-    private final int COUNT_MAX = 50;
+    private static final int COUNT_MAX = 50;
 
     private final RootUpnpProcessor rootProcessor;
     private final MediaFileUpnpProcessor mediaFileProcessor;

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/upnp/processor/IndexId3UpnpProcessor.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/upnp/processor/IndexId3UpnpProcessor.java
@@ -58,7 +58,7 @@ import java.util.function.Function;
 import static java.util.stream.Collectors.toList;
 import static org.airsonic.player.service.upnp.UpnpProcessDispatcher.CONTAINER_ID_INDEX_ID3_PREFIX;
 import static org.airsonic.player.service.upnp.UpnpProcessDispatcher.OBJECT_ID_SEPARATOR;
-import static org.airsonic.player.util.Util.subList;
+import static org.airsonic.player.util.PlayerUtils.subList;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
 @Service

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/upnp/processor/IndexId3UpnpProcessor.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/upnp/processor/IndexId3UpnpProcessor.java
@@ -64,7 +64,7 @@ import static org.springframework.util.ObjectUtils.isEmpty;
 @Service
 public class IndexId3UpnpProcessor extends UpnpContentProcessor<Id3Wrapper, Id3Wrapper> {
 
-    private final AtomicInteger INDEX_IDS = new AtomicInteger(Integer.MIN_VALUE);
+    private static final AtomicInteger INDEX_IDS = new AtomicInteger(Integer.MIN_VALUE);
 
     private final UpnpProcessorUtil util;
     private final JMediaFileService mediaFileService;

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/upnp/processor/IndexUpnpProcessor.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/upnp/processor/IndexUpnpProcessor.java
@@ -54,7 +54,7 @@ import static org.springframework.util.ObjectUtils.isEmpty;
 @Service
 public class IndexUpnpProcessor extends UpnpContentProcessor<MediaFile, MediaFile> {
 
-    private final AtomicInteger INDEX_IDS = new AtomicInteger(Integer.MIN_VALUE);
+    private static final AtomicInteger INDEX_IDS = new AtomicInteger(Integer.MIN_VALUE);
 
     private final UpnpProcessorUtil util;
 

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/upnp/processor/IndexUpnpProcessor.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/upnp/processor/IndexUpnpProcessor.java
@@ -48,7 +48,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.airsonic.player.util.Util.subList;
+import static org.airsonic.player.util.PlayerUtils.subList;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
 @Service

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/upnp/processor/PlaylistUpnpProcessor.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/upnp/processor/PlaylistUpnpProcessor.java
@@ -81,7 +81,7 @@ public class PlaylistUpnpProcessor extends UpnpContentProcessor <Playlist, Media
     public List<Playlist> getItems(long offset, long maxResults) {
         // Currently sorting on the Java side(Using sublist because less affected).
         List<Playlist> playlists = playlistService.getAllPlaylists();
-        return org.airsonic.player.util.Util.subList(playlists, offset, maxResults);
+        return org.airsonic.player.util.PlayerUtils.subList(playlists, offset, maxResults);
     }
 
     public Playlist getItemById(String id) {

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/upnp/processor/PodcastUpnpProcessor.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/upnp/processor/PodcastUpnpProcessor.java
@@ -135,7 +135,7 @@ public class PodcastUpnpProcessor extends UpnpContentProcessor <PodcastChannel, 
 
     @Override
     public List<PodcastChannel> getItems(long offset, long maxResults) {
-        return org.airsonic.player.util.Util.subList(podcastService.getAllChannels(), offset, maxResults);
+        return org.airsonic.player.util.PlayerUtils.subList(podcastService.getAllChannels(), offset, maxResults);
     }
 
     public PodcastChannel getItemById(String id) {
@@ -149,7 +149,7 @@ public class PodcastUpnpProcessor extends UpnpContentProcessor <PodcastChannel, 
 
     @Override
     public List<PodcastEpisode> getChildren(PodcastChannel channel, long offset, long maxResults) {
-        return org.airsonic.player.util.Util.subList(podcastService.getEpisodes(channel.getId()), offset, maxResults);
+        return org.airsonic.player.util.PlayerUtils.subList(podcastService.getEpisodes(channel.getId()), offset, maxResults);
     }
 
     public void addChild(DIDLContent didl, PodcastEpisode child) {

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/upnp/processor/PodcastUpnpProcessor.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/upnp/processor/PodcastUpnpProcessor.java
@@ -61,7 +61,7 @@ public class PodcastUpnpProcessor extends UpnpContentProcessor <PodcastChannel, 
 
     private final CoverArtLogic coverArtLogic;
 
-    private final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
 
     public PodcastUpnpProcessor(@Lazy UpnpProcessDispatcher d, UpnpProcessorUtil u, MediaFileService m, PodcastService p, CoverArtLogic c) {
         super(d, u);

--- a/jpsonic-main/src/main/java/org/airsonic/player/service/upnp/processor/RootUpnpProcessor.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/service/upnp/processor/RootUpnpProcessor.java
@@ -131,7 +131,7 @@ public class RootUpnpProcessor extends UpnpContentProcessor<Container, Container
             containers.add(getDispatcher().getPodcastProcessor().createRootContainer());
         }
 
-        return org.airsonic.player.util.Util.subList(containers, offset, maxResults);
+        return org.airsonic.player.util.PlayerUtils.subList(containers, offset, maxResults);
     }
 
     public Container getItemById(String id) {
@@ -149,7 +149,7 @@ public class RootUpnpProcessor extends UpnpContentProcessor<Container, Container
 
     @Override
     public List<Container> getChildren(Container item, long offset, long maxResults) {
-        return org.airsonic.player.util.Util.subList(getChildren(item), offset, maxResults);
+        return org.airsonic.player.util.PlayerUtils.subList(getChildren(item), offset, maxResults);
     }
 
     public void addChild(DIDLContent didl, Container child) {

--- a/jpsonic-main/src/main/java/org/airsonic/player/spring/DatabaseConfiguration.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/spring/DatabaseConfiguration.java
@@ -4,7 +4,7 @@ import org.airsonic.player.dao.DaoHelper;
 import org.airsonic.player.dao.GenericDaoHelper;
 import org.airsonic.player.dao.LegacyHsqlDaoHelper;
 import org.airsonic.player.service.SettingsService;
-import org.airsonic.player.util.Util;
+import org.airsonic.player.util.PlayerUtils;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -97,7 +97,7 @@ public class DatabaseConfiguration {
         springLiquibase.setChangeLog("classpath:liquibase/db-changelog.xml");
         springLiquibase.setRollbackFile(rollbackFile());
         Map<String, String> parameters = new HashMap<>();
-        parameters.put("defaultMusicFolder", Util.getDefaultMusicFolder());
+        parameters.put("defaultMusicFolder", PlayerUtils.getDefaultMusicFolder());
         parameters.put("mysqlVarcharLimit", mysqlVarcharLimit);
         parameters.put("userTableQuote", userTableQuote);
         springLiquibase.setChangeLogParameters(parameters);

--- a/jpsonic-main/src/main/java/org/airsonic/player/spring/LoggingExceptionResolver.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/spring/LoggingExceptionResolver.java
@@ -1,6 +1,6 @@
 package org.airsonic.player.spring;
 
-import org.airsonic.player.util.Util;
+import org.airsonic.player.util.PlayerUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.Ordered;
@@ -23,17 +23,17 @@ public class LoggingExceptionResolver implements HandlerExceptionResolver, Order
         // This happens often and outside of the control of the server, so
         // we catch Tomcat/Jetty "connection aborted by client" exceptions
         // and display a short error message.
-        boolean shouldCatch = Util.isInstanceOfClassName(e, "org.apache.catalina.connector.ClientAbortException");
+        boolean shouldCatch = PlayerUtils.isInstanceOfClassName(e, "org.apache.catalina.connector.ClientAbortException");
         if (shouldCatch) {
             if (LOG.isInfoEnabled()) {
-                LOG.info("{}: Client unexpectedly closed connection while loading {} ({})", request.getRemoteAddr(), Util.getAnonymizedURLForRequest(request), e.getCause().toString());
+                LOG.info("{}: Client unexpectedly closed connection while loading {} ({})", request.getRemoteAddr(), PlayerUtils.getAnonymizedURLForRequest(request), e.getCause().toString());
             }
             return null;
         }
 
         // Display a full stack trace in all other cases
         if (LOG.isErrorEnabled()) {
-            LOG.error("{}: An exception occurred while loading {}", request.getRemoteAddr(), Util.getAnonymizedURLForRequest(request), e);
+            LOG.error("{}: An exception occurred while loading {}", request.getRemoteAddr(), PlayerUtils.getAnonymizedURLForRequest(request), e);
         }
         return null;
     }

--- a/jpsonic-main/src/main/java/org/airsonic/player/taglib/UrlTag.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/taglib/UrlTag.java
@@ -55,7 +55,7 @@ import java.util.List;
  */
 public class UrlTag extends BodyTagSupport {
 
-    private String DEFAULT_ENCODING = "Utf8Hex";
+    private static final String DEFAULT_ENCODING = "Utf8Hex";
     private static final Logger LOG = LoggerFactory.getLogger(UrlTag.class);
 
     private String var;

--- a/jpsonic-main/src/main/java/org/airsonic/player/util/PlayerUtils.java
+++ b/jpsonic-main/src/main/java/org/airsonic/player/util/PlayerUtils.java
@@ -44,15 +44,15 @@ import java.util.*;
  *
  * @author Sindre Mehus
  */
-public final class Util {
+public final class PlayerUtils {
 
-    private static final Logger LOG = LoggerFactory.getLogger(Util.class);
+    private static final Logger LOG = LoggerFactory.getLogger(PlayerUtils.class);
     private static final String URL_SENSITIVE_REPLACEMENT_STRING = "<hidden>";
 
     /**
      * Disallow external instantiation.
      */
-    private Util() {
+    private PlayerUtils() {
     }
 
     public static String getDefaultMusicFolder() {

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/artistMain.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/artistMain.jsp
@@ -292,7 +292,7 @@
 </c:choose>
 
 <table id="artistInfoTable" style="padding:2em;clear:both;display:none" class="bgcolor2 dropshadow artistInfoTable">
-    <!--
+    <%--
 	    <tr>
 	        <td rowspan="5" style="vertical-align: top">
 	            <a id="artistImageZoom" rel="zoom" href="void">
@@ -301,7 +301,7 @@
 	        </td>
 	        <td style="text-align:center"><h2>${fn:escapeXml(model.dir.name)}</h2></td>
 	    </tr>
-     -->
+     --%>
     <tr>
         <td id="artistBio" style="padding-bottom: 0.5em"></td>
     </tr>

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/head.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/head.jsp
@@ -11,7 +11,7 @@
 <meta name="theme-color" content="#ffffff">
 <meta name="description" content="Airsonic: A free, web-based media streamer, providing ubiquitous access to your music.">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<!-- Included before airsonic stylesheet to allow overriding -->
+<%-- Included before airsonic stylesheet to allow overriding --%>
 <link type="text/css" rel="stylesheet" href="<c:url value='/script/mediaelement/mediaelementplayer.min.css'/>">
 <link rel="stylesheet" href="<c:url value='/${styleSheet}'/>" type="text/css">
 <title>Jpsonic</title>

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/left.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/left.jsp
@@ -123,7 +123,7 @@
 
 <c:if test="${not empty model.radios}">
     <h2 class="bgcolor1" style="padding-left: 2px"><fmt:message key="left.radio"/></h2>
-    <iframe id="radio-playlist-data" style="display:none;"></iframe>
+    <iframe src="left.jsp" id="radio-playlist-data" style="display:none;"></iframe>
     <c:forEach items="${model.radios}" var="radio" varStatus="loop">
         <p class="dense<c:if test='${loop.last}'> last</c:if>" style="padding-left: 2px">
         <a target="hidden" href="${radio.streamUrl}" class="radio-play" data-id="${radio.id}">

--- a/jpsonic-main/src/test/java/org/airsonic/player/service/search/AnalyzerFactoryLegacyTest.java
+++ b/jpsonic-main/src/test/java/org/airsonic/player/service/search/AnalyzerFactoryLegacyTest.java
@@ -61,12 +61,12 @@ public class AnalyzerFactoryLegacyTest {
 
         // no analyze field
         /*
-         * FieldNames.ID, FieldNames.FOLDER_ID, FieldNames.YEAR FieldNames.GENRE,
-         * FieldNames.GENRE_KEY, FieldNames.MEDIA_TYPE, FieldNames.FOLDER
+         * FieldNamesConstants.ID, FieldNamesConstants.FOLDER_ID, FieldNamesConstants.YEAR FieldNamesConstants.GENRE,
+         * FieldNamesConstants.GENRE_KEY, FieldNamesConstants.MEDIA_TYPE, FieldNamesConstants.FOLDER
          */
 
         // 4
-        String[] multiTokenFields = { FieldNames.ARTIST, FieldNames.ARTIST_READING, FieldNames.ALBUM, FieldNames.TITLE };
+        String[] multiTokenFields = { FieldNamesConstants.ARTIST, FieldNamesConstants.ARTIST_READING, FieldNamesConstants.ALBUM, FieldNamesConstants.TITLE };
         Arrays.stream(multiTokenFields).forEach(n -> {
             List<String> terms = toTermString(n, queryEng);
             assertEquals("multiToken : " + n, 7, terms.size());
@@ -74,7 +74,7 @@ public class AnalyzerFactoryLegacyTest {
 
         // 2
         String queryHira = "くいっくぶらうん";
-        String[] oneTokenHiraStopOnlyFields = { FieldNames.ALBUM_EX, FieldNames.TITLE_EX };
+        String[] oneTokenHiraStopOnlyFields = { FieldNamesConstants.ALBUM_EX, FieldNamesConstants.TITLE_EX };
         Arrays.stream(oneTokenHiraStopOnlyFields).forEach(n -> {
             List<String> terms = toTermString(n, queryEng);
             assertEquals("oneTokenHira(Eng) : " + n, 0, terms.size());
@@ -90,7 +90,7 @@ public class AnalyzerFactoryLegacyTest {
         });
 
         // 1
-        String[] oneTokenStopOnlyFields = { FieldNames.ARTIST_EX };
+        String[] oneTokenStopOnlyFields = { FieldNamesConstants.ARTIST_EX };
         Arrays.stream(oneTokenStopOnlyFields).forEach(n -> {
             List<String> terms = toTermString(n, queryEng);
             assertEquals("oneTokenHira(Eng) : " + n, 0, terms.size());
@@ -127,7 +127,7 @@ public class AnalyzerFactoryLegacyTest {
                  * It is not necessary to delimit
                  * this field originally.
                  */
-                case FieldNames.MEDIA_TYPE:
+                case FieldNamesConstants.MEDIA_TYPE:
                     assertEquals("tokenized : " + n, 2, terms.size());
                     assertEquals("tokenized : " + n, expected1, terms.get(0));
                     assertEquals("tokenized : " + n, expected2, terms.get(1));
@@ -137,30 +137,30 @@ public class AnalyzerFactoryLegacyTest {
                  * What should the fields of this be?
                  * Generally discarded.
                  */
-                case FieldNames.ARTIST:
-                case FieldNames.ALBUM:
-                case FieldNames.TITLE:
-                case FieldNames.COMPOSER:
+                case FieldNamesConstants.ARTIST:
+                case FieldNamesConstants.ALBUM:
+                case FieldNamesConstants.TITLE:
+                case FieldNamesConstants.COMPOSER:
                     assertEquals("tokenized : " + n, 2, terms.size());
                     assertEquals("tokenized : " + n, expected1, terms.get(0));
                     assertEquals("tokenized : " + n, expected2, terms.get(1));
                     break;
 
-                case FieldNames.TITLE_EX:
-                case FieldNames.ALBUM_EX:
-                case FieldNames.ARTIST_EX:
+                case FieldNamesConstants.TITLE_EX:
+                case FieldNamesConstants.ALBUM_EX:
+                case FieldNamesConstants.ARTIST_EX:
                     assertEquals("tokenized : " + n, 0, terms.size());
                     break;
 
-                case FieldNames.ARTIST_READING:
-                case FieldNames.COMPOSER_READING:
+                case FieldNamesConstants.ARTIST_READING:
+                case FieldNamesConstants.COMPOSER_READING:
                     assertEquals("tokenized : " + n, 1, terms.size());
                     assertEquals("tokenized : " + n, expected3, terms.get(0));
                     break;
 
-                case FieldNames.FOLDER:
-                case FieldNames.GENRE:
-                case FieldNames.GENRE_KEY:
+                case FieldNamesConstants.FOLDER:
+                case FieldNamesConstants.GENRE:
+                case FieldNamesConstants.GENRE_KEY:
                     assertEquals("tokenized : " + n, 1, terms.size());
                     assertEquals("tokenized : " + n, query, terms.get(0));
                     break;
@@ -187,15 +187,15 @@ public class AnalyzerFactoryLegacyTest {
         Arrays.stream(IndexType.values()).flatMap(i -> Arrays.stream(i.getFields())).forEach(n -> {
             List<String> terms = toTermString(n, query);
             switch (n) {
-                case FieldNames.MEDIA_TYPE:
-                case FieldNames.ARTIST:
-                case FieldNames.ALBUM:
-                case FieldNames.TITLE:
+                case FieldNamesConstants.MEDIA_TYPE:
+                case FieldNamesConstants.ARTIST:
+                case FieldNamesConstants.ALBUM:
+                case FieldNamesConstants.TITLE:
                     assertEquals("removed : " + n, 0, terms.size());
                     break;
-                case FieldNames.FOLDER:
-                case FieldNames.GENRE:
-                case FieldNames.GENRE_KEY:
+                case FieldNamesConstants.FOLDER:
+                case FieldNamesConstants.GENRE:
+                case FieldNamesConstants.GENRE_KEY:
                     assertEquals("remain : " + n, 1, terms.size());
                     break;
 
@@ -252,9 +252,9 @@ public class AnalyzerFactoryLegacyTest {
             List<String> noStopTerms = toTermString(n, queryNoStop);
             List<String> jpStopTerms = toTermString(n, queryJpStop);
             switch (n) {
-                case FieldNames.FOLDER:
-                case FieldNames.MEDIA_TYPE:
-                case FieldNames.GENRE_KEY:
+                case FieldNamesConstants.FOLDER:
+                case FieldNamesConstants.MEDIA_TYPE:
+                case FieldNamesConstants.GENRE_KEY:
                     assertEquals("through : " + n, 1, articleTerms.size());
                     assertEquals("through : " + n, queryArticle, articleTerms.get(0));
                     assertEquals("through : " + n, 1, indexArticleTerms.size());
@@ -264,7 +264,7 @@ public class AnalyzerFactoryLegacyTest {
                     assertEquals("through : " + n, 1, jpStopTerms.size());
                     assertEquals("through : " + n, queryJpStop, jpStopTerms.get(0));
                     break;
-                case FieldNames.GENRE:
+                case FieldNamesConstants.GENRE:
                     assertEquals("through : " + n, 1, articleTerms.size());
                     assertEquals("through : " + n, queryArticle, articleTerms.get(0));
                     assertEquals("through : " + n, 1, indexArticleTerms.size());
@@ -276,20 +276,20 @@ public class AnalyzerFactoryLegacyTest {
                     assertEquals("??????? : " + n, "の に は を た が で て と し れ さ ある いる も する から な こと として い や れる など なっ ない この ため その あっ よう また もの という あり まで られ なる へ か だ これ によって により おり より による ず なり られる において ば なかっ なく しかし について せ だっ その後 できる それ う ので なお のみ でき き つ における および いう さらに でも ら たり その他 に関する たち ます ん なら に対して 特に せる 及び これら", jpStopTerms.get(0));
                     assertEquals("??????? : " + n, " とき では にて ほか ながら うち そして とともに ただし かつて それぞれ または お ほど ものの に対する ほとんど と共に といった です とも ところ ここ", jpStopTerms.get(1));
                     break;
-                case FieldNames.ALBUM:
-                case FieldNames.TITLE:
+                case FieldNamesConstants.ALBUM:
+                case FieldNamesConstants.TITLE:
                     assertEquals("apply : " + n, 0, articleTerms.size());
                     assertEquals("apply : " + n, 0, indexArticleTerms.size());
                     assertEquals("through : " + n, 30, noStopTerms.size());
                     assertEquals("apply : " + n, 0, jpStopTerms.size());
                     break;
-                case FieldNames.ARTIST:
+                case FieldNamesConstants.ARTIST:
                     assertEquals("apply : " + n, 0, articleTerms.size());
                     assertEquals("apply : " + n, 0, indexArticleTerms.size());
                     assertEquals("through : " + n, 29, noStopTerms.size()); // with is removed
                     assertEquals("apply : " + n, 53, jpStopTerms.size());//false positives?
                     break;
-                case FieldNames.ARTIST_READING:
+                case FieldNamesConstants.ARTIST_READING:
                     assertEquals("apply : " + n, 0, articleTerms.size());
                     assertEquals("apply : " + n, 0, indexArticleTerms.size());
                     assertEquals("through : " + n, 29, noStopTerms.size()); // with is removed
@@ -308,9 +308,9 @@ public class AnalyzerFactoryLegacyTest {
             List<String> noStopTerms = toTermString(n, queryNoStop.replaceAll(" ", ""));
             List<String> jpStopTerms = toTermString(n, queryJpStop.replaceAll(" ", ""));
             switch (n) {
-                case FieldNames.ARTIST_EX:
-                case FieldNames.ALBUM_EX:
-                case FieldNames.TITLE_EX:
+                case FieldNamesConstants.ARTIST_EX:
+                case FieldNamesConstants.ALBUM_EX:
+                case FieldNamesConstants.TITLE_EX:
                     assertEquals("through : " + n, 1, articleTerms.size());
                     assertEquals("through : " + n, 1, indexArticleTerms.size());
                     assertEquals("apply : " + n, 0, noStopTerms.size());
@@ -327,12 +327,12 @@ public class AnalyzerFactoryLegacyTest {
      */
     @Test
     public void testArtistStopward() {
-        assertEquals(0, toTermString(FieldNames.ARTIST, "CV").size());
-        assertEquals(0, toTermString(FieldNames.ARTIST, "feat").size());
-        assertEquals(0, toTermString(FieldNames.ARTIST, "with").size());
-        assertEquals(0, toTermString(FieldNames.ARTIST_READING, "CV").size());
-        assertEquals(0, toTermString(FieldNames.ARTIST_READING, "feat").size());
-        assertEquals(0, toTermString(FieldNames.ARTIST_READING, "with").size());
+        assertEquals(0, toTermString(FieldNamesConstants.ARTIST, "CV").size());
+        assertEquals(0, toTermString(FieldNamesConstants.ARTIST, "feat").size());
+        assertEquals(0, toTermString(FieldNamesConstants.ARTIST, "with").size());
+        assertEquals(0, toTermString(FieldNamesConstants.ARTIST_READING, "CV").size());
+        assertEquals(0, toTermString(FieldNamesConstants.ARTIST_READING, "feat").size());
+        assertEquals(0, toTermString(FieldNamesConstants.ARTIST_READING, "with").size());
     }
 
     /**
@@ -409,28 +409,28 @@ public class AnalyzerFactoryLegacyTest {
         Arrays.stream(IndexType.values()).flatMap(i -> Arrays.stream(i.getFields())).forEach(n -> {
             List<String> terms = toTermString(n, query);
             switch (n) {
-                case FieldNames.TITLE_EX:
-                case FieldNames.ALBUM_EX:
-                case FieldNames.ARTIST_EX:
+                case FieldNamesConstants.TITLE_EX:
+                case FieldNamesConstants.ALBUM_EX:
+                case FieldNamesConstants.ARTIST_EX:
                     assertEquals("no case : " + n, 0, terms.size());
                     break;
-                case FieldNames.FOLDER:
-                case FieldNames.GENRE_KEY:
-                case FieldNames.MEDIA_TYPE:
+                case FieldNamesConstants.FOLDER:
+                case FieldNamesConstants.GENRE_KEY:
+                case FieldNamesConstants.MEDIA_TYPE:
                     assertEquals("through : " + n, 1, terms.size());
                     assertEquals("through : " + n, query, terms.get(0));
                     break;
-                case FieldNames.ARTIST_READING:
+                case FieldNamesConstants.ARTIST_READING:
                     assertEquals("apply : " + n, 1, terms.size());
                     assertEquals("apply : " + n, expected2, terms.get(0));
                     break;
-                case FieldNames.GENRE:
+                case FieldNamesConstants.GENRE:
                     assertEquals("apply : " + n, 1, terms.size());
                     assertEquals("apply : " + n, expected3, terms.get(0));
                     break;
-                case FieldNames.ARTIST:
-                case FieldNames.ALBUM:
-                case FieldNames.TITLE:
+                case FieldNamesConstants.ARTIST:
+                case FieldNamesConstants.ALBUM:
+                case FieldNamesConstants.TITLE:
                     assertEquals("apply : " + n, 2, terms.size());
                     assertEquals("apply : " + n, expected1a, terms.get(0));
                     assertEquals("apply : " + n, expected1b, terms.get(1));
@@ -454,13 +454,13 @@ public class AnalyzerFactoryLegacyTest {
             List<String> terms = toTermString(n, query);
             switch (n) {
                 // Do nothing
-                case FieldNames.FOLDER:
-                case FieldNames.GENRE_KEY:
-                case FieldNames.MEDIA_TYPE:
+                case FieldNamesConstants.FOLDER:
+                case FieldNamesConstants.GENRE_KEY:
+                case FieldNamesConstants.MEDIA_TYPE:
                     assertEquals("through : " + n, 1, terms.size());
                     assertEquals("through : " + n, query, terms.get(0));
                     break;
-                case FieldNames.GENRE:
+                case FieldNamesConstants.GENRE:
                     // Some character strings are replaced within the range that does not affect display
                     assertEquals("through : " + n, 1, terms.size());
                     assertEquals("apply : " + n, expected1, terms.get(0));
@@ -487,32 +487,32 @@ public class AnalyzerFactoryLegacyTest {
         Arrays.stream(IndexType.values()).flatMap(i -> Arrays.stream(i.getFields())).forEach(n -> {
             List<String> terms = toTermString(n, query);
             switch (n) {
-                case FieldNames.ARTIST_EX:
+                case FieldNamesConstants.ARTIST_EX:
                     assertEquals("no case : " + n, 0, terms.size());
                     break;
-                case FieldNames.FOLDER:
-                case FieldNames.MEDIA_TYPE:
-                case FieldNames.GENRE_KEY:
+                case FieldNamesConstants.FOLDER:
+                case FieldNamesConstants.MEDIA_TYPE:
+                case FieldNamesConstants.GENRE_KEY:
                     assertEquals("through : " + n, 1, terms.size());
                     assertEquals("through : " + n, query, terms.get(0));
                     break;
-                case FieldNames.GENRE:
+                case FieldNamesConstants.GENRE:
                     assertEquals("apply : " + n, 1, terms.size());
                     assertEquals("apply : " + n, apply1, terms.get(0));
                     break;
-                case FieldNames.TITLE_EX:
-                case FieldNames.ALBUM_EX:
+                case FieldNamesConstants.TITLE_EX:
+                case FieldNamesConstants.ALBUM_EX:
                     terms = toTermString(n, query2);
                     assertEquals("no case : " + n, 1, terms.size());
                     assertEquals("no case " + n, query2, terms.get(0));
                     break;
-                case FieldNames.ARTIST_READING:
+                case FieldNamesConstants.ARTIST_READING:
                     assertEquals("apply : " + n, 1, terms.size());
                     assertEquals("apply : " + n, apply2, terms.get(0));
                     break;
-                case FieldNames.ARTIST:
-                case FieldNames.ALBUM:
-                case FieldNames.TITLE:
+                case FieldNamesConstants.ARTIST:
+                case FieldNamesConstants.ALBUM:
+                case FieldNamesConstants.TITLE:
                     assertEquals("apply : " + n, 2, terms.size());
                     assertEquals("apply : " + n, apply1a, terms.get(0));
                     assertEquals("apply : " + n, apply1b, terms.get(1));
@@ -538,24 +538,24 @@ public class AnalyzerFactoryLegacyTest {
         Arrays.stream(IndexType.values()).flatMap(i -> Arrays.stream(i.getFields())).forEach(n -> {
             List<String> terms = toTermString(n, query);
             switch (n) {
-                case FieldNames.TITLE_EX:
-                case FieldNames.ALBUM_EX:
-                case FieldNames.ARTIST_EX:
+                case FieldNamesConstants.TITLE_EX:
+                case FieldNamesConstants.ALBUM_EX:
+                case FieldNamesConstants.ARTIST_EX:
                     assertEquals("no case : " + n, 0, terms.size());
                     break;
-                case FieldNames.FOLDER:
-                case FieldNames.GENRE:
-                case FieldNames.MEDIA_TYPE:
+                case FieldNamesConstants.FOLDER:
+                case FieldNamesConstants.GENRE:
+                case FieldNamesConstants.MEDIA_TYPE:
                     assertEquals("through : " + n, 1, terms.size());
                     assertEquals("through : " + n, query, terms.get(0));
                     break;
-                case FieldNames.ARTIST_READING:
+                case FieldNamesConstants.ARTIST_READING:
                     assertEquals("apply : " + n, 1, terms.size());
                     assertEquals("apply : " + n, expected1, terms.get(0));
                     break;
-                case FieldNames.ARTIST:
-                case FieldNames.ALBUM:
-                case FieldNames.TITLE:
+                case FieldNamesConstants.ARTIST:
+                case FieldNamesConstants.ALBUM:
+                case FieldNamesConstants.TITLE:
                     assertEquals("apply : " + n, 2, terms.size());
                     assertEquals("apply : " + n, expected1a, terms.get(0));
                     assertEquals("apply : " + n, expected1b, terms.get(1));
@@ -581,13 +581,13 @@ public class AnalyzerFactoryLegacyTest {
         Arrays.stream(IndexType.values()).flatMap(i -> Arrays.stream(i.getFields())).forEach(n -> {
             List<String> terms = toTermString(n, escapeRequires);
             // TODO These fields handle escape strings as they are.
-            if (FieldNames.FOLDER.equals(n) || FieldNames.GENRE_KEY.equals(n)) {
+            if (FieldNamesConstants.FOLDER.equals(n) || FieldNamesConstants.GENRE_KEY.equals(n)) {
                 assertEquals("through : " + n, 1, terms.size());
                 assertEquals("through : " + n, escapeRequires, terms.get(0));
                 terms = toTermString(n, fileUsable);
                 assertEquals("through : " + n, 1, terms.size());
                 assertEquals("through : " + n, fileUsable, terms.get(0));
-            } else if (FieldNames.GENRE.equals(n)) {
+            } else if (FieldNamesConstants.GENRE.equals(n)) {
                 // XXX @see AnalyzerFactory#addTokenFilterForTokenToDomainValue
                 assertEquals("through : " + n, 1, terms.size());
                 assertEquals("through : " + n, "+-&&||! { }[ ]^\"~*?:\\/", terms.get(0));
@@ -831,7 +831,7 @@ public class AnalyzerFactoryLegacyTest {
         String passable2 = "ABC123アイウ";
         String expected2 = "abc123あいう";
 
-        String n = FieldNames.ARTIST_READING;
+        String n = FieldNamesConstants.ARTIST_READING;
 
         List<String> terms = toTermString(n, notChange1);
         assertEquals("all Alpha : " + n, 2, terms.size());
@@ -863,7 +863,7 @@ public class AnalyzerFactoryLegacyTest {
         String notPass3 = "ABC123あいう";
         String passable = "あいう";
 
-        String[] otherThanHiraganaFields = { FieldNames.ALBUM_EX, FieldNames.TITLE_EX };
+        String[] otherThanHiraganaFields = { FieldNamesConstants.ALBUM_EX, FieldNamesConstants.TITLE_EX };
         Arrays.stream(otherThanHiraganaFields).forEach(n -> {
             List<String> terms = toTermString(n, notPass1);
             assertEquals("all Alpha : " + n, 0, terms.size());
@@ -896,30 +896,30 @@ public class AnalyzerFactoryLegacyTest {
         Arrays.stream(IndexType.values()).flatMap(i -> Arrays.stream(i.getFields())).forEach(n -> {
             List<String> terms = toTermString(n, query);
             switch (n) {
-                case FieldNames.FOLDER:
-                case FieldNames.GENRE:
-                case FieldNames.MEDIA_TYPE:
+                case FieldNamesConstants.FOLDER:
+                case FieldNamesConstants.GENRE:
+                case FieldNamesConstants.MEDIA_TYPE:
                     assertEquals("through : " + n, 1, terms.size());
                     assertEquals("through : " + n, query, terms.get(0));
                     break;
-                case FieldNames.ARTIST_READING:
+                case FieldNamesConstants.ARTIST_READING:
                     assertEquals("token through filtered : " + n, 1, terms.size());
                     assertEquals("token through filtered : " + n, expected2, terms.get(0));
                     break;
-                case FieldNames.ARTIST:
-                case FieldNames.ALBUM:
-                case FieldNames.TITLE:
+                case FieldNamesConstants.ARTIST:
+                case FieldNamesConstants.ALBUM:
+                case FieldNamesConstants.TITLE:
                     assertEquals("tokend : " + n, 2, terms.size());
                     assertEquals("tokend : " + n, expected2a, terms.get(0));
                     assertEquals("tokend : " + n, expected2b, terms.get(1));
                     break;
-                case FieldNames.TITLE_EX:
-                case FieldNames.ALBUM_EX:
+                case FieldNamesConstants.TITLE_EX:
+                case FieldNamesConstants.ALBUM_EX:
                     terms = toTermString(n, queryJp);
                     assertEquals("token through filtered : " + n, 1, terms.size());
                     assertEquals("token through filtered : " + n, expectedJp, terms.get(0));
                     break;
-                case FieldNames.ARTIST_EX:
+                case FieldNamesConstants.ARTIST_EX:
                     terms = toTermString(n, queryStop);
                     assertEquals("token through filtered : " + n, 1, terms.size());
                     assertEquals("token through filtered : " + n, expectedStop, terms.get(0));

--- a/jpsonic-main/src/test/java/org/airsonic/player/service/search/AnalyzerFactoryTest.java
+++ b/jpsonic-main/src/test/java/org/airsonic/player/service/search/AnalyzerFactoryTest.java
@@ -66,12 +66,12 @@ public class AnalyzerFactoryTest {
 
         // no analyze field
         /*
-         * FieldNames.ID, FieldNames.FOLDER_ID, FieldNames.YEAR FieldNames.GENRE,
-         * FieldNames.GENRE_KEY, FieldNames.MEDIA_TYPE, FieldNames.FOLDER
+         * FieldNamesConstants.ID, FieldNamesConstants.FOLDER_ID, FieldNamesConstants.YEAR FieldNamesConstants.GENRE,
+         * FieldNamesConstants.GENRE_KEY, FieldNamesConstants.MEDIA_TYPE, FieldNamesConstants.FOLDER
          */
 
         // 4
-        String[] multiTokenFields = { FieldNames.ARTIST, FieldNames.ARTIST_READING, FieldNames.ALBUM, FieldNames.TITLE };
+        String[] multiTokenFields = { FieldNamesConstants.ARTIST, FieldNamesConstants.ARTIST_READING, FieldNamesConstants.ALBUM, FieldNamesConstants.TITLE };
         Arrays.stream(multiTokenFields).forEach(n -> {
             List<String> terms = toTermString(n, queryEng);
             assertEquals("multiToken : " + n, 7, terms.size());
@@ -79,7 +79,7 @@ public class AnalyzerFactoryTest {
 
         // 2
         String queryHira = "くいっくぶらうん";
-        String[] oneTokenHiraStopOnlyFields = { FieldNames.ALBUM_EX, FieldNames.TITLE_EX };
+        String[] oneTokenHiraStopOnlyFields = { FieldNamesConstants.ALBUM_EX, FieldNamesConstants.TITLE_EX };
         Arrays.stream(oneTokenHiraStopOnlyFields).forEach(n -> {
             List<String> terms = toTermString(n, queryEng);
             assertEquals("oneTokenHira(Eng) : " + n, 0, terms.size());
@@ -95,7 +95,7 @@ public class AnalyzerFactoryTest {
         });
 
         // 1
-        String[] oneTokenStopOnlyFields = { FieldNames.ARTIST_EX };
+        String[] oneTokenStopOnlyFields = { FieldNamesConstants.ARTIST_EX };
         Arrays.stream(oneTokenStopOnlyFields).forEach(n -> {
             List<String> terms = toTermString(n, queryEng);
             assertEquals("oneTokenHira(Eng) : " + n, 0, terms.size());
@@ -132,7 +132,7 @@ public class AnalyzerFactoryTest {
                  * It is not necessary to delimit
                  * this field originally.
                  */
-                case FieldNames.MEDIA_TYPE:
+                case FieldNamesConstants.MEDIA_TYPE:
                     assertEquals("tokenized : " + n, 2, terms.size());
                     assertEquals("tokenized : " + n, expected1, terms.get(0));
                     assertEquals("tokenized : " + n, expected2, terms.get(1));
@@ -142,30 +142,30 @@ public class AnalyzerFactoryTest {
                  * What should the fields of this be?
                  * Generally discarded.
                  */
-                case FieldNames.ARTIST:
-                case FieldNames.ALBUM:
-                case FieldNames.TITLE:
-                case FieldNames.COMPOSER:
+                case FieldNamesConstants.ARTIST:
+                case FieldNamesConstants.ALBUM:
+                case FieldNamesConstants.TITLE:
+                case FieldNamesConstants.COMPOSER:
                     assertEquals("tokenized : " + n, 2, terms.size());
                     assertEquals("tokenized : " + n, expected1, terms.get(0));
                     assertEquals("tokenized : " + n, expected2, terms.get(1));
                     break;
 
-                case FieldNames.TITLE_EX:
-                case FieldNames.ALBUM_EX:
-                case FieldNames.ARTIST_EX:
+                case FieldNamesConstants.TITLE_EX:
+                case FieldNamesConstants.ALBUM_EX:
+                case FieldNamesConstants.ARTIST_EX:
                     assertEquals("tokenized : " + n, 0, terms.size());
                     break;
 
-                case FieldNames.ARTIST_READING:
-                case FieldNames.COMPOSER_READING:
+                case FieldNamesConstants.ARTIST_READING:
+                case FieldNamesConstants.COMPOSER_READING:
                     assertEquals("tokenized : " + n, 1, terms.size());
                     assertEquals("tokenized : " + n, expected3, terms.get(0));
                     break;
 
-                case FieldNames.FOLDER:
-                case FieldNames.GENRE:
-                case FieldNames.GENRE_KEY:
+                case FieldNamesConstants.FOLDER:
+                case FieldNamesConstants.GENRE:
+                case FieldNamesConstants.GENRE_KEY:
                     assertEquals("tokenized : " + n, 1, terms.size());
                     assertEquals("tokenized : " + n, query, terms.get(0));
                     break;
@@ -192,15 +192,15 @@ public class AnalyzerFactoryTest {
         Arrays.stream(IndexType.values()).flatMap(i -> Arrays.stream(i.getFields())).forEach(n -> {
             List<String> terms = toTermString(n, query);
             switch (n) {
-                case FieldNames.MEDIA_TYPE:
-                case FieldNames.ARTIST:
-                case FieldNames.ALBUM:
-                case FieldNames.TITLE:
+                case FieldNamesConstants.MEDIA_TYPE:
+                case FieldNamesConstants.ARTIST:
+                case FieldNamesConstants.ALBUM:
+                case FieldNamesConstants.TITLE:
                     assertEquals("removed : " + n, 0, terms.size());
                     break;
-                case FieldNames.FOLDER:
-                case FieldNames.GENRE:
-                case FieldNames.GENRE_KEY:
+                case FieldNamesConstants.FOLDER:
+                case FieldNamesConstants.GENRE:
+                case FieldNamesConstants.GENRE_KEY:
                     assertEquals("remain : " + n, 1, terms.size());
                     break;
 
@@ -257,9 +257,9 @@ public class AnalyzerFactoryTest {
             List<String> noStopTerms = toTermString(n, queryNoStop);
             List<String> jpStopTerms = toTermString(n, queryJpStop);
             switch (n) {
-                case FieldNames.FOLDER:
-                case FieldNames.MEDIA_TYPE:
-                case FieldNames.GENRE_KEY:
+                case FieldNamesConstants.FOLDER:
+                case FieldNamesConstants.MEDIA_TYPE:
+                case FieldNamesConstants.GENRE_KEY:
                     assertEquals("through : " + n, 1, articleTerms.size());
                     assertEquals("through : " + n, queryArticle, articleTerms.get(0));
                     assertEquals("through : " + n, 1, indexArticleTerms.size());
@@ -269,7 +269,7 @@ public class AnalyzerFactoryTest {
                     assertEquals("through : " + n, 1, jpStopTerms.size());
                     assertEquals("through : " + n, queryJpStop, jpStopTerms.get(0));
                     break;
-                case FieldNames.GENRE:
+                case FieldNamesConstants.GENRE:
                     assertEquals("through : " + n, 1, articleTerms.size());
                     assertEquals("through : " + n, queryArticle, articleTerms.get(0));
                     assertEquals("through : " + n, 1, indexArticleTerms.size());
@@ -281,20 +281,20 @@ public class AnalyzerFactoryTest {
                     assertEquals("??????? : " + n, "の に は を た が で て と し れ さ ある いる も する から な こと として い や れる など なっ ない この ため その あっ よう また もの という あり まで られ なる へ か だ これ によって により おり より による ず なり られる において ば なかっ なく しかし について せ だっ その後 できる それ う ので なお のみ でき き つ における および いう さらに でも ら たり その他 に関する たち ます ん なら に対して 特に せる 及び これら", jpStopTerms.get(0));
                     assertEquals("??????? : " + n, " とき では にて ほか ながら うち そして とともに ただし かつて それぞれ または お ほど ものの に対する ほとんど と共に といった です とも ところ ここ", jpStopTerms.get(1));
                     break;
-                case FieldNames.ALBUM:
-                case FieldNames.TITLE:
+                case FieldNamesConstants.ALBUM:
+                case FieldNamesConstants.TITLE:
                     assertEquals("apply : " + n, 0, articleTerms.size());
                     assertEquals("apply : " + n, 0, indexArticleTerms.size());
                     assertEquals("through : " + n, 30, noStopTerms.size());
                     assertEquals("apply : " + n, 110, jpStopTerms.size()); //XXX Legacy(0) -> Phrase(110)
                     break;
-                case FieldNames.ARTIST:
+                case FieldNamesConstants.ARTIST:
                     assertEquals("apply : " + n, 0, articleTerms.size());
                     assertEquals("apply : " + n, 0, indexArticleTerms.size());
                     assertEquals("through : " + n, 29, noStopTerms.size()); // with is removed
                     assertEquals("apply : " + n, 110, jpStopTerms.size()); //XXX Legacy(53) -> Phrase(110)
                     break;
-                case FieldNames.ARTIST_READING:
+                case FieldNamesConstants.ARTIST_READING:
                     assertEquals("article : " + n, 0, articleTerms.size());
                     assertEquals("indexArticle : " + n, 0, indexArticleTerms.size());
                     assertEquals("noStop : " + n, 29, noStopTerms.size()); // with is removed
@@ -309,9 +309,9 @@ public class AnalyzerFactoryTest {
         Arrays.stream(IndexType.values()).flatMap(i -> Arrays.stream(i.getFields())).forEach(n -> {
             // to be affected by other filters
             switch (n) {
-                case FieldNames.ARTIST_EX:
-                case FieldNames.ALBUM_EX:
-                case FieldNames.TITLE_EX:
+                case FieldNamesConstants.ARTIST_EX:
+                case FieldNamesConstants.ALBUM_EX:
+                case FieldNamesConstants.TITLE_EX:
                     //  #482 No longer used
                     break;
                 default:
@@ -325,12 +325,12 @@ public class AnalyzerFactoryTest {
      */
     @Test
     public void testArtistStopward() {
-        assertEquals(0, toTermString(FieldNames.ARTIST, "CV").size());
-        assertEquals(0, toTermString(FieldNames.ARTIST, "feat").size());
-        assertEquals(0, toTermString(FieldNames.ARTIST, "with").size());
-        assertEquals(0, toTermString(FieldNames.ARTIST_READING, "CV").size());
-        assertEquals(0, toTermString(FieldNames.ARTIST_READING, "feat").size());
-        assertEquals(0, toTermString(FieldNames.ARTIST_READING, "with").size());
+        assertEquals(0, toTermString(FieldNamesConstants.ARTIST, "CV").size());
+        assertEquals(0, toTermString(FieldNamesConstants.ARTIST, "feat").size());
+        assertEquals(0, toTermString(FieldNamesConstants.ARTIST, "with").size());
+        assertEquals(0, toTermString(FieldNamesConstants.ARTIST_READING, "CV").size());
+        assertEquals(0, toTermString(FieldNamesConstants.ARTIST_READING, "feat").size());
+        assertEquals(0, toTermString(FieldNamesConstants.ARTIST_READING, "with").size());
     }
 
     /**
@@ -406,31 +406,31 @@ public class AnalyzerFactoryTest {
         Arrays.stream(IndexType.values()).flatMap(i -> Arrays.stream(i.getFields())).forEach(n -> {
             List<String> terms = toTermString(n, query);
             switch (n) {
-                case FieldNames.TITLE_EX:
-                case FieldNames.ALBUM_EX:
-                case FieldNames.ARTIST_EX:
+                case FieldNamesConstants.TITLE_EX:
+                case FieldNamesConstants.ALBUM_EX:
+                case FieldNamesConstants.ARTIST_EX:
                     assertEquals("no case : " + n, 0, terms.size());
                     break;
-                case FieldNames.FOLDER:
-                case FieldNames.GENRE_KEY:
-                case FieldNames.MEDIA_TYPE:
+                case FieldNamesConstants.FOLDER:
+                case FieldNamesConstants.GENRE_KEY:
+                case FieldNamesConstants.MEDIA_TYPE:
                     assertEquals("through : " + n, 1, terms.size());
                     assertEquals("through : " + n, query, terms.get(0));
                     break;
-                case FieldNames.ARTIST_READING:
+                case FieldNamesConstants.ARTIST_READING:
                     assertEquals("apply : " + n, 4, terms.size());
                     assertEquals("apply : " + n, "caesar", terms.get(0));
                     assertEquals("apply : " + n, "しい", terms.get(1));
                     assertEquals("apply : " + n, "ーざ", terms.get(2));
                     assertEquals("apply : " + n, "ざあ", terms.get(3));
                     break;
-                case FieldNames.GENRE:
+                case FieldNamesConstants.GENRE:
                     assertEquals("apply : " + n, 1, terms.size());
                     assertEquals("apply : " + n, expected3, terms.get(0));
                     break;
-                case FieldNames.ARTIST:
-                case FieldNames.ALBUM:
-                case FieldNames.TITLE:
+                case FieldNamesConstants.ARTIST:
+                case FieldNamesConstants.ALBUM:
+                case FieldNamesConstants.TITLE:
                     assertEquals("apply : " + n, 2, terms.size());
                     assertEquals("apply : " + n, expected1a, terms.get(0));
                     assertEquals("apply : " + n, expected1b, terms.get(1));
@@ -454,13 +454,13 @@ public class AnalyzerFactoryTest {
             List<String> terms = toTermString(n, query);
             switch (n) {
                 // Do nothing
-                case FieldNames.FOLDER:
-                case FieldNames.GENRE_KEY:
-                case FieldNames.MEDIA_TYPE:
+                case FieldNamesConstants.FOLDER:
+                case FieldNamesConstants.GENRE_KEY:
+                case FieldNamesConstants.MEDIA_TYPE:
                     assertEquals("through : " + n, 1, terms.size());
                     assertEquals("through : " + n, query, terms.get(0));
                     break;
-                case FieldNames.GENRE:
+                case FieldNamesConstants.GENRE:
                     // Some character strings are replaced within the range that does not affect display
                     assertEquals("through : " + n, 1, terms.size());
                     assertEquals("apply : " + n, expected1, terms.get(0));
@@ -486,35 +486,35 @@ public class AnalyzerFactoryTest {
         Arrays.stream(IndexType.values()).flatMap(i -> Arrays.stream(i.getFields())).forEach(n -> {
             List<String> terms = toTermString(n, query);
             switch (n) {
-                case FieldNames.ARTIST_EX:
+                case FieldNamesConstants.ARTIST_EX:
                     assertEquals("no case : " + n, 0, terms.size());
                     break;
-                case FieldNames.FOLDER:
-                case FieldNames.MEDIA_TYPE:
-                case FieldNames.GENRE_KEY:
+                case FieldNamesConstants.FOLDER:
+                case FieldNamesConstants.MEDIA_TYPE:
+                case FieldNamesConstants.GENRE_KEY:
                     assertEquals("through : " + n, 1, terms.size());
                     assertEquals("through : " + n, query, terms.get(0));
                     break;
-                case FieldNames.GENRE:
+                case FieldNamesConstants.GENRE:
                     assertEquals("apply : " + n, 1, terms.size());
                     assertEquals("apply : " + n, apply1, terms.get(0));
                     break;
-                case FieldNames.TITLE_EX:
-                case FieldNames.ALBUM_EX:
+                case FieldNamesConstants.TITLE_EX:
+                case FieldNamesConstants.ALBUM_EX:
                     terms = toTermString(n, query2);
                     assertEquals("no case : " + n, 2, terms.size());
                     assertEquals("bigram : " + n, "ぁぃ", terms.get(0));
                     assertEquals("bigram : " + n, "ぃぅ", terms.get(1));
                     break;
-                case FieldNames.ARTIST_READING:
+                case FieldNamesConstants.ARTIST_READING:
                     assertEquals("apply : " + n, 3, terms.size());
                     assertEquals("apply : " + n, apply1a, terms.get(0));
                     assertEquals("apply : " + n, "あい", terms.get(1));
                     assertEquals("apply : " + n, "いう", terms.get(2));
                     break;
-                case FieldNames.ARTIST:
-                case FieldNames.ALBUM:
-                case FieldNames.TITLE:
+                case FieldNamesConstants.ARTIST:
+                case FieldNamesConstants.ALBUM:
+                case FieldNamesConstants.TITLE:
                     assertEquals("apply : " + n, 2, terms.size());
                     assertEquals("apply : " + n, apply1a, terms.get(0));
                     assertEquals("apply : " + n, apply1b, terms.get(1));
@@ -539,25 +539,25 @@ public class AnalyzerFactoryTest {
         Arrays.stream(IndexType.values()).flatMap(i -> Arrays.stream(i.getFields())).forEach(n -> {
             List<String> terms = toTermString(n, query);
             switch (n) {
-                case FieldNames.TITLE_EX:
-                case FieldNames.ALBUM_EX:
-                case FieldNames.ARTIST_EX:
+                case FieldNamesConstants.TITLE_EX:
+                case FieldNamesConstants.ALBUM_EX:
+                case FieldNamesConstants.ARTIST_EX:
                     assertEquals("no case : " + n, 0, terms.size());
                     break;
-                case FieldNames.FOLDER:
-                case FieldNames.GENRE:
-                case FieldNames.MEDIA_TYPE:
+                case FieldNamesConstants.FOLDER:
+                case FieldNamesConstants.GENRE:
+                case FieldNamesConstants.MEDIA_TYPE:
                     assertEquals("through : " + n, 1, terms.size());
                     assertEquals("through : " + n, query, terms.get(0));
                     break;
-                case FieldNames.ARTIST_READING:
+                case FieldNamesConstants.ARTIST_READING:
                     assertEquals("apply : " + n, 2, terms.size());
                     assertEquals("apply : " + n, "abcdefg", terms.get(0));
                     assertEquals("apply : " + n, "ふ", terms.get(1));
                     break;
-                case FieldNames.ARTIST:
-                case FieldNames.ALBUM:
-                case FieldNames.TITLE:
+                case FieldNamesConstants.ARTIST:
+                case FieldNamesConstants.ALBUM:
+                case FieldNamesConstants.TITLE:
                     assertEquals("apply : " + n, 2, terms.size());
                     assertEquals("apply : " + n, expected1a, terms.get(0));
                     assertEquals("apply : " + n, expected1b, terms.get(1));
@@ -583,13 +583,13 @@ public class AnalyzerFactoryTest {
         Arrays.stream(IndexType.values()).flatMap(i -> Arrays.stream(i.getFields())).forEach(n -> {
             List<String> terms = toTermString(n, escapeRequires);
             // TODO These fields handle escape strings as they are.
-            if (FieldNames.FOLDER.equals(n) || FieldNames.GENRE_KEY.equals(n)) {
+            if (FieldNamesConstants.FOLDER.equals(n) || FieldNamesConstants.GENRE_KEY.equals(n)) {
                 assertEquals("through : " + n, 1, terms.size());
                 assertEquals("through : " + n, escapeRequires, terms.get(0));
                 terms = toTermString(n, fileUsable);
                 assertEquals("through : " + n, 1, terms.size());
                 assertEquals("through : " + n, fileUsable, terms.get(0));
-            } else if (FieldNames.GENRE.equals(n)) {
+            } else if (FieldNamesConstants.GENRE.equals(n)) {
                 // XXX @see AnalyzerFactory#addTokenFilterForTokenToDomainValue
                 assertEquals("through : " + n, 1, terms.size());
                 assertEquals("through : " + n, "+-&&||! { }[ ]^\"~*?:\\/", terms.get(0));
@@ -832,7 +832,7 @@ public class AnalyzerFactoryTest {
         String expected1 = "abc123あいう";
         String passable2 = "ABC123アイウ";
 
-        String n = FieldNames.ARTIST_READING;
+        String n = FieldNamesConstants.ARTIST_READING;
 
         List<String> terms = toTermString(n, notChange1);
         assertEquals("all Alpha : " + n, 2, terms.size());
@@ -889,26 +889,26 @@ public class AnalyzerFactoryTest {
         Arrays.stream(IndexType.values()).flatMap(i -> Arrays.stream(i.getFields())).forEach(n -> {
             List<String> terms = toTermString(n, query);
             switch (n) {
-                case FieldNames.FOLDER:
-                case FieldNames.GENRE:
-                case FieldNames.MEDIA_TYPE:
+                case FieldNamesConstants.FOLDER:
+                case FieldNamesConstants.GENRE:
+                case FieldNamesConstants.MEDIA_TYPE:
                     assertEquals("through : " + n, 1, terms.size());
                     assertEquals("through : " + n, query, terms.get(0));
                     break;
-                case FieldNames.ARTIST_READING:
+                case FieldNamesConstants.ARTIST_READING:
                     assertEquals("token through filtered : " + n, 1, terms.size());
                     assertEquals("token through filtered : " + n, expected2, terms.get(0));
                     break;
-                case FieldNames.ARTIST:
-                case FieldNames.ALBUM:
-                case FieldNames.TITLE:
+                case FieldNamesConstants.ARTIST:
+                case FieldNamesConstants.ALBUM:
+                case FieldNamesConstants.TITLE:
                     assertEquals("tokend : " + n, 2, terms.size());
                     assertEquals("tokend : " + n, expected2a, terms.get(0));
                     assertEquals("tokend : " + n, expected2b, terms.get(1));
                     break;
-                case FieldNames.TITLE_EX:
-                case FieldNames.ALBUM_EX:
-                case FieldNames.ARTIST_EX:
+                case FieldNamesConstants.TITLE_EX:
+                case FieldNamesConstants.ALBUM_EX:
+                case FieldNamesConstants.ARTIST_EX:
                     //  #482 No longer used
                     break;
                 default:

--- a/jpsonic-main/src/test/java/org/airsonic/player/service/search/DocumentFactoryLegacyTest.java
+++ b/jpsonic-main/src/test/java/org/airsonic/player/service/search/DocumentFactoryLegacyTest.java
@@ -87,14 +87,14 @@ public class DocumentFactoryLegacyTest {
         album.setFolderId(10);
         Document document = documentFactory.createAlbumId3Document(album);
         assertEquals("fields.size", 14, document.getFields().size());
-        assertEquals("FieldNames.ID", "1", document.get(FieldNames.ID));
-        assertEquals("FieldNames.ALBUM", "name", document.get(FieldNames.ALBUM));
-        assertEquals("FieldNames.ALBUM_EX", "name", document.get(FieldNames.ALBUM_EX));
-        assertEquals("FieldNames.ARTIST", "artist", document.get(FieldNames.ARTIST));
-        assertEquals("FieldNames.ARTIST_EX", "artist", document.get(FieldNames.ARTIST_EX));
-        assertEquals("FieldNames.ARTIST_READING", "artistSort", document.get(FieldNames.ARTIST_READING));
-        assertEquals("FieldNames.GENRE", "genre", document.get(FieldNames.GENRE));
-        assertEquals("FieldNames.FOLDER_ID", "10", document.get(FieldNames.FOLDER_ID));
+        assertEquals("FieldNamesConstants.ID", "1", document.get(FieldNamesConstants.ID));
+        assertEquals("FieldNamesConstants.ALBUM", "name", document.get(FieldNamesConstants.ALBUM));
+        assertEquals("FieldNamesConstants.ALBUM_EX", "name", document.get(FieldNamesConstants.ALBUM_EX));
+        assertEquals("FieldNamesConstants.ARTIST", "artist", document.get(FieldNamesConstants.ARTIST));
+        assertEquals("FieldNamesConstants.ARTIST_EX", "artist", document.get(FieldNamesConstants.ARTIST_EX));
+        assertEquals("FieldNamesConstants.ARTIST_READING", "artistSort", document.get(FieldNamesConstants.ARTIST_READING));
+        assertEquals("FieldNamesConstants.GENRE", "genre", document.get(FieldNamesConstants.GENRE));
+        assertEquals("FieldNamesConstants.FOLDER_ID", "10", document.get(FieldNamesConstants.FOLDER_ID));
     }
 
     @Test
@@ -108,12 +108,12 @@ public class DocumentFactoryLegacyTest {
         MusicFolder musicFolder = new MusicFolder(100, musicDir, "Music", true, new Date());
         Document document = documentFactory.createArtistId3Document(artist, musicFolder);
         assertEquals("fields.size", 8, document.getFields().size());
-        assertEquals("FieldNames.ID", "1", document.get(FieldNames.ID));
-        assertEquals("FieldNames.ARTIST", "name", document.get(FieldNames.ARTIST));
-        assertEquals("FieldNames.ARTIST_EX", "name", document.get(FieldNames.ARTIST_EX));
-        assertEquals("FieldNames.ARTIST_READING", "sort", document.get(FieldNames.ARTIST_READING));
-        assertNotEquals("FieldNames.FOLDER_ID", "10", document.get(FieldNames.FOLDER_ID));
-        assertEquals("FieldNames.FOLDER_ID", "100", document.get(FieldNames.FOLDER_ID));
+        assertEquals("FieldNamesConstants.ID", "1", document.get(FieldNamesConstants.ID));
+        assertEquals("FieldNamesConstants.ARTIST", "name", document.get(FieldNamesConstants.ARTIST));
+        assertEquals("FieldNamesConstants.ARTIST_EX", "name", document.get(FieldNamesConstants.ARTIST_EX));
+        assertEquals("FieldNamesConstants.ARTIST_READING", "sort", document.get(FieldNamesConstants.ARTIST_READING));
+        assertNotEquals("FieldNamesConstants.FOLDER_ID", "10", document.get(FieldNamesConstants.FOLDER_ID));
+        assertEquals("FieldNamesConstants.FOLDER_ID", "100", document.get(FieldNamesConstants.FOLDER_ID));
     }
 
     @Test(expected = NullPointerException.class)
@@ -133,14 +133,14 @@ public class DocumentFactoryLegacyTest {
         album.setFolder("folder");
         Document document = documentFactory.createAlbumDocument(album);
         assertEquals("fields.size", 14, document.getFields().size());
-        assertEquals("FieldNames.ID", "1", document.get(FieldNames.ID));
-        assertEquals("FieldNames.ALBUM", "albumName", document.get(FieldNames.ALBUM));
-        assertEquals("FieldNames.ALBUM_EX", "albumName", document.get(FieldNames.ALBUM_EX));
-        assertEquals("FieldNames.ARTIST", "artist", document.get(FieldNames.ARTIST));
-        assertEquals("FieldNames.ARTIST_EX", "artist", document.get(FieldNames.ARTIST_EX));
-        assertEquals("FieldNames.ARTIST_READING", "artistSort", document.get(FieldNames.ARTIST_READING));
-        assertEquals("FieldNames.GENRE", "genre", document.get(FieldNames.GENRE));
-        assertEquals("FieldNames.FOLDER", "folder", document.get(FieldNames.FOLDER));
+        assertEquals("FieldNamesConstants.ID", "1", document.get(FieldNamesConstants.ID));
+        assertEquals("FieldNamesConstants.ALBUM", "albumName", document.get(FieldNamesConstants.ALBUM));
+        assertEquals("FieldNamesConstants.ALBUM_EX", "albumName", document.get(FieldNamesConstants.ALBUM_EX));
+        assertEquals("FieldNamesConstants.ARTIST", "artist", document.get(FieldNamesConstants.ARTIST));
+        assertEquals("FieldNamesConstants.ARTIST_EX", "artist", document.get(FieldNamesConstants.ARTIST_EX));
+        assertEquals("FieldNamesConstants.ARTIST_READING", "artistSort", document.get(FieldNamesConstants.ARTIST_READING));
+        assertEquals("FieldNamesConstants.GENRE", "genre", document.get(FieldNamesConstants.GENRE));
+        assertEquals("FieldNamesConstants.FOLDER", "folder", document.get(FieldNamesConstants.FOLDER));
     }
 
     @Test
@@ -152,11 +152,11 @@ public class DocumentFactoryLegacyTest {
         artist.setFolder("folder");
         Document document = documentFactory.createArtistDocument(artist);
         assertEquals("fields.size", 8, document.getFields().size());
-        assertEquals("FieldNames.ID", "1", document.get(FieldNames.ID));
-        assertEquals("FieldNames.ARTIST", "artist", document.get(FieldNames.ARTIST));
-        assertEquals("FieldNames.ARTIST_EX", "artist", document.get(FieldNames.ARTIST_EX));
-        assertEquals("FieldNames.ARTIST_READING", "artistSort", document.get(FieldNames.ARTIST_READING));
-        assertEquals("FieldNames.FOLDER", "folder", document.get(FieldNames.FOLDER));
+        assertEquals("FieldNamesConstants.ID", "1", document.get(FieldNamesConstants.ID));
+        assertEquals("FieldNamesConstants.ARTIST", "artist", document.get(FieldNamesConstants.ARTIST));
+        assertEquals("FieldNamesConstants.ARTIST_EX", "artist", document.get(FieldNamesConstants.ARTIST_EX));
+        assertEquals("FieldNamesConstants.ARTIST_READING", "artistSort", document.get(FieldNamesConstants.ARTIST_READING));
+        assertEquals("FieldNamesConstants.FOLDER", "folder", document.get(FieldNamesConstants.FOLDER));
     }
 
     @Test
@@ -173,17 +173,17 @@ public class DocumentFactoryLegacyTest {
         song.setFolder("folder");
         Document document = documentFactory.createSongDocument(song);
         assertEquals("fields.size", 16, document.getFields().size());
-        assertEquals("FieldNames.ID", "1", document.get(FieldNames.ID));
-        assertEquals("FieldNames.ARTIST", "artist", document.get(FieldNames.ARTIST));
-        assertEquals("FieldNames.ARTIST_EX", "artist", document.get(FieldNames.ARTIST_EX));
-        assertEquals("FieldNames.ARTIST_READING", "artistSort", document.get(FieldNames.ARTIST_READING));
-        assertEquals("FieldNames.TITLE", "title", document.get(FieldNames.TITLE));
-        assertEquals("FieldNames.TITLE_EX", "title", document.get(FieldNames.TITLE_EX));
-        assertEquals("FieldNames.MEDIA_TYPE", "MUSIC", document.get(FieldNames.MEDIA_TYPE));
-        assertEquals("FieldNames.GENRE", "genre", document.get(FieldNames.GENRE));
-        assertEquals("FieldNames.YEAR", null, document.get(FieldNames.YEAR));
-        // assertEquals("FieldNames.YEAR", "2000", document.get(FieldNames.YEAR));
-        assertEquals("FieldNames.FOLDER", "folder", document.get(FieldNames.FOLDER));
+        assertEquals("FieldNamesConstants.ID", "1", document.get(FieldNamesConstants.ID));
+        assertEquals("FieldNamesConstants.ARTIST", "artist", document.get(FieldNamesConstants.ARTIST));
+        assertEquals("FieldNamesConstants.ARTIST_EX", "artist", document.get(FieldNamesConstants.ARTIST_EX));
+        assertEquals("FieldNamesConstants.ARTIST_READING", "artistSort", document.get(FieldNamesConstants.ARTIST_READING));
+        assertEquals("FieldNamesConstants.TITLE", "title", document.get(FieldNamesConstants.TITLE));
+        assertEquals("FieldNamesConstants.TITLE_EX", "title", document.get(FieldNamesConstants.TITLE_EX));
+        assertEquals("FieldNamesConstants.MEDIA_TYPE", "MUSIC", document.get(FieldNamesConstants.MEDIA_TYPE));
+        assertEquals("FieldNamesConstants.GENRE", "genre", document.get(FieldNamesConstants.GENRE));
+        assertEquals("FieldNamesConstants.YEAR", null, document.get(FieldNamesConstants.YEAR));
+        // assertEquals("FieldNamesConstants.YEAR", "2000", document.get(FieldNamesConstants.YEAR));
+        assertEquals("FieldNamesConstants.FOLDER", "folder", document.get(FieldNamesConstants.FOLDER));
     }
 
     @Test
@@ -193,22 +193,22 @@ public class DocumentFactoryLegacyTest {
         song.setGenre("genre");
         Document document = documentFactory.createGenreDocument(song);
         assertEquals("fields.size", 3, document.getFields().size());
-        assertEquals("FieldNames.GENRE_KEY", "genre", document.get(FieldNames.GENRE_KEY));
-        assertEquals("FieldNames.GENRE", "genre", document.get(FieldNames.GENRE));
+        assertEquals("FieldNamesConstants.GENRE_KEY", "genre", document.get(FieldNamesConstants.GENRE_KEY));
+        assertEquals("FieldNamesConstants.GENRE", "genre", document.get(FieldNamesConstants.GENRE));
     }
 
     @Test(expected = NullPointerException.class)
     public void testCreateNullAlbum() {
         Document document = documentFactory.createAlbumId3Document(new Album());
         assertEquals("fields.size", 1, document.getFields().size());
-        assertEquals("FieldNames.ID", "0", document.get(FieldNames.ID)); // Because domain getter is int type
-        assertNull("FieldNames.ALBUM", document.get(FieldNames.ALBUM));
-        assertNull("FieldNames.ALBUM_EX", document.get(FieldNames.ALBUM_EX));
-        assertNull("FieldNames.ARTIST", document.get(FieldNames.ARTIST));
-        assertNull("FieldNames.ARTIST_EX", document.get(FieldNames.ARTIST_EX));
-        assertNull("FieldNames.ARTIST_READING", document.get(FieldNames.ARTIST_READING));
-        assertNull("FieldNames.GENRE", document.get(FieldNames.GENRE));
-        assertNull("FieldNames.FOLDER_ID", document.get(FieldNames.FOLDER_ID));
+        assertEquals("FieldNamesConstants.ID", "0", document.get(FieldNamesConstants.ID)); // Because domain getter is int type
+        assertNull("FieldNamesConstants.ALBUM", document.get(FieldNamesConstants.ALBUM));
+        assertNull("FieldNamesConstants.ALBUM_EX", document.get(FieldNamesConstants.ALBUM_EX));
+        assertNull("FieldNamesConstants.ARTIST", document.get(FieldNamesConstants.ARTIST));
+        assertNull("FieldNamesConstants.ARTIST_EX", document.get(FieldNamesConstants.ARTIST_EX));
+        assertNull("FieldNamesConstants.ARTIST_READING", document.get(FieldNamesConstants.ARTIST_READING));
+        assertNull("FieldNamesConstants.GENRE", document.get(FieldNamesConstants.GENRE));
+        assertNull("FieldNamesConstants.FOLDER_ID", document.get(FieldNamesConstants.FOLDER_ID));
     }
 
     @Test
@@ -217,12 +217,12 @@ public class DocumentFactoryLegacyTest {
         MusicFolder musicFolder = new MusicFolder(100, musicDir, "Music", true, new Date());
         Document document = documentFactory.createArtistId3Document(new Artist(), musicFolder);
         assertEquals("fields.size", 2, document.getFields().size());
-        assertEquals("FieldNames.ID", "0", document.get(FieldNames.ID)); // Because domain getter is int type
-        assertNull("FieldNames.ARTIST", document.get(FieldNames.ARTIST));
-        assertNull("FieldNames.ARTIST_EX", document.get(FieldNames.ARTIST_EX));
-        assertNull("FieldNames.ARTIST_READING", document.get(FieldNames.ARTIST_READING));
-        assertNotEquals("FieldNames.FOLDER_ID", "10", document.get(FieldNames.FOLDER_ID));
-        assertEquals("FieldNames.FOLDER_ID", "100", document.get(FieldNames.FOLDER_ID));
+        assertEquals("FieldNamesConstants.ID", "0", document.get(FieldNamesConstants.ID)); // Because domain getter is int type
+        assertNull("FieldNamesConstants.ARTIST", document.get(FieldNamesConstants.ARTIST));
+        assertNull("FieldNamesConstants.ARTIST_EX", document.get(FieldNamesConstants.ARTIST_EX));
+        assertNull("FieldNamesConstants.ARTIST_READING", document.get(FieldNamesConstants.ARTIST_READING));
+        assertNotEquals("FieldNamesConstants.FOLDER_ID", "10", document.get(FieldNamesConstants.FOLDER_ID));
+        assertEquals("FieldNamesConstants.FOLDER_ID", "100", document.get(FieldNamesConstants.FOLDER_ID));
     }
 
     @Test
@@ -232,13 +232,13 @@ public class DocumentFactoryLegacyTest {
         mediaFile.setFolder("folder");
         Document document = documentFactory.createAlbumDocument(mediaFile);
         assertEquals("fields.size", 2, document.getFields().size());
-        assertEquals("FieldNames.ID", "0", document.get(FieldNames.ID)); // Because domain getter is int type
-        assertNull("FieldNames.ALBUM", document.get(FieldNames.ALBUM));
-        assertNull("FieldNames.ALBUM_EX", document.get(FieldNames.ALBUM_EX));
-        assertNull("FieldNames.ARTIST", document.get(FieldNames.ARTIST));
-        assertNull("FieldNames.ARTIST_EX", document.get(FieldNames.ARTIST_EX));
-        assertNull("FieldNames.ARTIST_READING", document.get(FieldNames.ARTIST_READING));
-        assertNull("FieldNames.GENRE", document.get(FieldNames.GENRE));
+        assertEquals("FieldNamesConstants.ID", "0", document.get(FieldNamesConstants.ID)); // Because domain getter is int type
+        assertNull("FieldNamesConstants.ALBUM", document.get(FieldNamesConstants.ALBUM));
+        assertNull("FieldNamesConstants.ALBUM_EX", document.get(FieldNamesConstants.ALBUM_EX));
+        assertNull("FieldNamesConstants.ARTIST", document.get(FieldNamesConstants.ARTIST));
+        assertNull("FieldNamesConstants.ARTIST_EX", document.get(FieldNamesConstants.ARTIST_EX));
+        assertNull("FieldNamesConstants.ARTIST_READING", document.get(FieldNamesConstants.ARTIST_READING));
+        assertNull("FieldNamesConstants.GENRE", document.get(FieldNamesConstants.GENRE));
     }
 
     @Test
@@ -248,10 +248,10 @@ public class DocumentFactoryLegacyTest {
         mediaFile.setFolder("folder");
         Document document = documentFactory.createArtistDocument(mediaFile);
         assertEquals("fields.size", 2, document.getFields().size());
-        assertEquals("FieldNames.ID", "0", document.get(FieldNames.ID)); // Because domain getter is int type
-        assertNull("FieldNames.ARTIST", document.get(FieldNames.ARTIST));
-        assertNull("FieldNames.ARTIST_EX", document.get(FieldNames.ARTIST_EX));
-        assertNull("FieldNames.ARTIST_READING", document.get(FieldNames.ARTIST_READING));
+        assertEquals("FieldNamesConstants.ID", "0", document.get(FieldNamesConstants.ID)); // Because domain getter is int type
+        assertNull("FieldNamesConstants.ARTIST", document.get(FieldNamesConstants.ARTIST));
+        assertNull("FieldNamesConstants.ARTIST_EX", document.get(FieldNamesConstants.ARTIST_EX));
+        assertNull("FieldNamesConstants.ARTIST_READING", document.get(FieldNamesConstants.ARTIST_READING));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -290,14 +290,14 @@ public class DocumentFactoryLegacyTest {
         song.setFolder("folder");
         Document document = documentFactory.createSongDocument(song);
         assertEquals("fields.size", 3, document.getFields().size());
-        assertEquals("FieldNames.ID", "0", document.get(FieldNames.ID)); // Because domain getter is int type
-        assertNull("FieldNames.ARTIST", document.get(FieldNames.ARTIST));
-        assertNull("FieldNames.ARTIST_EX", document.get(FieldNames.ARTIST_EX));
-        assertNull("FieldNames.ARTIST_READING", document.get(FieldNames.ARTIST_READING));
-        assertNull("FieldNames.TITLE", document.get(FieldNames.TITLE));
-        assertNull("FieldNames.TITLE_EX", document.get(FieldNames.TITLE_EX));
-        assertNull("FieldNames.GENRE", document.get(FieldNames.GENRE));
-        assertNull("FieldNames.YEAR", document.get(FieldNames.YEAR));
+        assertEquals("FieldNamesConstants.ID", "0", document.get(FieldNamesConstants.ID)); // Because domain getter is int type
+        assertNull("FieldNamesConstants.ARTIST", document.get(FieldNamesConstants.ARTIST));
+        assertNull("FieldNamesConstants.ARTIST_EX", document.get(FieldNamesConstants.ARTIST_EX));
+        assertNull("FieldNamesConstants.ARTIST_READING", document.get(FieldNamesConstants.ARTIST_READING));
+        assertNull("FieldNamesConstants.TITLE", document.get(FieldNamesConstants.TITLE));
+        assertNull("FieldNamesConstants.TITLE_EX", document.get(FieldNamesConstants.TITLE_EX));
+        assertNull("FieldNamesConstants.GENRE", document.get(FieldNamesConstants.GENRE));
+        assertNull("FieldNamesConstants.YEAR", document.get(FieldNamesConstants.YEAR));
     }
 
 }

--- a/jpsonic-main/src/test/java/org/airsonic/player/service/search/DocumentFactoryTest.java
+++ b/jpsonic-main/src/test/java/org/airsonic/player/service/search/DocumentFactoryTest.java
@@ -87,14 +87,14 @@ public class DocumentFactoryTest {
         album.setFolderId(10);
         Document document = documentFactory.createAlbumId3Document(album);
         assertEquals("fields.size", 14, document.getFields().size());
-        assertEquals("FieldNames.ID", "1", document.get(FieldNames.ID));
-        assertEquals("FieldNames.ALBUM", "name", document.get(FieldNames.ALBUM));
-        assertEquals("FieldNames.ALBUM_EX", "name", document.get(FieldNames.ALBUM_EX));
-        assertEquals("FieldNames.ARTIST", "artist", document.get(FieldNames.ARTIST));
-        assertEquals("FieldNames.ARTIST_EX", "artist", document.get(FieldNames.ARTIST_EX));
-        assertEquals("FieldNames.ARTIST_READING", "artistSort", document.get(FieldNames.ARTIST_READING));
-        assertEquals("FieldNames.GENRE", "genre", document.get(FieldNames.GENRE));
-        assertEquals("FieldNames.FOLDER_ID", "10", document.get(FieldNames.FOLDER_ID));
+        assertEquals("FieldNamesConstants.ID", "1", document.get(FieldNamesConstants.ID));
+        assertEquals("FieldNamesConstants.ALBUM", "name", document.get(FieldNamesConstants.ALBUM));
+        assertEquals("FieldNamesConstants.ALBUM_EX", "name", document.get(FieldNamesConstants.ALBUM_EX));
+        assertEquals("FieldNamesConstants.ARTIST", "artist", document.get(FieldNamesConstants.ARTIST));
+        assertEquals("FieldNamesConstants.ARTIST_EX", "artist", document.get(FieldNamesConstants.ARTIST_EX));
+        assertEquals("FieldNamesConstants.ARTIST_READING", "artistSort", document.get(FieldNamesConstants.ARTIST_READING));
+        assertEquals("FieldNamesConstants.GENRE", "genre", document.get(FieldNamesConstants.GENRE));
+        assertEquals("FieldNamesConstants.FOLDER_ID", "10", document.get(FieldNamesConstants.FOLDER_ID));
     }
 
     @Test
@@ -108,12 +108,12 @@ public class DocumentFactoryTest {
         MusicFolder musicFolder = new MusicFolder(100, musicDir, "Music", true, new Date());
         Document document = documentFactory.createArtistId3Document(artist, musicFolder);
         assertEquals("fields.size", 8, document.getFields().size());
-        assertEquals("FieldNames.ID", "1", document.get(FieldNames.ID));
-        assertEquals("FieldNames.ARTIST", "name", document.get(FieldNames.ARTIST));
-        assertEquals("FieldNames.ARTIST_EX", "name", document.get(FieldNames.ARTIST_EX));
-        assertEquals("FieldNames.ARTIST_READING", "sort", document.get(FieldNames.ARTIST_READING));
-        assertNotEquals("FieldNames.FOLDER_ID", "10", document.get(FieldNames.FOLDER_ID));
-        assertEquals("FieldNames.FOLDER_ID", "100", document.get(FieldNames.FOLDER_ID));
+        assertEquals("FieldNamesConstants.ID", "1", document.get(FieldNamesConstants.ID));
+        assertEquals("FieldNamesConstants.ARTIST", "name", document.get(FieldNamesConstants.ARTIST));
+        assertEquals("FieldNamesConstants.ARTIST_EX", "name", document.get(FieldNamesConstants.ARTIST_EX));
+        assertEquals("FieldNamesConstants.ARTIST_READING", "sort", document.get(FieldNamesConstants.ARTIST_READING));
+        assertNotEquals("FieldNamesConstants.FOLDER_ID", "10", document.get(FieldNamesConstants.FOLDER_ID));
+        assertEquals("FieldNamesConstants.FOLDER_ID", "100", document.get(FieldNamesConstants.FOLDER_ID));
     }
 
     @Test(expected = NullPointerException.class)
@@ -133,14 +133,14 @@ public class DocumentFactoryTest {
         album.setFolder("folder");
         Document document = documentFactory.createAlbumDocument(album);
         assertEquals("fields.size", 14, document.getFields().size());
-        assertEquals("FieldNames.ID", "1", document.get(FieldNames.ID));
-        assertEquals("FieldNames.ALBUM", "albumName", document.get(FieldNames.ALBUM));
-        assertEquals("FieldNames.ALBUM_EX", "albumName", document.get(FieldNames.ALBUM_EX));
-        assertEquals("FieldNames.ARTIST", "artist", document.get(FieldNames.ARTIST));
-        assertEquals("FieldNames.ARTIST_EX", "artist", document.get(FieldNames.ARTIST_EX));
-        assertEquals("FieldNames.ARTIST_READING", "artistSort", document.get(FieldNames.ARTIST_READING));
-        assertEquals("FieldNames.GENRE", "genre", document.get(FieldNames.GENRE));
-        assertEquals("FieldNames.FOLDER", "folder", document.get(FieldNames.FOLDER));
+        assertEquals("FieldNamesConstants.ID", "1", document.get(FieldNamesConstants.ID));
+        assertEquals("FieldNamesConstants.ALBUM", "albumName", document.get(FieldNamesConstants.ALBUM));
+        assertEquals("FieldNamesConstants.ALBUM_EX", "albumName", document.get(FieldNamesConstants.ALBUM_EX));
+        assertEquals("FieldNamesConstants.ARTIST", "artist", document.get(FieldNamesConstants.ARTIST));
+        assertEquals("FieldNamesConstants.ARTIST_EX", "artist", document.get(FieldNamesConstants.ARTIST_EX));
+        assertEquals("FieldNamesConstants.ARTIST_READING", "artistSort", document.get(FieldNamesConstants.ARTIST_READING));
+        assertEquals("FieldNamesConstants.GENRE", "genre", document.get(FieldNamesConstants.GENRE));
+        assertEquals("FieldNamesConstants.FOLDER", "folder", document.get(FieldNamesConstants.FOLDER));
     }
 
     @Test
@@ -152,11 +152,11 @@ public class DocumentFactoryTest {
         artist.setFolder("folder");
         Document document = documentFactory.createArtistDocument(artist);
         assertEquals("fields.size", 8, document.getFields().size());
-        assertEquals("FieldNames.ID", "1", document.get(FieldNames.ID));
-        assertEquals("FieldNames.ARTIST", "artist", document.get(FieldNames.ARTIST));
-        assertEquals("FieldNames.ARTIST_EX", "artist", document.get(FieldNames.ARTIST_EX));
-        assertEquals("FieldNames.ARTIST_READING", "artistSort", document.get(FieldNames.ARTIST_READING));
-        assertEquals("FieldNames.FOLDER", "folder", document.get(FieldNames.FOLDER));
+        assertEquals("FieldNamesConstants.ID", "1", document.get(FieldNamesConstants.ID));
+        assertEquals("FieldNamesConstants.ARTIST", "artist", document.get(FieldNamesConstants.ARTIST));
+        assertEquals("FieldNamesConstants.ARTIST_EX", "artist", document.get(FieldNamesConstants.ARTIST_EX));
+        assertEquals("FieldNamesConstants.ARTIST_READING", "artistSort", document.get(FieldNamesConstants.ARTIST_READING));
+        assertEquals("FieldNamesConstants.FOLDER", "folder", document.get(FieldNamesConstants.FOLDER));
     }
 
     @Test
@@ -173,17 +173,17 @@ public class DocumentFactoryTest {
         song.setFolder("folder");
         Document document = documentFactory.createSongDocument(song);
         assertEquals("fields.size", 16, document.getFields().size());
-        assertEquals("FieldNames.ID", "1", document.get(FieldNames.ID));
-        assertEquals("FieldNames.ARTIST", "artist", document.get(FieldNames.ARTIST));
-        assertEquals("FieldNames.ARTIST_EX", "artist", document.get(FieldNames.ARTIST_EX));
-        assertEquals("FieldNames.ARTIST_READING", "artistSort", document.get(FieldNames.ARTIST_READING));
-        assertEquals("FieldNames.TITLE", "title", document.get(FieldNames.TITLE));
-        assertEquals("FieldNames.TITLE_EX", "title", document.get(FieldNames.TITLE_EX));
-        assertEquals("FieldNames.MEDIA_TYPE", "MUSIC", document.get(FieldNames.MEDIA_TYPE));
-        assertEquals("FieldNames.GENRE", "genre", document.get(FieldNames.GENRE));
-        assertEquals("FieldNames.YEAR", null, document.get(FieldNames.YEAR));
-        // assertEquals("FieldNames.YEAR", "2000", document.get(FieldNames.YEAR));
-        assertEquals("FieldNames.FOLDER", "folder", document.get(FieldNames.FOLDER));
+        assertEquals("FieldNamesConstants.ID", "1", document.get(FieldNamesConstants.ID));
+        assertEquals("FieldNamesConstants.ARTIST", "artist", document.get(FieldNamesConstants.ARTIST));
+        assertEquals("FieldNamesConstants.ARTIST_EX", "artist", document.get(FieldNamesConstants.ARTIST_EX));
+        assertEquals("FieldNamesConstants.ARTIST_READING", "artistSort", document.get(FieldNamesConstants.ARTIST_READING));
+        assertEquals("FieldNamesConstants.TITLE", "title", document.get(FieldNamesConstants.TITLE));
+        assertEquals("FieldNamesConstants.TITLE_EX", "title", document.get(FieldNamesConstants.TITLE_EX));
+        assertEquals("FieldNamesConstants.MEDIA_TYPE", "MUSIC", document.get(FieldNamesConstants.MEDIA_TYPE));
+        assertEquals("FieldNamesConstants.GENRE", "genre", document.get(FieldNamesConstants.GENRE));
+        assertEquals("FieldNamesConstants.YEAR", null, document.get(FieldNamesConstants.YEAR));
+        // assertEquals("FieldNamesConstants.YEAR", "2000", document.get(FieldNamesConstants.YEAR));
+        assertEquals("FieldNamesConstants.FOLDER", "folder", document.get(FieldNamesConstants.FOLDER));
     }
 
     @Test
@@ -193,22 +193,22 @@ public class DocumentFactoryTest {
         song.setGenre("genre");
         Document document = documentFactory.createGenreDocument(song);
         assertEquals("fields.size", 3, document.getFields().size());
-        assertEquals("FieldNames.GENRE_KEY", "genre", document.get(FieldNames.GENRE_KEY));
-        assertEquals("FieldNames.GENRE", "genre", document.get(FieldNames.GENRE));
+        assertEquals("FieldNamesConstants.GENRE_KEY", "genre", document.get(FieldNamesConstants.GENRE_KEY));
+        assertEquals("FieldNamesConstants.GENRE", "genre", document.get(FieldNamesConstants.GENRE));
     }
 
     @Test(expected = NullPointerException.class)
     public void testCreateNullAlbum() {
         Document document = documentFactory.createAlbumId3Document(new Album());
         assertEquals("fields.size", 1, document.getFields().size());
-        assertEquals("FieldNames.ID", "0", document.get(FieldNames.ID)); // Because domain getter is int type
-        assertNull("FieldNames.ALBUM", document.get(FieldNames.ALBUM));
-        assertNull("FieldNames.ALBUM_EX", document.get(FieldNames.ALBUM_EX));
-        assertNull("FieldNames.ARTIST", document.get(FieldNames.ARTIST));
-        assertNull("FieldNames.ARTIST_EX", document.get(FieldNames.ARTIST_EX));
-        assertNull("FieldNames.ARTIST_READING", document.get(FieldNames.ARTIST_READING));
-        assertNull("FieldNames.GENRE", document.get(FieldNames.GENRE));
-        assertNull("FieldNames.FOLDER_ID", document.get(FieldNames.FOLDER_ID));
+        assertEquals("FieldNamesConstants.ID", "0", document.get(FieldNamesConstants.ID)); // Because domain getter is int type
+        assertNull("FieldNamesConstants.ALBUM", document.get(FieldNamesConstants.ALBUM));
+        assertNull("FieldNamesConstants.ALBUM_EX", document.get(FieldNamesConstants.ALBUM_EX));
+        assertNull("FieldNamesConstants.ARTIST", document.get(FieldNamesConstants.ARTIST));
+        assertNull("FieldNamesConstants.ARTIST_EX", document.get(FieldNamesConstants.ARTIST_EX));
+        assertNull("FieldNamesConstants.ARTIST_READING", document.get(FieldNamesConstants.ARTIST_READING));
+        assertNull("FieldNamesConstants.GENRE", document.get(FieldNamesConstants.GENRE));
+        assertNull("FieldNamesConstants.FOLDER_ID", document.get(FieldNamesConstants.FOLDER_ID));
     }
 
     @Test
@@ -217,12 +217,12 @@ public class DocumentFactoryTest {
         MusicFolder musicFolder = new MusicFolder(100, musicDir, "Music", true, new Date());
         Document document = documentFactory.createArtistId3Document(new Artist(), musicFolder);
         assertEquals("fields.size", 2, document.getFields().size());
-        assertEquals("FieldNames.ID", "0", document.get(FieldNames.ID)); // Because domain getter is int type
-        assertNull("FieldNames.ARTIST", document.get(FieldNames.ARTIST));
-        assertNull("FieldNames.ARTIST_EX", document.get(FieldNames.ARTIST_EX));
-        assertNull("FieldNames.ARTIST_READING", document.get(FieldNames.ARTIST_READING));
-        assertNotEquals("FieldNames.FOLDER_ID", "10", document.get(FieldNames.FOLDER_ID));
-        assertEquals("FieldNames.FOLDER_ID", "100", document.get(FieldNames.FOLDER_ID));
+        assertEquals("FieldNamesConstants.ID", "0", document.get(FieldNamesConstants.ID)); // Because domain getter is int type
+        assertNull("FieldNamesConstants.ARTIST", document.get(FieldNamesConstants.ARTIST));
+        assertNull("FieldNamesConstants.ARTIST_EX", document.get(FieldNamesConstants.ARTIST_EX));
+        assertNull("FieldNamesConstants.ARTIST_READING", document.get(FieldNamesConstants.ARTIST_READING));
+        assertNotEquals("FieldNamesConstants.FOLDER_ID", "10", document.get(FieldNamesConstants.FOLDER_ID));
+        assertEquals("FieldNamesConstants.FOLDER_ID", "100", document.get(FieldNamesConstants.FOLDER_ID));
     }
 
     @Test
@@ -232,13 +232,13 @@ public class DocumentFactoryTest {
         mediaFile.setFolder("folder");
         Document document = documentFactory.createAlbumDocument(mediaFile);
         assertEquals("fields.size", 2, document.getFields().size());
-        assertEquals("FieldNames.ID", "0", document.get(FieldNames.ID)); // Because domain getter is int type
-        assertNull("FieldNames.ALBUM", document.get(FieldNames.ALBUM));
-        assertNull("FieldNames.ALBUM_EX", document.get(FieldNames.ALBUM_EX));
-        assertNull("FieldNames.ARTIST", document.get(FieldNames.ARTIST));
-        assertNull("FieldNames.ARTIST_EX", document.get(FieldNames.ARTIST_EX));
-        assertNull("FieldNames.ARTIST_READING", document.get(FieldNames.ARTIST_READING));
-        assertNull("FieldNames.GENRE", document.get(FieldNames.GENRE));
+        assertEquals("FieldNamesConstants.ID", "0", document.get(FieldNamesConstants.ID)); // Because domain getter is int type
+        assertNull("FieldNamesConstants.ALBUM", document.get(FieldNamesConstants.ALBUM));
+        assertNull("FieldNamesConstants.ALBUM_EX", document.get(FieldNamesConstants.ALBUM_EX));
+        assertNull("FieldNamesConstants.ARTIST", document.get(FieldNamesConstants.ARTIST));
+        assertNull("FieldNamesConstants.ARTIST_EX", document.get(FieldNamesConstants.ARTIST_EX));
+        assertNull("FieldNamesConstants.ARTIST_READING", document.get(FieldNamesConstants.ARTIST_READING));
+        assertNull("FieldNamesConstants.GENRE", document.get(FieldNamesConstants.GENRE));
     }
 
     @Test
@@ -248,10 +248,10 @@ public class DocumentFactoryTest {
         mediaFile.setFolder("folder");
         Document document = documentFactory.createArtistDocument(mediaFile);
         assertEquals("fields.size", 2, document.getFields().size());
-        assertEquals("FieldNames.ID", "0", document.get(FieldNames.ID)); // Because domain getter is int type
-        assertNull("FieldNames.ARTIST", document.get(FieldNames.ARTIST));
-        assertNull("FieldNames.ARTIST_EX", document.get(FieldNames.ARTIST_EX));
-        assertNull("FieldNames.ARTIST_READING", document.get(FieldNames.ARTIST_READING));
+        assertEquals("FieldNamesConstants.ID", "0", document.get(FieldNamesConstants.ID)); // Because domain getter is int type
+        assertNull("FieldNamesConstants.ARTIST", document.get(FieldNamesConstants.ARTIST));
+        assertNull("FieldNamesConstants.ARTIST_EX", document.get(FieldNamesConstants.ARTIST_EX));
+        assertNull("FieldNamesConstants.ARTIST_READING", document.get(FieldNamesConstants.ARTIST_READING));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -290,14 +290,14 @@ public class DocumentFactoryTest {
         song.setFolder("folder");
         Document document = documentFactory.createSongDocument(song);
         assertEquals("fields.size", 3, document.getFields().size());
-        assertEquals("FieldNames.ID", "0", document.get(FieldNames.ID)); // Because domain getter is int type
-        assertNull("FieldNames.ARTIST", document.get(FieldNames.ARTIST));
-        assertNull("FieldNames.ARTIST_EX", document.get(FieldNames.ARTIST_EX));
-        assertNull("FieldNames.ARTIST_READING", document.get(FieldNames.ARTIST_READING));
-        assertNull("FieldNames.TITLE", document.get(FieldNames.TITLE));
-        assertNull("FieldNames.TITLE_EX", document.get(FieldNames.TITLE_EX));
-        assertNull("FieldNames.GENRE", document.get(FieldNames.GENRE));
-        assertNull("FieldNames.YEAR", document.get(FieldNames.YEAR));
+        assertEquals("FieldNamesConstants.ID", "0", document.get(FieldNamesConstants.ID)); // Because domain getter is int type
+        assertNull("FieldNamesConstants.ARTIST", document.get(FieldNamesConstants.ARTIST));
+        assertNull("FieldNamesConstants.ARTIST_EX", document.get(FieldNamesConstants.ARTIST_EX));
+        assertNull("FieldNamesConstants.ARTIST_READING", document.get(FieldNamesConstants.ARTIST_READING));
+        assertNull("FieldNamesConstants.TITLE", document.get(FieldNamesConstants.TITLE));
+        assertNull("FieldNamesConstants.TITLE_EX", document.get(FieldNamesConstants.TITLE_EX));
+        assertNull("FieldNamesConstants.GENRE", document.get(FieldNamesConstants.GENRE));
+        assertNull("FieldNamesConstants.YEAR", document.get(FieldNamesConstants.YEAR));
     }
 
 }

--- a/jpsonic-main/src/test/java/org/airsonic/player/service/search/IndexTypeTestCase.java
+++ b/jpsonic-main/src/test/java/org/airsonic/player/service/search/IndexTypeTestCase.java
@@ -29,9 +29,9 @@ public class IndexTypeTestCase extends TestCase {
     @Test
     public void testAlbumBoosts() {
         assertEquals(3, IndexType.ALBUM.getBoosts().size());
-        assertEquals(IndexType.ALBUM.getBoosts().get(FieldNames.ALBUM), 2.3F);
-        assertEquals(IndexType.ALBUM.getBoosts().get(FieldNames.ALBUM_EX), 2.3F);
-        assertEquals(IndexType.ALBUM.getBoosts().get(FieldNames.ARTIST_READING), 1.1F);
+        assertEquals(IndexType.ALBUM.getBoosts().get(FieldNamesConstants.ALBUM), 2.3F);
+        assertEquals(IndexType.ALBUM.getBoosts().get(FieldNamesConstants.ALBUM_EX), 2.3F);
+        assertEquals(IndexType.ALBUM.getBoosts().get(FieldNamesConstants.ARTIST_READING), 1.1F);
     }
 
     @Test
@@ -42,9 +42,9 @@ public class IndexTypeTestCase extends TestCase {
     @Test
     public void testAlbumId3Boosts() {
         assertEquals(3, IndexType.ALBUM_ID3.getBoosts().size());
-        assertEquals(IndexType.ALBUM_ID3.getBoosts().get(FieldNames.ALBUM), 2.3F);
-        assertEquals(IndexType.ALBUM_ID3.getBoosts().get(FieldNames.ALBUM_EX), 2.3F);
-        assertEquals(IndexType.ALBUM_ID3.getBoosts().get(FieldNames.ARTIST_READING), 1.1F);
+        assertEquals(IndexType.ALBUM_ID3.getBoosts().get(FieldNamesConstants.ALBUM), 2.3F);
+        assertEquals(IndexType.ALBUM_ID3.getBoosts().get(FieldNamesConstants.ALBUM_EX), 2.3F);
+        assertEquals(IndexType.ALBUM_ID3.getBoosts().get(FieldNamesConstants.ARTIST_READING), 1.1F);
     }
 
     @Test
@@ -65,7 +65,7 @@ public class IndexTypeTestCase extends TestCase {
     @Test
     public void testArtistId3Boosts() {
         assertEquals(1, IndexType.ARTIST_ID3.getBoosts().size());
-        assertEquals(IndexType.ARTIST_ID3.getBoosts().get(FieldNames.ARTIST_READING), 1.1F);
+        assertEquals(IndexType.ARTIST_ID3.getBoosts().get(FieldNamesConstants.ARTIST_READING), 1.1F);
     }
 
     @Test
@@ -76,7 +76,7 @@ public class IndexTypeTestCase extends TestCase {
     @Test
     public void testGenreBoosts() {
         assertEquals(1, IndexType.GENRE.getBoosts().size());
-        assertEquals(IndexType.GENRE.getBoosts().get(FieldNames.GENRE_KEY), 1.1F);
+        assertEquals(IndexType.GENRE.getBoosts().get(FieldNamesConstants.GENRE_KEY), 1.1F);
     }
 
     @Test
@@ -87,12 +87,12 @@ public class IndexTypeTestCase extends TestCase {
     @Test
     public void testSongBoosts() {
         assertEquals(6, IndexType.SONG.getBoosts().size());
-        assertEquals(IndexType.SONG.getBoosts().get(FieldNames.TITLE_EX), 2.3F);
-        assertEquals(IndexType.SONG.getBoosts().get(FieldNames.TITLE), 2.2F);
-        assertEquals(IndexType.SONG.getBoosts().get(FieldNames.ARTIST_READING), 1.4F);
-        assertEquals(IndexType.SONG.getBoosts().get(FieldNames.ARTIST_EX), 1.3F);
-        assertEquals(IndexType.SONG.getBoosts().get(FieldNames.ARTIST), 1.2F);
-        assertEquals(IndexType.SONG.getBoosts().get(FieldNames.COMPOSER_READING), 1.1F);
+        assertEquals(IndexType.SONG.getBoosts().get(FieldNamesConstants.TITLE_EX), 2.3F);
+        assertEquals(IndexType.SONG.getBoosts().get(FieldNamesConstants.TITLE), 2.2F);
+        assertEquals(IndexType.SONG.getBoosts().get(FieldNamesConstants.ARTIST_READING), 1.4F);
+        assertEquals(IndexType.SONG.getBoosts().get(FieldNamesConstants.ARTIST_EX), 1.3F);
+        assertEquals(IndexType.SONG.getBoosts().get(FieldNamesConstants.ARTIST), 1.2F);
+        assertEquals(IndexType.SONG.getBoosts().get(FieldNamesConstants.COMPOSER_READING), 1.1F);
     }
 
     @Test

--- a/jpsonic-main/src/test/java/org/airsonic/player/service/search/QueryFactoryTestCase.java
+++ b/jpsonic-main/src/test/java/org/airsonic/player/service/search/QueryFactoryTestCase.java
@@ -89,37 +89,37 @@ public class QueryFactoryTestCase {
 
     @Test
     public void testSearchByNameArtist() throws IOException {
-        Query query = queryFactory.searchByName(FieldNames.ARTIST, QUERY_PATTERN_INCLUDING_KATAKANA);
+        Query query = queryFactory.searchByName(FieldNamesConstants.ARTIST, QUERY_PATTERN_INCLUDING_KATAKANA);
         assertEquals(QUERY_PATTERN_INCLUDING_KATAKANA, "art:ネコ art:abc*", query.toString());
-        query = queryFactory.searchByName(FieldNames.ARTIST, QUERY_PATTERN_ALPHANUMERIC_ONLY);
+        query = queryFactory.searchByName(FieldNamesConstants.ARTIST, QUERY_PATTERN_ALPHANUMERIC_ONLY);
         assertEquals(QUERY_PATTERN_ALPHANUMERIC_ONLY, "art:abc art:123*", query.toString());
-        query = queryFactory.searchByName(FieldNames.ARTIST, QUERY_PATTERN_HIRAGANA_ONLY);
+        query = queryFactory.searchByName(FieldNamesConstants.ARTIST, QUERY_PATTERN_HIRAGANA_ONLY);
         assertEquals(QUERY_PATTERN_HIRAGANA_ONLY, "art:ねこ art:いぬ*", query.toString());
-        query = queryFactory.searchByName(FieldNames.ARTIST, QUERY_PATTERN_OTHERS);
+        query = queryFactory.searchByName(FieldNamesConstants.ARTIST, QUERY_PATTERN_OTHERS);
         assertEquals(QUERY_PATTERN_OTHERS, "art:abc art:ねこ*", query.toString());
     }
 
     @Test
     public void testSearchByNameAlbum() throws IOException {
-        Query query = queryFactory.searchByName(FieldNames.ALBUM, QUERY_PATTERN_INCLUDING_KATAKANA);
+        Query query = queryFactory.searchByName(FieldNamesConstants.ALBUM, QUERY_PATTERN_INCLUDING_KATAKANA);
         assertEquals(QUERY_PATTERN_INCLUDING_KATAKANA, "alb:ネコ alb:abc*", query.toString());
-        query = queryFactory.searchByName(FieldNames.ALBUM, QUERY_PATTERN_ALPHANUMERIC_ONLY);
+        query = queryFactory.searchByName(FieldNamesConstants.ALBUM, QUERY_PATTERN_ALPHANUMERIC_ONLY);
         assertEquals(QUERY_PATTERN_ALPHANUMERIC_ONLY, "alb:abc alb:123*", query.toString());
-        query = queryFactory.searchByName(FieldNames.ALBUM, QUERY_PATTERN_HIRAGANA_ONLY);
+        query = queryFactory.searchByName(FieldNamesConstants.ALBUM, QUERY_PATTERN_HIRAGANA_ONLY);
         assertEquals(QUERY_PATTERN_HIRAGANA_ONLY, "alb:ねこ alb:いぬ*", query.toString());
-        query = queryFactory.searchByName(FieldNames.ALBUM, QUERY_PATTERN_OTHERS);
+        query = queryFactory.searchByName(FieldNamesConstants.ALBUM, QUERY_PATTERN_OTHERS);
         assertEquals(QUERY_PATTERN_OTHERS, "alb:abc alb:ねこ*", query.toString());
     }
 
     @Test
     public void testSearchByNameTitle() throws IOException {
-        Query query = queryFactory.searchByName(FieldNames.TITLE, QUERY_PATTERN_INCLUDING_KATAKANA);
+        Query query = queryFactory.searchByName(FieldNamesConstants.TITLE, QUERY_PATTERN_INCLUDING_KATAKANA);
         assertEquals(QUERY_PATTERN_INCLUDING_KATAKANA, "tit:ネコ tit:abc*", query.toString());
-        query = queryFactory.searchByName(FieldNames.TITLE, QUERY_PATTERN_ALPHANUMERIC_ONLY);
+        query = queryFactory.searchByName(FieldNamesConstants.TITLE, QUERY_PATTERN_ALPHANUMERIC_ONLY);
         assertEquals(QUERY_PATTERN_ALPHANUMERIC_ONLY, "tit:abc tit:123*", query.toString());
-        query = queryFactory.searchByName(FieldNames.TITLE, QUERY_PATTERN_HIRAGANA_ONLY);
+        query = queryFactory.searchByName(FieldNamesConstants.TITLE, QUERY_PATTERN_HIRAGANA_ONLY);
         assertEquals(QUERY_PATTERN_HIRAGANA_ONLY, "tit:ねこ tit:いぬ*", query.toString());
-        query = queryFactory.searchByName(FieldNames.TITLE, QUERY_PATTERN_OTHERS);
+        query = queryFactory.searchByName(FieldNamesConstants.TITLE, QUERY_PATTERN_OTHERS);
         assertEquals(QUERY_PATTERN_OTHERS, "tit:abc tit:ねこ*", query.toString());
     }
 

--- a/jpsonic-main/src/test/java/org/airsonic/player/util/UtilTest.java
+++ b/jpsonic-main/src/test/java/org/airsonic/player/util/UtilTest.java
@@ -14,7 +14,7 @@ public class UtilTest {
     @Test
     public void objectToStringMapNull() {
         MediaLibraryStatistics statistics = null;
-        Map<String, String> stringStringMap = Util.objectToStringMap(statistics);
+        Map<String, String> stringStringMap = PlayerUtils.objectToStringMap(statistics);
         assertNull(stringStringMap);
     }
 
@@ -27,7 +27,7 @@ public class UtilTest {
         statistics.incrementArtists(910823);
         statistics.incrementTotalDurationInSeconds(30);
         statistics.incrementTotalLengthInBytes(2930491082L);
-        Map<String, String> stringStringMap = Util.objectToStringMap(statistics);
+        Map<String, String> stringStringMap = PlayerUtils.objectToStringMap(statistics);
         assertEquals("5", stringStringMap.get("albumCount"));
         assertEquals("4", stringStringMap.get("songCount"));
         assertEquals("910823", stringStringMap.get("artistCount"));
@@ -45,7 +45,7 @@ public class UtilTest {
         stringStringMap.put("totalDurationInSeconds", "30");
         stringStringMap.put("totalLengthInBytes", "2930491082");
         stringStringMap.put("scanDate", "1568350960725");
-        MediaLibraryStatistics statistics = Util.stringMapToObject(MediaLibraryStatistics.class, stringStringMap);
+        MediaLibraryStatistics statistics = PlayerUtils.stringMapToObject(MediaLibraryStatistics.class, stringStringMap);
         assertEquals(Integer.valueOf(5), statistics.getAlbumCount());
         assertEquals(Integer.valueOf(4), statistics.getSongCount());
         assertEquals(Integer.valueOf(910823), statistics.getArtistCount());
@@ -64,7 +64,7 @@ public class UtilTest {
         stringStringMap.put("totalLengthInBytes", "2930491082");
         stringStringMap.put("scanDate", "1568350960725");
         stringStringMap.put("extraneousData", "nothingHereToLookAt");
-        MediaLibraryStatistics statistics = Util.stringMapToObject(MediaLibraryStatistics.class, stringStringMap);
+        MediaLibraryStatistics statistics = PlayerUtils.stringMapToObject(MediaLibraryStatistics.class, stringStringMap);
         assertEquals(Integer.valueOf(5), statistics.getAlbumCount());
         assertEquals(Integer.valueOf(4), statistics.getSongCount());
         assertEquals(Integer.valueOf(910823), statistics.getArtistCount());
@@ -75,14 +75,14 @@ public class UtilTest {
 
     public void stringMapToObjectWithNoData() {
         Map<String, String> stringStringMap = new HashMap<>();
-        MediaLibraryStatistics statistics = Util.stringMapToObject(MediaLibraryStatistics.class, stringStringMap);
+        MediaLibraryStatistics statistics = PlayerUtils.stringMapToObject(MediaLibraryStatistics.class, stringStringMap);
         assertNotNull(statistics);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void stringMapToValidObjectWithNoData() {
         Map<String, String> stringStringMap = new HashMap<>();
-        MediaLibraryStatistics statistics = Util.stringMapToValidObject(MediaLibraryStatistics.class, stringStringMap);
+        MediaLibraryStatistics statistics = PlayerUtils.stringMapToValidObject(MediaLibraryStatistics.class, stringStringMap);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <jetty.schema.version>3.1.2</jetty.schema.version>
         <jetty.version>9.4.30.v20200611</jetty.version>
         <jetty-jsp.version>9.4.30.v20200611</jetty-jsp.version>
+        <pmd.version>6.24.0</pmd.version>
         <log4j.version>2.13.3</log4j.version>
         <docker.container.repo>airsonic/airsonic</docker.container.repo>
         <compile.version>1.8</compile.version>
@@ -440,6 +441,28 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-pmd-plugin</artifactId>
                     <version>3.13.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>net.sourceforge.pmd</groupId>
+                            <artifactId>pmd-core</artifactId>
+                            <version>${pmd.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>net.sourceforge.pmd</groupId>
+                            <artifactId>pmd-java</artifactId>
+                            <version>${pmd.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>net.sourceforge.pmd</groupId>
+                            <artifactId>pmd-javascript</artifactId>
+                            <version>${pmd.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>net.sourceforge.pmd</groupId>
+                            <artifactId>pmd-jsp</artifactId>
+                            <version>${pmd.version}</version>
+                        </dependency>
+                    </dependencies>
                     <executions>
                         <execution>
                             <id>validate</id>


### PR DESCRIPTION
Add PMD rulesets. These are hardly valid on Airsonic.
This update enables blocker/critical rules for all categories. Some suppressions are documented in the rulesets file.