### PR TITLE
Lib updates

### DIFF
--- a/jpsonic-main/cve-suppressed.xml
+++ b/jpsonic-main/cve-suppressed.xml
@@ -66,25 +66,4 @@
         <cve>CVE-2018-14948</cve>
     </suppress>
 
-    <suppress>
-        <notes><![CDATA[dhowden tag is not used in this project]]></notes>
-        <gav regex="true">.*jaudiotagger.*|.*taglibs-standard-impl.*</gav>
-        <cve>CVE-2020-29242</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[dhowden tag is not used in this project]]></notes>
-        <gav regex="true">.*jaudiotagger.*|.*taglibs-standard-impl.*</gav>
-        <cve>CVE-2020-29243</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[dhowden tag is not used in this project]]></notes>
-        <gav regex="true">.*jaudiotagger.*|.*taglibs-standard-impl.*</gav>
-        <cve>CVE-2020-29244</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[dhowden tag is not used in this project]]></notes>
-        <gav regex="true">.*jaudiotagger.*|.*taglibs-standard-impl.*</gav>
-        <cve>CVE-2020-29245</cve>
-    </suppress>
-
 </suppressions>

--- a/jpsonic-main/cve-suppressed.xml
+++ b/jpsonic-main/cve-suppressed.xml
@@ -24,6 +24,16 @@
         <cve>CVE-2020-13943</cve>
     </suppress>
     <suppress>
+        <notes><![CDATA[False positive for tomcat.]]></notes>
+        <gav regex="true">^org\.mortbay\.jasper:apache-jsp:.*$</gav>
+        <cve>CVE-2021-25122</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[False positive for tomcat.]]></notes>
+        <gav regex="true">^org\.mortbay\.jasper:apache-jsp:.*$</gav>
+        <cve>CVE-2021-25329</cve>
+    </suppress>
+    <suppress>
         <notes><![CDATA[False positive. Jetty configuration does not include HTTP/2 now.]]></notes>
         <gav regex="true">^org\.mortbay\.jasper:apache-jsp:.*$</gav>
         <cve>CVE-2020-11996</cve>

--- a/jpsonic-main/cve-suppressed.xml
+++ b/jpsonic-main/cve-suppressed.xml
@@ -87,10 +87,4 @@
         <cve>CVE-2020-29245</cve>
     </suppress>
 
-    <suppress>
-        <notes><![CDATA[#899 Temporary suppression is added.]]></notes>
-        <gav regex="true">.*hibernate-validator.*</gav>
-        <cve>CVE-2020-10693</cve>
-    </suppress>
-
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
                 <groupId>org.checkerframework</groupId>
                 <artifactId>checker-qual</artifactId>
                 <scope>compile</scope>
-                <version>3.10.0</version>
+                <version>3.11.0</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jdt</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -445,7 +445,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.40</version>
+                            <version>8.41</version>
                         </dependency>
                     </dependencies>
                     <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.11</version>
+                <version>3.12.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -529,7 +529,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>6.1.1</version>
+                    <version>6.1.2</version>
                     <inherited>true</inherited>
                     <configuration>
                         <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>

--- a/pom.xml
+++ b/pom.xml
@@ -522,7 +522,7 @@
                         <dependency>
                             <groupId>com.github.spotbugs</groupId>
                             <artifactId>spotbugs</artifactId>
-                            <version>4.2.1</version>
+                            <version>4.2.2</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <failOnDependencyWarning>true</failOnDependencyWarning>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <cxf.version>3.4.2</cxf.version>
-        <jackson.version>2.12.1</jackson.version>
+        <jackson.version>2.12.2</jackson.version>
         <tomcat.version>9.0.43</tomcat.version>
         <jetty.schema.version>3.1.2</jetty.schema.version>
         <jetty.version>9.4.38.v20210224</jetty.version>


### PR DESCRIPTION
Includes false positive suppression for CVE-2021-25122 and CVE-2021-25329.
Also remove false positive suppression that is disabled by updating dependency-check-maven, for cleansing cve-suppressed.xml.