### PR TITLE
Change spec for the last modified date, etc

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/TagService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/TagService.java
@@ -82,7 +82,7 @@ public class TagService {
 
         MediaFile file = mediaFileService.getMediaFile(id);
         MetaDataParser parser = metaDataParserFactory.getParser(file.getFile());
-        if (!parser.isEditingSupported(file.getFile())) {
+        if (parser == null || !parser.isEditingSupported(file.getFile())) {
             return "Tag editing of " + FilenameUtils.getExtension(file.getPath()) + " files is not supported.";
         }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/EditTagsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/EditTagsController.java
@@ -115,14 +115,16 @@ public class EditTagsController {
     }
 
     private ParsedSong createParsedSong(MediaFile file, int index) {
-        MetaDataParser parser = metaDataParserFactory.getParser(file.getFile());
         ParsedSong parsedSong = new ParsedSong();
         parsedSong.setId(file.getId());
         parsedSong.setFileName(FilenameUtils.getBaseName(file.getPath()));
         parsedSong.setTrack(file.getTrackNumber());
         parsedSong.setSuggestedTrack(index + 1);
         parsedSong.setTitle(file.getTitle());
-        parsedSong.setSuggestedTitle(parser.guessTitle(file.getFile()));
+        MetaDataParser parser = metaDataParserFactory.getParser(file.getFile());
+        if (parser != null) {
+            parsedSong.setSuggestedTitle(parser.guessTitle(file.getFile()));
+        }
         parsedSong.setArtist(file.getArtist());
         parsedSong.setAlbum(file.getAlbumName());
         parsedSong.setYear(file.getYear());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -668,11 +668,12 @@ public class MediaFileDao extends AbstractDao {
     }
 
     public void resetLastScanned() {
-        update("update media_file set last_scanned = ? where present", ZERO_DATE);
+        update("update media_file set last_scanned = ?, children_last_updated = ? where present", ZERO_DATE, ZERO_DATE);
     }
 
     public void resetLastScanned(int id) {
-        update("update media_file set last_scanned = ? where present and id = ?", ZERO_DATE, id);
+        update("update media_file set last_scanned = ?, children_last_updated = ? where present and id = ?", ZERO_DATE,
+                ZERO_DATE, id);
     }
 
     public void markPresent(String path, Date lastScanned) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileCache.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileCache.java
@@ -20,43 +20,50 @@
 package com.tesshu.jpsonic.service;
 
 import java.io.File;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.tesshu.jpsonic.domain.MediaFile;
 import net.sf.ehcache.Ehcache;
 import net.sf.ehcache.Element;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MediaFileCache {
 
     private final Ehcache mediaFileMemoryCache;
-    private boolean enabled;
+    private AtomicBoolean enabled;
 
     public MediaFileCache(Ehcache mediaFileMemoryCache) {
         super();
         this.mediaFileMemoryCache = mediaFileMemoryCache;
-        enabled = true;
+        enabled = new AtomicBoolean(true);
+    }
+
+    boolean isEnabled() {
+        return enabled.get();
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled.set(enabled);
+        if (!isEnabled()) {
+            mediaFileMemoryCache.removeAll();
+        }
     }
 
     void put(File file, MediaFile mediaFile) {
-        if (enabled) {
+        if (isEnabled()) {
             mediaFileMemoryCache.put(new Element(file, mediaFile));
         }
     }
 
+    @Nullable
     MediaFile get(File file) {
-        if (!enabled) {
+        if (!isEnabled()) {
             return null;
         }
         Element element = mediaFileMemoryCache.get(file);
         return element == null ? null : (MediaFile) element.getObjectValue();
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-        if (!enabled) {
-            mediaFileMemoryCache.removeAll();
-        }
     }
 
     public void removeAll() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
@@ -444,7 +444,7 @@ public class MediaFileService {
         if (file.isFile()) {
             applyFile(file, mediaFile, statistics);
         } else {
-            applyDirectory(file, mediaFile);
+            applyDirectory(file, mediaFile, statistics);
         }
         return mediaFile;
     }
@@ -487,7 +487,7 @@ public class MediaFileService {
         to.setMediaType(getMediaType(to));
     }
 
-    private void applyDirectory(File file, MediaFile to) {
+    private void applyDirectory(File file, MediaFile to, MediaLibraryStatistics... statistics) {
         // Is this an album?
         if (!isRoot(to)) {
             File[] children = FileUtil.listFiles(file);
@@ -499,17 +499,16 @@ public class MediaFileService {
                 to.setMediaType(MediaFile.MediaType.ALBUM);
 
                 // Guess artist/album name, year and genre.
-                MetaDataParser parser = metaDataParserFactory.getParser(firstChildMediaFile);
-                if (parser != null) {
-                    MetaData metaData = parser.getMetaData(firstChildMediaFile);
-                    to.setArtist(metaData.getAlbumArtist());
-                    to.setArtistSort(metaData.getAlbumArtistSort());
-                    to.setArtistSortRaw(metaData.getAlbumArtistSort());
-                    to.setAlbumName(metaData.getAlbumName());
-                    to.setAlbumSort(metaData.getAlbumSort());
-                    to.setAlbumSortRaw(metaData.getAlbumSort());
-                    to.setYear(metaData.getYear());
-                    to.setGenre(metaData.getGenre());
+                MediaFile firstChild = getMediaFile(firstChildMediaFile, false, statistics);
+                if (firstChild != null) {
+                    to.setArtist(firstChild.getAlbumArtist());
+                    to.setArtistSort(firstChild.getAlbumArtistSort());
+                    to.setArtistSortRaw(firstChild.getAlbumArtistSort());
+                    to.setAlbumName(firstChild.getAlbumName());
+                    to.setAlbumSort(firstChild.getAlbumSort());
+                    to.setAlbumSortRaw(firstChild.getAlbumSort());
+                    to.setYear(firstChild.getYear());
+                    to.setGenre(firstChild.getGenre());
                 }
 
                 // Look for cover art.

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
@@ -153,7 +153,7 @@ public class MediaFileService {
         return getMediaFile(mediaFile.getParentPath());
     }
 
-    private boolean isSchemeLastModified() {
+    boolean isSchemeLastModified() {
         return FileModifiedCheckScheme.LAST_MODIFIED == FileModifiedCheckScheme
                 .valueOf(settingsService.getFileModifiedCheckSchemeName());
     }
@@ -311,7 +311,7 @@ public class MediaFileService {
         mediaFile.setStarredDate(starredDate);
     }
 
-    private void updateChildren(MediaFile parent) {
+    void updateChildren(MediaFile parent) {
 
         if (isSchemeLastModified() //
                 && parent.getChildrenLastUpdated().getTime() >= parent.getChanged().getTime()) {
@@ -408,7 +408,7 @@ public class MediaFileService {
                 || "Thumbs.db".equals(name);
     }
 
-    private MediaFile createMediaFile(File file) {
+    MediaFile createMediaFile(File file) {
 
         MediaFile existingFile = mediaFileDao.getMediaFile(file.getPath());
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
@@ -327,7 +327,7 @@ public class MediaFileService {
                 && parent.getChildrenLastUpdated().getTime() >= parent.getChanged().getTime()) {
             return;
         } else if (isSchemeLastScaned() //
-                && parent.getMediaType() == MediaType.ALBUM && !ZERO_DATE.equals(parent.getLastScanned())) {
+                && parent.getMediaType() == MediaType.ALBUM && !ZERO_DATE.equals(parent.getChildrenLastUpdated())) {
             return;
         }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
@@ -41,6 +41,7 @@ import com.tesshu.jpsonic.domain.FileModifiedCheckScheme;
 import com.tesshu.jpsonic.domain.Genre;
 import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.domain.MediaFile.MediaType;
+import com.tesshu.jpsonic.domain.MediaLibraryStatistics;
 import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.domain.RandomSearchCriteria;
 import com.tesshu.jpsonic.service.metadata.MetaData;
@@ -50,6 +51,7 @@ import com.tesshu.jpsonic.service.metadata.ParserUtils;
 import com.tesshu.jpsonic.util.FileUtil;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,7 +94,7 @@ public class MediaFileService {
         return getMediaFile(file, settingsService.isFastCacheEnabled());
     }
 
-    public @Nullable MediaFile getMediaFile(File file, boolean useFastCache) {
+    public @Nullable MediaFile getMediaFile(File file, boolean useFastCache, MediaLibraryStatistics... statistics) {
 
         // Look in fast memory cache first.
         MediaFile result = mediaFileCache.get(file);
@@ -116,7 +118,7 @@ public class MediaFileService {
             return null;
         }
         // Not found in database, must read from disk.
-        result = createMediaFile(file);
+        result = createMediaFile(file, statistics);
 
         // Put in cache and database.
         mediaFileCache.put(file, result);
@@ -163,7 +165,14 @@ public class MediaFileService {
                 .valueOf(settingsService.getFileModifiedCheckSchemeName());
     }
 
-    MediaFile checkLastModified(final MediaFile mediaFile, boolean useFastCache) {
+    long getLastModified(@NonNull File file, MediaLibraryStatistics... statistics) {
+        if (statistics.length == 0 || isSchemeLastModified()) {
+            return FileUtil.lastModified(file);
+        }
+        return statistics[0].getScanDate().getTime();
+    }
+
+    MediaFile checkLastModified(final MediaFile mediaFile, boolean useFastCache, MediaLibraryStatistics... statistics) {
 
         // Determine if the file has not changed
         if (useFastCache) {
@@ -174,7 +183,7 @@ public class MediaFileService {
             switch (scheme) {
             case LAST_MODIFIED:
                 if (!settingsService.isIgnoreFileTimestamps()
-                        && mediaFile.getChanged().getTime() >= FileUtil.lastModified(mediaFile.getFile())
+                        && mediaFile.getChanged().getTime() >= getLastModified(mediaFile.getFile(), statistics)
                         && !ZERO_DATE.equals(mediaFile.getLastScanned())) {
                     return mediaFile;
                 } else if (settingsService.isIgnoreFileTimestamps() && !ZERO_DATE.equals(mediaFile.getLastScanned())) {
@@ -192,18 +201,19 @@ public class MediaFileService {
         }
 
         // Updating database file from disk
-        MediaFile mf = createMediaFile(mediaFile.getFile());
+        MediaFile mf = createMediaFile(mediaFile.getFile(), statistics);
         mediaFileDao.createOrUpdateMediaFile(mf);
         return mf;
     }
 
     public List<MediaFile> getChildrenOf(MediaFile parent, boolean includeFiles, boolean includeDirectories,
-            boolean sort) {
-        return getChildrenOf(parent, includeFiles, includeDirectories, sort, settingsService.isFastCacheEnabled());
+            boolean sort, MediaLibraryStatistics... statistics) {
+        return getChildrenOf(parent, includeFiles, includeDirectories, sort, settingsService.isFastCacheEnabled(),
+                statistics);
     }
 
     public List<MediaFile> getChildrenOf(MediaFile parent, boolean includeFiles, boolean includeDirectories,
-            boolean sort, boolean useFastCache) {
+            boolean sort, boolean useFastCache, MediaLibraryStatistics... statistics) {
 
         if (!parent.isDirectory()) {
             return Collections.emptyList();
@@ -211,7 +221,7 @@ public class MediaFileService {
 
         // Make sure children are stored and up-to-date in the database.
         if (!useFastCache) {
-            updateChildren(parent);
+            updateChildren(parent, statistics);
         }
 
         List<MediaFile> result = new ArrayList<>();
@@ -311,7 +321,7 @@ public class MediaFileService {
         mediaFile.setStarredDate(starredDate);
     }
 
-    void updateChildren(MediaFile parent) {
+    void updateChildren(MediaFile parent, MediaLibraryStatistics... statistics) {
 
         if (isSchemeLastModified() //
                 && parent.getChildrenLastUpdated().getTime() >= parent.getChanged().getTime()) {
@@ -331,7 +341,7 @@ public class MediaFileService {
         for (File child : children) {
             if (storedChildrenMap.remove(child.getPath()) == null) {
                 // Add children that are not already stored.
-                mediaFileDao.createOrUpdateMediaFile(createMediaFile(child));
+                mediaFileDao.createOrUpdateMediaFile(createMediaFile(child, statistics));
             }
         }
 
@@ -408,34 +418,38 @@ public class MediaFileService {
                 || "Thumbs.db".equals(name);
     }
 
-    MediaFile createMediaFile(File file) {
+    MediaFile createMediaFile(File file, MediaLibraryStatistics... statistics) {
 
         MediaFile existingFile = mediaFileDao.getMediaFile(file.getPath());
 
         MediaFile mediaFile = new MediaFile();
-        Date lastModified = new Date(FileUtil.lastModified(file));
+
+        // Variable initial value
+        Date lastModified = new Date(getLastModified(file, statistics));
+        mediaFile.setChanged(lastModified);
+        mediaFile.setCreated(lastModified);
+
+        mediaFile.setLastScanned(existingFile == null ? ZERO_DATE : existingFile.getLastScanned());
+        mediaFile.setChildrenLastUpdated(ZERO_DATE);
+
         mediaFile.setPath(file.getPath());
         mediaFile.setFolder(securityService.getRootFolderForFile(file));
         mediaFile.setParentPath(file.getParent());
-        mediaFile.setChanged(lastModified);
-        mediaFile.setLastScanned(existingFile == null ? ZERO_DATE : existingFile.getLastScanned());
         mediaFile.setPlayCount(existingFile == null ? 0 : existingFile.getPlayCount());
         mediaFile.setLastPlayed(existingFile == null ? null : existingFile.getLastPlayed());
         mediaFile.setComment(existingFile == null ? null : existingFile.getComment());
-        mediaFile.setChildrenLastUpdated(ZERO_DATE);
-        mediaFile.setCreated(lastModified);
         mediaFile.setMediaType(MediaFile.MediaType.DIRECTORY);
         mediaFile.setPresent(true);
 
         if (file.isFile()) {
-            applyFile(file, mediaFile);
+            applyFile(file, mediaFile, statistics);
         } else {
             applyDirectory(file, mediaFile);
         }
         return mediaFile;
     }
 
-    private void applyFile(File file, MediaFile to) {
+    private void applyFile(File file, MediaFile to, MediaLibraryStatistics... statistics) {
         MetaDataParser parser = metaDataParserFactory.getParser(file);
         if (parser != null) {
             MetaData metaData = parser.getMetaData(file);
@@ -465,6 +479,7 @@ public class MediaFileService {
             to.setComposerSort(metaData.getComposerSort());
             to.setComposerSortRaw(metaData.getComposerSort());
             utils.analyze(to);
+            to.setLastScanned(statistics.length == 0 ? new Date() : statistics[0].getScanDate());
         }
         String format = StringUtils.trimToNull(StringUtils.lowerCase(FilenameUtils.getExtension(to.getPath())));
         to.setFormat(format);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaScannerService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaScannerService.java
@@ -283,10 +283,10 @@ public class MediaScannerService {
         indexManager.index(file);
 
         if (file.isDirectory()) {
-            for (MediaFile child : mediaFileService.getChildrenOf(file, true, false, false, false)) {
+            for (MediaFile child : mediaFileService.getChildrenOf(file, true, false, false, false, statistics)) {
                 scanFile(child, musicFolder, statistics, albumCount, genres, isPodcast);
             }
-            for (MediaFile child : mediaFileService.getChildrenOf(file, false, true, false, false)) {
+            for (MediaFile child : mediaFileService.getChildrenOf(file, false, true, false, false, statistics)) {
                 scanFile(child, musicFolder, statistics, albumCount, genres, isPodcast);
             }
         } else {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PodcastService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PodcastService.java
@@ -658,7 +658,7 @@ public class PodcastService {
         MediaFile mediaFile = mediaFileService.getMediaFile(file, false);
         if (StringUtils.isNotBlank(episode.getTitle())) {
             MetaDataParser parser = metaDataParserFactory.getParser(file);
-            if (!parser.isEditingSupported(file)) {
+            if (parser == null || !parser.isEditingSupported(file)) {
                 return;
             }
             MetaData metaData = parser.getRawMetaData(file);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MetaDataParserFactory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MetaDataParserFactory.java
@@ -24,6 +24,7 @@ package com.tesshu.jpsonic.service.metadata;
 import java.io.File;
 import java.util.List;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.springframework.stereotype.Component;
 
 /**
@@ -49,7 +50,7 @@ public class MetaDataParserFactory {
      *
      * @return An applicable parser, or <code>null</code> if no parser is found.
      */
-    public MetaDataParser getParser(File file) {
+    public @Nullable MetaDataParser getParser(File file) {
         for (MetaDataParser parser : parsers) {
             if (parser.isApplicable(file)) {
                 return parser;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaFileServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaFileServiceTest.java
@@ -580,6 +580,25 @@ class MediaFileServiceTest {
             Mockito.verify(mediaFileDao, Mockito.never()).getChildrenOf(Mockito.anyString());
             Mockito.verify(mediaFileDao, Mockito.never()).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
             Mockito.verify(mediaFileDao, Mockito.never()).deleteMediaFile(Mockito.anyString());
+
+            Mockito.when(settingsService.getFileModifiedCheckSchemeName())
+                    .thenReturn(FileModifiedCheckScheme.LAST_SCANNED.name());
+            assertFalse(mediaFileService.isSchemeLastModified());
+
+            /*
+             * If Scheme is set to Last Scaned, Only updated if childrenLastUpdated is zero (zero = initial value or
+             * immediately after reset)
+             */
+            mediaFileService.updateChildren(album);
+            Mockito.verify(mediaFileDao, Mockito.never()).getChildrenOf(Mockito.anyString());
+            Mockito.verify(mediaFileDao, Mockito.never()).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.never()).deleteMediaFile(Mockito.anyString());
+
+            album.setChildrenLastUpdated(ZERO_DATE);
+            mediaFileService.updateChildren(album);
+            Mockito.verify(mediaFileDao, Mockito.times(1)).getChildrenOf(Mockito.anyString());
+            Mockito.verify(mediaFileDao, Mockito.times(3)).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.never()).deleteMediaFile(Mockito.anyString());
         }
     }
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaFileServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaFileServiceTest.java
@@ -750,10 +750,16 @@ class MediaFileServiceTest {
             // Because firstChild is parsed
             Mockito.verify(musicParser, Mockito.times(1)).getMetaData(Mockito.any(File.class));
 
-            Mockito.verify(mediaFileDao, Mockito.never()).createOrUpdateMediaFile(mediaFileCaptor.capture());
+            /*
+             * Because firstChild is registered. Since firstChild is registered at this time, firstChild will not be
+             * parsed when updateChildren is executed.
+             */
+            Mockito.verify(mediaFileDao, Mockito.times(1)).createOrUpdateMediaFile(mediaFileCaptor.capture());
+            // [Windows] assertEquals("02 eyes like dull hazlenuts", mediaFileCaptor.getValue().getName());
+            // [Linux] assertEquals("10 telegraph hill", mediaFileCaptor.getValue().getName());
 
             // 3times [parent, firstChild(before create), firstChild(after create)]
-            Mockito.verify(mediaFileDao, Mockito.times(1)).getMediaFile(pathsCaptor.capture());
+            Mockito.verify(mediaFileDao, Mockito.times(3)).getMediaFile(pathsCaptor.capture());
         }
     }
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaFileServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaFileServiceTest.java
@@ -24,12 +24,13 @@ import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 import java.lang.annotation.Documented;
 import java.net.URISyntaxException;
 import java.util.Date;
@@ -40,11 +41,14 @@ import com.tesshu.jpsonic.dao.AlbumDao;
 import com.tesshu.jpsonic.dao.MediaFileDao;
 import com.tesshu.jpsonic.domain.FileModifiedCheckScheme;
 import com.tesshu.jpsonic.domain.MediaFile;
+import com.tesshu.jpsonic.service.metadata.MetaData;
 import com.tesshu.jpsonic.service.metadata.MetaDataParserFactory;
+import com.tesshu.jpsonic.service.metadata.MusicParser;
 import com.tesshu.jpsonic.util.FileUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 @SuppressWarnings("PMD.TooManyStaticImports")
@@ -53,6 +57,7 @@ class MediaFileServiceTest {
     private SettingsService settingsService;
     private SecurityService securityService;
     private MediaFileDao mediaFileDao;
+    private MetaDataParserFactory metaDataParserFactory;
     private MediaFileService mediaFileService;
     private File dir;
 
@@ -61,10 +66,15 @@ class MediaFileServiceTest {
         settingsService = mock(SettingsService.class);
         securityService = mock(SecurityService.class);
         mediaFileDao = mock(MediaFileDao.class);
+        metaDataParserFactory = mock(MetaDataParserFactory.class);
         mediaFileService = new MediaFileService(settingsService, mock(MusicFolderService.class), securityService,
-                mock(MediaFileCache.class), mediaFileDao, mock(AlbumDao.class), mock(MetaDataParserFactory.class),
+                mock(MediaFileCache.class), mediaFileDao, mock(AlbumDao.class), metaDataParserFactory,
                 mock(MediaFileServiceUtils.class));
         dir = new File(MediaFileServiceTest.class.getResource("/MEDIAS/Music").toURI());
+    }
+
+    private File createFile(String path) throws URISyntaxException {
+        return new File(MediaFileServiceTest.class.getResource(path).toURI());
     }
 
     @Documented
@@ -495,14 +505,166 @@ class MediaFileServiceTest {
     }
 
     @Nested
-    class FindCoverArtTest {
+    class UpdateChildrenTest {
 
-        private File createFile(String path) throws URISyntaxException, IOException {
-            return new File(MediaFileServiceTest.class.getResource(path).toURI());
+        @Test
+        void testUpdateChildren() throws URISyntaxException {
+
+            assertTrue(mediaFileService.isSchemeLastModified());
+
+            Mockito.when(settingsService.getVideoFileTypesAsArray()).thenReturn(new String[0]);
+            Mockito.when(settingsService.getMusicFileTypesAsArray()).thenReturn(new String[] { "mp3" });
+            Mockito.when(securityService.isReadAllowed(Mockito.any(File.class))).thenReturn(true);
+            File dir = createFile("/MEDIAS/Music2/_DIR_ chrome hoof - 2004");
+            assertTrue(dir.isDirectory());
+
+            MediaFile album = mediaFileService.createMediaFile(dir);
+            assertEquals(ZERO_DATE, album.getChildrenLastUpdated());
+            assertThat("Initial value had been assigned to 'changed'.", album.getChanged().getTime(),
+                    greaterThan(album.getChildrenLastUpdated().getTime()));
+            Mockito.clearInvocations(mediaFileDao);
+
+            // Typical case where an update is performed
+            mediaFileService.updateChildren(album);
+            Mockito.verify(mediaFileDao, Mockito.times(1)).getChildrenOf(Mockito.anyString());
+            Mockito.verify(mediaFileDao, Mockito.times(3)).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.never()).deleteMediaFile(Mockito.anyString());
+            Mockito.clearInvocations(mediaFileDao);
+
+            // Typical case where an update isn't performed
+            album.setChildrenLastUpdated(new Date()); // If it has already been executed, etc.
+            mediaFileService.updateChildren(album);
+            Mockito.verify(mediaFileDao, Mockito.never()).getChildrenOf(Mockito.anyString());
+            Mockito.verify(mediaFileDao, Mockito.never()).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.never()).deleteMediaFile(Mockito.anyString());
+        }
+    }
+
+    @Nested
+    class CreateMediaFileTest {
+
+        @Test
+        void testCreateMediaFile() throws URISyntaxException {
+            File file = createFile("/MEDIAS/Music2/_DIR_ chrome hoof - 2004/10 telegraph hill.mp3");
+            assertTrue(file.isFile());
+            assertTrue(mediaFileService.isSchemeLastModified());
+
+            // Newly created case
+            Mockito.when(metaDataParserFactory.getParser(file)).thenReturn(null);
+            Mockito.when(settingsService.getVideoFileTypesAsArray()).thenReturn(new String[0]);
+
+            MediaFile mediaFile = mediaFileService.createMediaFile(file);
+            assertEquals(file.lastModified(), mediaFile.getChanged().getTime());
+            assertEquals(file.lastModified(), mediaFile.getCreated().getTime());
+            assertEquals(ZERO_DATE.getTime(), mediaFile.getLastScanned().getTime());
+            assertEquals(ZERO_DATE.getTime(), mediaFile.getChildrenLastUpdated().getTime());
+            assertEquals(0, mediaFile.getPlayCount());
+            assertNull(mediaFile.getLastPlayed());
+            assertNull(mediaFile.getComment());
+
+            // Update case
+            mediaFile.setPlayCount(100);
+            Date lastPlayed = new Date();
+            mediaFile.setLastPlayed(lastPlayed);
+            mediaFile.setComment("comment");
+            Mockito.when(mediaFileDao.getMediaFile(file.getPath())).thenReturn(mediaFile);
+            mediaFile = mediaFileService.createMediaFile(file);
+            assertEquals(file.lastModified(), mediaFile.getChanged().getTime());
+            assertEquals(file.lastModified(), mediaFile.getCreated().getTime());
+            assertEquals(ZERO_DATE.getTime(), mediaFile.getLastScanned().getTime());
+            assertEquals(ZERO_DATE.getTime(), mediaFile.getChildrenLastUpdated().getTime());
+            assertEquals(100, mediaFile.getPlayCount());
+            assertEquals(lastPlayed.getTime(), mediaFile.getLastPlayed().getTime());
+            assertEquals("comment", mediaFile.getComment());
+
+            Mockito.when(settingsService.getFileModifiedCheckSchemeName())
+                    .thenReturn(FileModifiedCheckScheme.LAST_SCANNED.name());
+            assertFalse(mediaFileService.isSchemeLastModified());
+
+            mediaFile = mediaFileService.createMediaFile(file);
+            assertEquals(file.lastModified(), mediaFile.getChanged().getTime());
+            assertEquals(file.lastModified(), mediaFile.getCreated().getTime());
+            assertEquals(ZERO_DATE.getTime(), mediaFile.getLastScanned().getTime());
+            assertEquals(ZERO_DATE.getTime(), mediaFile.getChildrenLastUpdated().getTime());
         }
 
         @Test
-        void coverArtFileTypesTest() throws ExecutionException, URISyntaxException, IOException {
+        void testApplyFile() throws URISyntaxException {
+            File file = createFile("/MEDIAS/Music2/_DIR_ chrome hoof - 2004/10 telegraph hill.mp3");
+            assertTrue(file.isFile());
+            assertTrue(mediaFileService.isSchemeLastModified());
+
+            // Newly created case
+            MusicParser musicParser = new MusicParser(null);
+            Mockito.when(metaDataParserFactory.getParser(file)).thenReturn(musicParser);
+            Mockito.when(settingsService.getVideoFileTypesAsArray()).thenReturn(new String[0]);
+
+            MediaFile mediaFile = mediaFileService.createMediaFile(file);
+            assertEquals(ZERO_DATE.getTime(), mediaFile.getLastScanned().getTime());
+            assertEquals(ZERO_DATE.getTime(), mediaFile.getChildrenLastUpdated().getTime());
+
+            // Update case
+            Mockito.when(mediaFileDao.getMediaFile(file.getPath())).thenReturn(mediaFile);
+            mediaFile = mediaFileService.createMediaFile(file);
+            assertEquals(ZERO_DATE.getTime(), mediaFile.getLastScanned().getTime());
+            assertEquals(ZERO_DATE.getTime(), mediaFile.getChildrenLastUpdated().getTime());
+        }
+
+        @Test
+        void testApplyDirWithoutChild() throws URISyntaxException {
+            File file = createFile("/MEDIAS/Music2");
+            assertTrue(file.isDirectory());
+            assertTrue(mediaFileService.isSchemeLastModified());
+
+            // Newly created case
+            MusicParser musicParser = new MusicParser(null);
+            Mockito.when(metaDataParserFactory.getParser(file)).thenReturn(musicParser);
+            Mockito.when(settingsService.getVideoFileTypesAsArray()).thenReturn(new String[0]);
+
+            MediaFile mediaFile = mediaFileService.createMediaFile(file);
+            assertEquals(ZERO_DATE.getTime(), mediaFile.getLastScanned().getTime());
+            assertEquals(ZERO_DATE.getTime(), mediaFile.getChildrenLastUpdated().getTime());
+
+            // Update case
+            Mockito.when(mediaFileDao.getMediaFile(file.getPath())).thenReturn(mediaFile);
+            mediaFile = mediaFileService.createMediaFile(file);
+            assertEquals(ZERO_DATE.getTime(), mediaFile.getLastScanned().getTime());
+            assertEquals(ZERO_DATE.getTime(), mediaFile.getChildrenLastUpdated().getTime());
+        }
+
+        @Test
+        void testApplyDirWithChild() throws URISyntaxException {
+            MusicParser musicParser = mock(MusicParser.class);
+            Mockito.when(musicParser.getMetaData(Mockito.any(File.class))).thenReturn(new MetaData());
+            Mockito.when(metaDataParserFactory.getParser(Mockito.any(File.class))).thenReturn(musicParser);
+            Mockito.when(settingsService.getVideoFileTypesAsArray()).thenReturn(new String[0]);
+            Mockito.when(settingsService.getMusicFileTypesAsArray()).thenReturn(new String[] { "mp3" });
+            Mockito.when(securityService.isReadAllowed(Mockito.any(File.class))).thenReturn(true);
+
+            File dir = createFile("/MEDIAS/Music2/_DIR_ chrome hoof - 2004");
+            assertTrue(dir.isDirectory());
+            assertTrue(mediaFileService.isSchemeLastModified());
+
+            final ArgumentCaptor<String> pathsCaptor = ArgumentCaptor.forClass(String.class);
+            final ArgumentCaptor<MediaFile> mediaFileCaptor = ArgumentCaptor.forClass(MediaFile.class);
+
+            mediaFileService.createMediaFile(dir);
+
+            // Because firstChild is parsed
+            Mockito.verify(musicParser, Mockito.times(1)).getMetaData(Mockito.any(File.class));
+
+            Mockito.verify(mediaFileDao, Mockito.never()).createOrUpdateMediaFile(mediaFileCaptor.capture());
+
+            // 3times [parent, firstChild(before create), firstChild(after create)]
+            Mockito.verify(mediaFileDao, Mockito.times(1)).getMediaFile(pathsCaptor.capture());
+        }
+    }
+
+    @Nested
+    class FindCoverArtTest {
+
+        @Test
+        void coverArtFileTypesTest() throws ExecutionException, URISyntaxException {
             // fileNames
             File file = createFile("/MEDIAS/Metadata/coverart/cover.jpg");
             assertEquals(file, mediaFileService.findCoverArt(file).get());
@@ -539,7 +701,7 @@ class MediaFileServiceTest {
         }
 
         @Test
-        void testIsEmbeddedArtworkApplicable() throws ExecutionException, URISyntaxException, IOException {
+        void testIsEmbeddedArtworkApplicable() throws ExecutionException, URISyntaxException {
 
             Mockito.when(securityService.isReadAllowed(Mockito.any(File.class))).thenReturn(true);
             Mockito.when(settingsService.isFastCacheEnabled()).thenReturn(true);


### PR DESCRIPTION
Related #1414

 - Add test cases
 - When creating MediaFile, it is modified so that either the last modification date of the file or the scan execution time is used depending on the settings by User.
 - Fix updateChildren to use childrenLastUpdated instead of lastScanned to determine if an album has been scanned
 - Delete duplicate parse processing of createMediaFile