### PR TITLE
NIO2 Migration (#1446)

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/CoverArtService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/CoverArtService.java
@@ -143,7 +143,7 @@ public class CoverArtService {
     }
 
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops") // (File) Not reusable
-    private void renameWithoutReplacement(MediaFile mediaFile, File newCoverFile) throws IOException {
+    void renameWithoutReplacement(MediaFile mediaFile, File newCoverFile) throws IOException {
         MediaFile dir = mediaFile;
         while (true) {
             File coverFile = mediaFileService.getCoverArt(dir);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/CoverArtService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/CoverArtService.java
@@ -89,7 +89,7 @@ public class CoverArtService {
     public String saveCoverArtImage(int albumId, String url) {
         try {
             MediaFile mediaFile = mediaFileService.getMediaFile(albumId);
-            saveCoverArt(mediaFile.getPath(), url);
+            saveCoverArt(mediaFile.getPathString(), url);
             return null;
         } catch (ExecutionException e) {
             ConcurrentUtils.handleCauseUnchecked(e);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/TagService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/TagService.java
@@ -21,6 +21,7 @@
 
 package com.tesshu.jpsonic.ajax;
 
+import java.nio.file.Path;
 import java.util.Objects;
 import java.util.concurrent.CompletionException;
 
@@ -81,8 +82,9 @@ public class TagService {
             String yearStr, String genreStr) {
 
         MediaFile file = mediaFileService.getMediaFile(id);
-        MetaDataParser parser = metaDataParserFactory.getParser(file.getFile());
-        if (parser == null || !parser.isEditingSupported(file.getFile())) {
+        Path path = file.toPath();
+        MetaDataParser parser = metaDataParserFactory.getParser(path);
+        if (parser == null || !parser.isEditingSupported(path)) {
             return "Tag editing of " + FilenameUtils.getExtension(file.getPathString()) + " files is not supported.";
         }
 
@@ -100,7 +102,7 @@ public class TagService {
             return "SKIPPED";
         }
 
-        MetaData newMetaData = parser.getMetaData(file.getFile());
+        MetaData newMetaData = parser.getMetaData(path);
 
         // Note: album artist is intentionally set, as it is not user-changeable.
         newMetaData.setArtist(artist);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/TagService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/TagService.java
@@ -83,7 +83,7 @@ public class TagService {
         MediaFile file = mediaFileService.getMediaFile(id);
         MetaDataParser parser = metaDataParserFactory.getParser(file.getFile());
         if (parser == null || !parser.isEditingSupported(file.getFile())) {
-            return "Tag editing of " + FilenameUtils.getExtension(file.getPath()) + " files is not supported.";
+            return "Tag editing of " + FilenameUtils.getExtension(file.getPathString()) + " files is not supported.";
         }
 
         String artist = StringUtils.trimToNull(artistStr);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/ChangeCoverArtController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/ChangeCoverArtController.java
@@ -84,7 +84,7 @@ public class ChangeCoverArtController {
 
     private List<MediaFile> getAncestors(MediaFile dir) {
         LinkedList<MediaFile> result = new LinkedList<>();
-        if (securityService.isInPodcastFolder(dir.getFile())) {
+        if (securityService.isInPodcastFolder(dir.toPath())) {
             // For podcasts, don't use ancestors
             return result;
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/CoverArtController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/CoverArtController.java
@@ -32,8 +32,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -231,7 +232,7 @@ public class CoverArtController {
 
     private void sendImage(File file, HttpServletResponse response) throws ExecutionException {
         response.setContentType(StringUtil.getMimeType(FilenameUtils.getExtension(file.getName())));
-        try (InputStream in = Files.newInputStream(Paths.get(file.toURI()))) {
+        try (InputStream in = Files.newInputStream(file.toPath())) {
             IOUtils.copy(in, response.getOutputStream());
         } catch (IOException e) {
             throw new ExecutionException("Cannot copy image: " + file.getPath(), e);
@@ -258,13 +259,13 @@ public class CoverArtController {
     }
 
     void sendUnscaled(CoverArtRequest coverArtRequest, HttpServletResponse response) throws ExecutionException {
-        File file = coverArtRequest.getCoverArt();
-        Pair<InputStream, String> imageInputStreamWithType = getImageInputStreamWithType(file);
+        Path path = coverArtRequest.getCoverArt();
+        Pair<InputStream, String> imageInputStreamWithType = getImageInputStreamWithType(path);
         response.setContentType(imageInputStreamWithType.getRight());
         try (InputStream in = imageInputStreamWithType.getLeft()) {
             IOUtils.copy(in, response.getOutputStream());
         } catch (IOException e) {
-            throw new ExecutionException("Cannot copy image: " + file.getPath(), e);
+            throw new ExecutionException("Cannot copy image: " + path, e);
         }
     }
 
@@ -280,7 +281,7 @@ public class CoverArtController {
         synchronized (IMG_LOCKS.get(lockKey)) {
             if (IMG_LOCKS.get(lockKey) != null && IMG_LOCKS.get(lockKey).equals(lock)
                     && (!cachedImage.exists() || request.lastModified() > cachedImage.lastModified())) {
-                try (OutputStream out = Files.newOutputStream(Paths.get(cachedImage.toURI()))) {
+                try (OutputStream out = Files.newOutputStream(cachedImage.toPath())) {
                     semaphore.acquire();
                     BufferedImage image = request.createImage(size);
                     ImageIO.write(image, encoding, out);
@@ -303,8 +304,8 @@ public class CoverArtController {
      * returned.
      */
     @NonNull
-    InputStream getImageInputStream(File file) throws ExecutionException {
-        return getImageInputStreamWithType(file).getLeft();
+    InputStream getImageInputStream(Path path) throws ExecutionException {
+        return getImageInputStreamWithType(path).getLeft();
     }
 
     /**
@@ -317,22 +318,22 @@ public class CoverArtController {
      * calling this method auto-closes the resource after this method completes.
      */
     @NonNull
-    Pair<InputStream, String> getImageInputStreamWithType(File file) throws ExecutionException {
+    Pair<InputStream, String> getImageInputStreamWithType(Path path) throws ExecutionException {
 
-        if (!ParserUtils.isEmbeddedArtworkApplicable(file)) {
+        if (!ParserUtils.isEmbeddedArtworkApplicable(path)) {
             InputStream is;
             try {
-                is = Files.newInputStream(Paths.get(file.toURI()));
+                is = Files.newInputStream(path);
             } catch (IOException e) {
-                throw new ExecutionException("Image cannot be read: " + file.getPath(), e);
+                throw new ExecutionException("Image cannot be read: " + path, e);
             }
-            String mimeType = StringUtil.getMimeType(FilenameUtils.getExtension(file.getName()));
+            String mimeType = StringUtil.getMimeType(FilenameUtils.getExtension(path.getFileName().toString()));
             return Pair.of(is, mimeType);
         }
 
-        Optional<Artwork> op = ParserUtils.getEmbeddedArtwork(file);
+        Optional<Artwork> op = ParserUtils.getEmbeddedArtwork(path);
         if (op.isEmpty()) {
-            throw new ExecutionException(new IOException("Embeded image cannot be read: " + file.getPath()));
+            throw new ExecutionException(new IOException("Embeded image cannot be read: " + path));
         }
 
         Artwork artwork = op.get();
@@ -341,7 +342,7 @@ public class CoverArtController {
 
     @Nullable
     BufferedImage getImageInputStreamForVideo(MediaFile mediaFile, int width, int height, int offset) {
-        return ffmpeg.createImage(mediaFile.getFile(), width, height, offset);
+        return ffmpeg.createImage(mediaFile.toPath(), width, height, offset);
     }
 
     private File getImageCacheDirectory(int size) {
@@ -395,20 +396,28 @@ public class CoverArtController {
 
     private abstract class CoverArtRequest {
 
-        protected File coverArt;
+        protected Path coverArt;
 
         private CoverArtRequest() {
         }
 
         private CoverArtRequest(String coverArtPath) {
-            this.coverArt = coverArtPath == null ? null : new File(coverArtPath);
+            this.coverArt = coverArtPath == null ? null : Path.of(coverArtPath);
         }
 
-        private File getCoverArt() {
+        private Path getCoverArt() {
             return coverArt;
         }
 
         public abstract String getKey();
+
+        long getLastModified(Path path) {
+            try {
+                return Files.getLastModifiedTime(path).toMillis();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
 
         public abstract long lastModified();
 
@@ -470,7 +479,7 @@ public class CoverArtController {
 
         @Override
         public long lastModified() {
-            return coverArt == null ? artist.getLastScanned().getTime() : coverArt.lastModified();
+            return coverArt == null ? artist.getLastScanned().getTime() : getLastModified(coverArt);
         }
 
         @Override
@@ -500,7 +509,7 @@ public class CoverArtController {
 
         @Override
         public long lastModified() {
-            return coverArt == null ? album.getLastScanned().getTime() : coverArt.lastModified();
+            return coverArt == null ? album.getLastScanned().getTime() : getLastModified(coverArt);
         }
 
         @Override
@@ -621,12 +630,12 @@ public class CoverArtController {
 
         @Override
         public String getKey() {
-            return coverArt == null ? dir.getPathString() : coverArt.getPath();
+            return coverArt == null ? dir.getPathString() : coverArt.toString();
         }
 
         @Override
         public long lastModified() {
-            return coverArt == null ? dir.getChanged().getTime() : coverArt.lastModified();
+            return coverArt == null ? dir.getChanged().getTime() : getLastModified(coverArt);
         }
 
         @Override

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/CoverArtController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/CoverArtController.java
@@ -454,7 +454,7 @@ public class CoverArtController {
         public abstract String getArtist();
     }
 
-    private class ArtistCoverArtRequest extends CoverArtRequest {
+    class ArtistCoverArtRequest extends CoverArtRequest {
 
         private final Artist artist;
 
@@ -484,7 +484,7 @@ public class CoverArtController {
         }
     }
 
-    private class AlbumCoverArtRequest extends CoverArtRequest {
+    class AlbumCoverArtRequest extends CoverArtRequest {
 
         private final Album album;
 
@@ -514,7 +514,7 @@ public class CoverArtController {
         }
     }
 
-    private class PlaylistCoverArtRequest extends CoverArtRequest {
+    class PlaylistCoverArtRequest extends CoverArtRequest {
 
         private static final int IMAGE_COMPOSITES_THRESHOLD = 4;
 
@@ -579,7 +579,7 @@ public class CoverArtController {
         }
     }
 
-    private class PodcastCoverArtRequest extends CoverArtRequest {
+    class PodcastCoverArtRequest extends CoverArtRequest {
 
         private final PodcastChannel channel;
 
@@ -640,7 +640,7 @@ public class CoverArtController {
         }
     }
 
-    private class VideoCoverArtRequest extends CoverArtRequest {
+    class VideoCoverArtRequest extends CoverArtRequest {
 
         private final MediaFile mediaFile;
         private final int offset;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/CoverArtController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/CoverArtController.java
@@ -614,14 +614,14 @@ public class CoverArtController {
         private final MediaFile dir;
 
         MediaFileCoverArtRequest(MediaFile mediaFile) {
-            super(mediaFile.getCoverArtPath());
+            super(mediaFile.getCoverArtPathString());
             dir = mediaFile.isDirectory() ? mediaFile : mediaFileService.getParentOf(mediaFile);
             coverArt = mediaFileService.getCoverArt(mediaFile);
         }
 
         @Override
         public String getKey() {
-            return coverArt == null ? dir.getPath() : coverArt.getPath();
+            return coverArt == null ? dir.getPathString() : coverArt.getPath();
         }
 
         @Override
@@ -646,7 +646,7 @@ public class CoverArtController {
         private final int offset;
 
         VideoCoverArtRequest(MediaFile mediaFile, int offset) {
-            super(mediaFile.getCoverArtPath());
+            super(mediaFile.getCoverArtPathString());
             this.mediaFile = mediaFile;
             this.offset = offset;
         }
@@ -669,7 +669,7 @@ public class CoverArtController {
 
         @Override
         public String getKey() {
-            return mediaFile.getPath() + "/" + offset;
+            return mediaFile.getPathString() + "/" + offset;
         }
 
         @Override

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DownloadController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DownloadController.java
@@ -178,7 +178,7 @@ public class DownloadController {
             downloadFile(response, status, mediaFile.getFile(), range);
         } else {
             List<MediaFile> children = mediaFileService.getChildrenOf(mediaFile, true, false, true);
-            String zipFileName = FilenameUtils.getBaseName(mediaFile.getPath()) + ".zip";
+            String zipFileName = FilenameUtils.getBaseName(mediaFile.getPathString()) + ".zip";
             File coverArtFile = indexes == null ? mediaFile.getCoverArtFile() : null;
             downloadFiles(response, status, children, indexes, coverArtFile, range, zipFileName);
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/EditTagsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/EditTagsController.java
@@ -21,6 +21,7 @@
 
 package com.tesshu.jpsonic.controller;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -100,7 +101,7 @@ public class EditTagsController {
 
     private List<MediaFile> getAncestors(MediaFile dir) {
         LinkedList<MediaFile> result = new LinkedList<>();
-        if (securityService.isInPodcastFolder(dir.getFile())) {
+        if (securityService.isInPodcastFolder(dir.toPath())) {
             // For podcasts, don't use ancestors
             return result;
         }
@@ -121,9 +122,10 @@ public class EditTagsController {
         parsedSong.setTrack(file.getTrackNumber());
         parsedSong.setSuggestedTrack(index + 1);
         parsedSong.setTitle(file.getTitle());
-        MetaDataParser parser = metaDataParserFactory.getParser(file.getFile());
+        Path path = file.toPath();
+        MetaDataParser parser = metaDataParserFactory.getParser(path);
         if (parser != null) {
-            parsedSong.setSuggestedTitle(parser.guessTitle(file.getFile()));
+            parsedSong.setSuggestedTitle(parser.guessTitle(path));
         }
         parsedSong.setArtist(file.getArtist());
         parsedSong.setAlbum(file.getAlbumName());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/EditTagsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/EditTagsController.java
@@ -117,7 +117,7 @@ public class EditTagsController {
     private ParsedSong createParsedSong(MediaFile file, int index) {
         ParsedSong parsedSong = new ParsedSong();
         parsedSong.setId(file.getId());
-        parsedSong.setFileName(FilenameUtils.getBaseName(file.getPath()));
+        parsedSong.setFileName(FilenameUtils.getBaseName(file.getPathString()));
         parsedSong.setTrack(file.getTrackNumber());
         parsedSong.setSuggestedTrack(index + 1);
         parsedSong.setTitle(file.getTitle());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/ExternalPlayerController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/ExternalPlayerController.java
@@ -138,7 +138,7 @@ public class ExternalPlayerController {
 
         if (share != null) {
             for (MediaFile file : shareService.getSharedFiles(share.getId(), musicFolders)) {
-                if (file.getFile().exists()) {
+                if (file.exists()) {
                     if (file.isDirectory()) {
                         List<MediaFile> childrenOf = mediaFileService.getChildrenOf(file, true, false, true);
                         result.addAll(childrenOf.stream().map(mf -> addUrlInfo(request, player, mf, finalExpires))

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/HomeController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/HomeController.java
@@ -280,10 +280,10 @@ public class HomeController {
     private Album createAlbum(MediaFile file) {
         Album album = new Album();
         album.setId(file.getId());
-        album.setPath(file.getPath());
+        album.setPath(file.getPathString());
         album.setArtist(file.getArtist());
         album.setAlbumTitle(file.getAlbumName());
-        album.setCoverArtPath(file.getCoverArtPath());
+        album.setCoverArtPath(file.getCoverArtPathString());
         return album;
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MainController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MainController.java
@@ -112,7 +112,7 @@ public class MainController {
         map.put("userRating", getUserRating(username, dir));
         map.put("averageRating", getAverageRating(dir));
         map.put("starred", mediaFileService.getMediaFileStarredDate(dir.getId(), username) != null);
-        if (!securityService.isInPodcastFolder(dir.getFile())) {
+        if (!securityService.isInPodcastFolder(dir.toPath())) {
             MediaFile parent = mediaFileService.getParentOf(dir);
             map.put("parent", parent);
             map.put("navigateUpAllowed", !mediaFileService.isRoot(parent));
@@ -293,7 +293,7 @@ public class MainController {
 
     private List<MediaFile> getAncestors(MediaFile dir) {
         LinkedList<MediaFile> result = new LinkedList<>();
-        if (securityService.isInPodcastFolder(dir.getFile())) {
+        if (securityService.isInPodcastFolder(dir.toPath())) {
             // For podcasts, don't use ancestors
             return result;
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/NowPlayingController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/NowPlayingController.java
@@ -68,7 +68,8 @@ public class NowPlayingController {
         Player player = playerService.getPlayer(request, response);
         List<TransferStatus> statuses = statusService.getStreamStatusesForPlayer(player);
 
-        MediaFile current = statuses.isEmpty() ? null : mediaFileService.getMediaFile(statuses.get(0).getFile());
+        MediaFile current = statuses.isEmpty() ? null
+                : mediaFileService.getMediaFile(statuses.get(0).getFile().toPath());
         MediaFile dir = current == null ? null : mediaFileService.getParentOf(current);
 
         String url;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StatusController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StatusController.java
@@ -143,7 +143,7 @@ public class StatusController {
         }
 
         public String getPath() {
-            return FileUtil.getShortPath(transferStatus.getFile());
+            return FileUtil.getShortPath(transferStatus.getFile().toPath());
         }
 
         public String getBytes() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StreamController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StreamController.java
@@ -286,13 +286,13 @@ public class StreamController {
 
     private static void writeVerboseLog(boolean verbose, boolean isHeaderRequest, MediaFile file) {
         if (verbose && isHeaderRequest && LOG.isInfoEnabled()) {
-            LOG.info("Header request for [{}]", file.getPath());
+            LOG.info("Header request for [{}]", file.getPathString());
         }
     }
 
     private static void writeVerboseLog(boolean verbose, HttpServletResponse response, MediaFile file) {
         if (verbose && LOG.isInfoEnabled()) {
-            LOG.info("Streaming request for [{}] with range [{}]", file.getPath(), response.getHeader("Content-Range"));
+            LOG.info("Streaming request for [{}] with range [{}]", file.getPathString(), response.getHeader("Content-Range"));
         }
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StreamController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StreamController.java
@@ -286,13 +286,13 @@ public class StreamController {
 
     private static void writeVerboseLog(boolean verbose, boolean isHeaderRequest, MediaFile file) {
         if (verbose && isHeaderRequest && LOG.isInfoEnabled()) {
-            LOG.info("Header request for [{}]", file.getPathString());
+            LOG.info("Header request for [{}]", file.toPath());
         }
     }
 
     private static void writeVerboseLog(boolean verbose, HttpServletResponse response, MediaFile file) {
         if (verbose && LOG.isInfoEnabled()) {
-            LOG.info("Streaming request for [{}] with range [{}]", file.getPathString(), response.getHeader("Content-Range"));
+            LOG.info("Streaming request for [{}] with range [{}]", file.toPath(), response.getHeader("Content-Range"));
         }
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SubsonicRESTController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SubsonicRESTController.java
@@ -1430,7 +1430,7 @@ public class SubsonicRESTController {
 
     private String findCoverArt(MediaFile mediaFile, MediaFile parent) {
         MediaFile dir = mediaFile.isDirectory() ? mediaFile : parent;
-        if (dir != null && dir.getCoverArtPath() != null) {
+        if (dir != null && dir.getCoverArtPathString() != null) {
             return String.valueOf(dir.getId());
         }
         return null;
@@ -1439,7 +1439,7 @@ public class SubsonicRESTController {
     public static String getRelativePath(MediaFile musicFile, SettingsService settingsService,
             MusicFolderService musicFolderService) {
 
-        String filePath = musicFile.getPath();
+        String filePath = musicFile.getPathString();
 
         // Convert slashes.
         filePath = filePath.replace('\\', '/');

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/UploadController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/UploadController.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -235,7 +234,7 @@ public class UploadController {
      * [AvoidCatchingGenericException] Wrap&Throw due to constraints of 'apache commons' {@link FileItem#write(File)}
      */
     private void addUploadedFile(FileItem targetItem, File targetFile, List<File> to) throws ExecutionException {
-        if (!securityService.isUploadAllowed(targetFile)) {
+        if (!securityService.isUploadAllowed(targetFile.toPath())) {
             throw new ExecutionException(new GeneralSecurityException(
                     "Permission denied: " + StringEscapeUtils.escapeHtml4(targetFile.getPath())));
         }
@@ -282,7 +281,7 @@ public class UploadController {
 
     private List<File> unzip(ZipFile zipFile, ZipEntry entry, File entryFile) throws ExecutionException {
 
-        if (!securityService.isUploadAllowed(entryFile)) {
+        if (!securityService.isUploadAllowed(entryFile.toPath())) {
             throw new ExecutionException(new GeneralSecurityException(
                     "Permission denied: " + StringEscapeUtils.escapeHtml4(entryFile.getPath())));
         }
@@ -292,7 +291,7 @@ public class UploadController {
         }
 
         List<File> unzippedFiles = new ArrayList<>();
-        try (OutputStream outputStream = Files.newOutputStream(Paths.get(entryFile.toURI()));
+        try (OutputStream outputStream = Files.newOutputStream(entryFile.toPath());
                 InputStream inputStream = zipFile.getInputStream(entry)) {
             byte[] buf = new byte[8192];
             while (true) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/VideoPlayerController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/VideoPlayerController.java
@@ -105,7 +105,7 @@ public class VideoPlayerController {
         map.put("isShowDownload", userSettings.isShowDownload());
         map.put("isShowShare", userSettings.isShowShare());
 
-        if (!securityService.isInPodcastFolder(dir.getFile())) {
+        if (!securityService.isInPodcastFolder(dir.toPath())) {
             MediaFile parent = mediaFileService.getParentOf(file);
             map.put("parent", parent);
             map.put("navigateUpAllowed", !mediaFileService.isRoot(parent));

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AlbumDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AlbumDao.java
@@ -107,7 +107,7 @@ public class AlbumDao extends AbstractDao {
 
         // Look for album with the same path as the file.
         for (Album candidate : candidates) {
-            if (Objects.equals(candidate.getPath(), file.getParentPath())) {
+            if (Objects.equals(candidate.getPath(), file.getParentPathString())) {
                 return candidate;
             }
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AlbumDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AlbumDao.java
@@ -21,6 +21,8 @@
 
 package com.tesshu.jpsonic.dao;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collections;
@@ -33,7 +35,6 @@ import java.util.stream.Collectors;
 import com.tesshu.jpsonic.domain.Album;
 import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.domain.MusicFolder;
-import com.tesshu.jpsonic.util.FileUtil;
 import com.tesshu.jpsonic.util.LegacyMap;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
@@ -100,7 +101,7 @@ public class AlbumDao extends AbstractDao {
 
         // Look for album with the correct artist.
         for (Album candidate : candidates) {
-            if (Objects.equals(candidate.getArtist(), file.getArtist()) && FileUtil.exists(candidate.getPath())) {
+            if (Objects.equals(candidate.getArtist(), file.getArtist()) && Files.exists(Path.of(candidate.getPath()))) {
                 return candidate;
             }
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/JMediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/JMediaFileDao.java
@@ -294,7 +294,7 @@ public class JMediaFileDao extends AbstractDao {
         return query(
                 "select " + getQueryColoms() + " from media_file "
                         + "where parent_path=? and present and type in (?,?,?) order by track_number limit ? offset ?",
-                rowMapper, album.getPath(), MediaType.MUSIC.name(), MediaType.AUDIOBOOK.name(),
+                rowMapper, album.getPathString(), MediaType.MUSIC.name(), MediaType.AUDIOBOOK.name(),
                 MediaType.PODCAST.name(), count, offset);
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -203,8 +203,8 @@ public class MediaFileDao extends AbstractDao {
             }
 
             update("insert into media_file (" + INSERT_COLUMNS + ") values (" + questionMarks(INSERT_COLUMNS) + ")",
-                    file.getPathString(), file.getFolder(), file.getMediaType().name(), file.getFormat(), file.getTitle(),
-                    file.getAlbumName(), file.getArtist(), file.getAlbumArtist(), file.getDiscNumber(),
+                    file.getPathString(), file.getFolder(), file.getMediaType().name(), file.getFormat(),
+                    file.getTitle(), file.getAlbumName(), file.getArtist(), file.getAlbumArtist(), file.getDiscNumber(),
                     file.getTrackNumber(), file.getYear(), file.getGenre(), file.getBitRate(), file.isVariableBitRate(),
                     file.getDurationSeconds(), file.getFileSize(), file.getWidth(), file.getHeight(),
                     file.getCoverArtPathString(), file.getParentPathString(), file.getPlayCount(), file.getLastPlayed(),

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -161,7 +161,7 @@ public class MediaFileDao extends AbstractDao {
     @Transactional
     public void createOrUpdateMediaFile(MediaFile file) {
         if (LOG.isTraceEnabled()) {
-            LOG.trace("Creating/Updating new media file at {}", file.getPath());
+            LOG.trace("Creating/Updating new media file at {}", file.getPathString());
         }
         String sql = "update media_file set " + "folder=?," + "type=?," + "format=?," + "title=?," + "album=?,"
                 + "artist=?," + "album_artist=?," + "disc_number=?," + "track_number=?," + "year=?," + "genre=?,"
@@ -183,7 +183,7 @@ public class MediaFileDao extends AbstractDao {
                 file.getAlbumName(), file.getArtist(), file.getAlbumArtist(), file.getDiscNumber(),
                 file.getTrackNumber(), file.getYear(), file.getGenre(), file.getBitRate(), file.isVariableBitRate(),
                 file.getDurationSeconds(), file.getFileSize(), file.getWidth(), file.getHeight(),
-                file.getCoverArtPath(), file.getParentPath(), file.getPlayCount(), file.getLastPlayed(),
+                file.getCoverArtPathString(), file.getParentPathString(), file.getPlayCount(), file.getLastPlayed(),
                 file.getComment(), file.getChanged(), file.getLastScanned(), file.getChildrenLastUpdated(),
                 file.isPresent(), VERSION, file.getMusicBrainzReleaseId(), file.getMusicBrainzRecordingId(),
                 // JP >>>>
@@ -191,11 +191,11 @@ public class MediaFileDao extends AbstractDao {
                 file.getAlbumArtistSort(), file.getComposerSort(), file.getArtistReading(), file.getAlbumReading(),
                 file.getAlbumArtistReading(), file.getArtistSortRaw(), file.getAlbumSortRaw(),
                 file.getAlbumArtistSortRaw(), file.getComposerSortRaw(), file.getOrder(), // <<<< JP
-                file.getPath());
+                file.getPathString());
         if (n == 0) {
 
             // Copy values from obsolete table music_file_info.
-            MediaFile musicFileInfo = getMusicFileInfo(file.getPath());
+            MediaFile musicFileInfo = getMusicFileInfo(file.getPathString());
             if (musicFileInfo != null) {
                 file.setComment(musicFileInfo.getComment());
                 file.setLastPlayed(musicFileInfo.getLastPlayed());
@@ -203,11 +203,11 @@ public class MediaFileDao extends AbstractDao {
             }
 
             update("insert into media_file (" + INSERT_COLUMNS + ") values (" + questionMarks(INSERT_COLUMNS) + ")",
-                    file.getPath(), file.getFolder(), file.getMediaType().name(), file.getFormat(), file.getTitle(),
+                    file.getPathString(), file.getFolder(), file.getMediaType().name(), file.getFormat(), file.getTitle(),
                     file.getAlbumName(), file.getArtist(), file.getAlbumArtist(), file.getDiscNumber(),
                     file.getTrackNumber(), file.getYear(), file.getGenre(), file.getBitRate(), file.isVariableBitRate(),
                     file.getDurationSeconds(), file.getFileSize(), file.getWidth(), file.getHeight(),
-                    file.getCoverArtPath(), file.getParentPath(), file.getPlayCount(), file.getLastPlayed(),
+                    file.getCoverArtPathString(), file.getParentPathString(), file.getPlayCount(), file.getLastPlayed(),
                     file.getComment(), file.getCreated(), file.getChanged(), file.getLastScanned(),
                     file.getChildrenLastUpdated(), file.isPresent(), VERSION, file.getMusicBrainzReleaseId(),
                     file.getMusicBrainzRecordingId(),
@@ -218,7 +218,7 @@ public class MediaFileDao extends AbstractDao {
                     file.getAlbumArtistSortRaw(), file.getComposerSortRaw(), -1); // <<<< JP
         }
 
-        int id = queryForInt("select id from media_file where path=?", null, file.getPath());
+        int id = queryForInt("select id from media_file where path=?", null, file.getPathString());
         file.setId(id);
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/RatingDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/RatingDao.java
@@ -84,9 +84,9 @@ public class RatingDao extends AbstractDao {
             return;
         }
 
-        update("delete from user_rating where username=? and path=?", username, mediaFile.getPath());
+        update("delete from user_rating where username=? and path=?", username, mediaFile.getPathString());
         if (rating != null) {
-            update("insert into user_rating values(?, ?, ?)", username, mediaFile.getPath(), rating);
+            update("insert into user_rating values(?, ?, ?)", username, mediaFile.getPathString(), rating);
         }
     }
 
@@ -101,7 +101,7 @@ public class RatingDao extends AbstractDao {
     public Double getAverageRating(MediaFile mediaFile) {
         try {
             return getJdbcTemplate().queryForObject("select avg(rating) from user_rating where path=?", Double.class,
-                    new Object[] { mediaFile.getPath() });
+                    new Object[] { mediaFile.getPathString() });
         } catch (EmptyResultDataAccessException x) {
             return null;
         }
@@ -120,7 +120,7 @@ public class RatingDao extends AbstractDao {
     public Integer getRatingForUser(String username, MediaFile mediaFile) {
         try {
             return getJdbcTemplate().queryForObject("select rating from user_rating where username=? and path=?",
-                    Integer.class, new Object[] { username, mediaFile.getPath() });
+                    Integer.class, new Object[] { username, mediaFile.getPathString() });
         } catch (EmptyResultDataAccessException x) {
             return null;
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/JpMediaFileComparator.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/JpMediaFileComparator.java
@@ -73,7 +73,7 @@ class JpMediaFileComparator implements MediaFileComparator {
             return i;
         }
 
-        return comparator.compare(a.getPath(), b.getPath());
+        return comparator.compare(a.getPathString(), b.getPathString());
     }
 
     private int compareDirectoryAndFile(MediaFile a, MediaFile b) {
@@ -106,7 +106,7 @@ class JpMediaFileComparator implements MediaFileComparator {
         } else {
             n = comparator.compare(a.getName(), b.getName());
         }
-        return n == 0 ? comparator.compare(a.getPath(), b.getPath()) : n; // To make it consistent to
+        return n == 0 ? comparator.compare(a.getPathString(), b.getPathString()) : n; // To make it consistent to
                                                                           // MediaFile.equals()
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/JpMediaFileComparator.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/JpMediaFileComparator.java
@@ -107,7 +107,7 @@ class JpMediaFileComparator implements MediaFileComparator {
             n = comparator.compare(a.getName(), b.getName());
         }
         return n == 0 ? comparator.compare(a.getPathString(), b.getPathString()) : n; // To make it consistent to
-                                                                          // MediaFile.equals()
+        // MediaFile.equals()
     }
 
     private <T extends Comparable<T>> int nullSafeCompare(T a, T b, boolean nullIsSmaller) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaFile.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaFile.java
@@ -171,8 +171,8 @@ public class MediaFile {
         this.folder = folder;
     }
 
+    @Deprecated
     public File getFile() {
-        // TODO: Optimize
         return new File(path);
     }
 
@@ -359,6 +359,7 @@ public class MediaFile {
         this.parentPath = parentPath;
     }
 
+    @Deprecated
     public File getParentFile() {
         return getFile().getParentFile();
     }
@@ -468,8 +469,8 @@ public class MediaFile {
         return path.hashCode();
     }
 
+    @Deprecated
     public File getCoverArtFile() {
-        // TODO: Optimize
         return coverArtPath == null ? null : new File(coverArtPath);
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaFile.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaFile.java
@@ -22,12 +22,14 @@
 package com.tesshu.jpsonic.domain;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import com.tesshu.jpsonic.util.FileUtil;
 import com.tesshu.jpsonic.util.StringUtil;
 import org.apache.commons.io.FilenameUtils;
 
@@ -176,8 +178,12 @@ public class MediaFile {
         return new File(pathString);
     }
 
+    public Path toPath() {
+        return Path.of(pathString);
+    }
+
     public boolean exists() {
-        return FileUtil.exists(getFile());
+        return Files.exists(toPath());
     }
 
     public MediaType getMediaType() {
@@ -364,6 +370,10 @@ public class MediaFile {
         return getFile().getParentFile();
     }
 
+    public Path getParent() {
+        return toPath().getParent();
+    }
+
     public int getPlayCount() {
         return playCount;
     }
@@ -472,6 +482,10 @@ public class MediaFile {
     @Deprecated
     public File getCoverArtFile() {
         return coverArtPathString == null ? null : new File(coverArtPathString);
+    }
+
+    public Optional<Path> getCoverArtPath() {
+        return coverArtPathString == null ? Optional.empty() : Optional.of(Path.of(coverArtPathString));
     }
 
     public String getComposer() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaFile.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaFile.java
@@ -39,7 +39,7 @@ import org.apache.commons.io.FilenameUtils;
 public class MediaFile {
 
     private int id;
-    private String path;
+    private String pathString;
     private String folder;
     private MediaType mediaType;
     private String format;
@@ -57,8 +57,8 @@ public class MediaFile {
     private Long fileSize;
     private Integer width;
     private Integer height;
-    private String coverArtPath;
-    private String parentPath;
+    private String coverArtPathString;
+    private String parentPathString;
     private int playCount;
     private Date lastPlayed;
     private String comment;
@@ -97,7 +97,7 @@ public class MediaFile {
             String albumReading, String albumArtistReading, String artistSortRaw, String albumSortRaw,
             String albumArtistSortRaw, String composerSortRaw, int order) {
         this.id = id;
-        this.path = path;
+        this.pathString = path;
         this.folder = folder;
         this.mediaType = mediaType;
         this.format = format;
@@ -115,8 +115,8 @@ public class MediaFile {
         this.fileSize = fileSize;
         this.width = width;
         this.height = height;
-        this.coverArtPath = coverArtPath;
-        this.parentPath = parentPath;
+        this.coverArtPathString = coverArtPath;
+        this.parentPathString = parentPath;
         this.playCount = playCount;
         this.lastPlayed = lastPlayed;
         this.comment = comment;
@@ -155,12 +155,12 @@ public class MediaFile {
         this.id = id;
     }
 
-    public String getPath() {
-        return path;
+    public String getPathString() {
+        return pathString;
     }
 
-    public void setPath(String path) {
-        this.path = path;
+    public void setPathString(String path) {
+        this.pathString = path;
     }
 
     public String getFolder() {
@@ -173,7 +173,7 @@ public class MediaFile {
 
     @Deprecated
     public File getFile() {
-        return new File(path);
+        return new File(pathString);
     }
 
     public boolean exists() {
@@ -250,9 +250,9 @@ public class MediaFile {
 
     public String getName() {
         if (isFile()) {
-            return title == null ? FilenameUtils.getBaseName(path) : title;
+            return title == null ? FilenameUtils.getBaseName(pathString) : title;
         }
-        return FilenameUtils.getName(path);
+        return FilenameUtils.getName(pathString);
     }
 
     public Integer getDiscNumber() {
@@ -343,20 +343,20 @@ public class MediaFile {
         this.height = height;
     }
 
-    public String getCoverArtPath() {
-        return coverArtPath;
+    public String getCoverArtPathString() {
+        return coverArtPathString;
     }
 
-    public void setCoverArtPath(String coverArtPath) {
-        this.coverArtPath = coverArtPath;
+    public void setCoverArtPathString(String coverArtPath) {
+        this.coverArtPathString = coverArtPath;
     }
 
-    public String getParentPath() {
-        return parentPath;
+    public String getParentPathString() {
+        return parentPathString;
     }
 
-    public void setParentPath(String parentPath) {
-        this.parentPath = parentPath;
+    public void setParentPathString(String parentPath) {
+        this.parentPathString = parentPath;
     }
 
     @Deprecated
@@ -461,17 +461,17 @@ public class MediaFile {
 
     @Override
     public boolean equals(Object o) {
-        return o instanceof MediaFile && ((MediaFile) o).path.equals(path);
+        return o instanceof MediaFile && ((MediaFile) o).pathString.equals(pathString);
     }
 
     @Override
     public int hashCode() {
-        return path.hashCode();
+        return pathString.hashCode();
     }
 
     @Deprecated
     public File getCoverArtFile() {
-        return coverArtPath == null ? null : new File(coverArtPath);
+        return coverArtPathString == null ? null : new File(coverArtPathString);
     }
 
     public String getComposer() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaFileWithUrlInfo.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaFileWithUrlInfo.java
@@ -70,6 +70,7 @@ public class MediaFileWithUrlInfo {
         file.setFolder(folder);
     }
 
+    @Deprecated
     public File getFile() {
         return file.getFile();
     }
@@ -250,6 +251,7 @@ public class MediaFileWithUrlInfo {
         file.setParentPath(parentPath);
     }
 
+    @Deprecated
     public File getParentFile() {
         return file.getParentFile();
     }
@@ -330,6 +332,7 @@ public class MediaFileWithUrlInfo {
         return file.getVersion();
     }
 
+    @Deprecated
     public File getCoverArtFile() {
         return file.getCoverArtFile();
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaFileWithUrlInfo.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaFileWithUrlInfo.java
@@ -54,12 +54,12 @@ public class MediaFileWithUrlInfo {
         file.setId(id);
     }
 
-    public String getPath() {
-        return file.getPath();
+    public String getPathString() {
+        return file.getPathString();
     }
 
-    public void setPath(String path) {
-        file.setPath(path);
+    public void setPathString(String path) {
+        file.setPathString(path);
     }
 
     public String getFolder() {
@@ -235,20 +235,20 @@ public class MediaFileWithUrlInfo {
         file.setHeight(height);
     }
 
-    public String getCoverArtPath() {
-        return file.getCoverArtPath();
+    public String getCoverArtPathString() {
+        return file.getCoverArtPathString();
     }
 
-    public void setCoverArtPath(String coverArtPath) {
-        file.setCoverArtPath(coverArtPath);
+    public void setCoverArtPathString(String coverArtPath) {
+        file.setCoverArtPathString(coverArtPath);
     }
 
-    public String getParentPath() {
-        return file.getParentPath();
+    public String getParentPathString() {
+        return file.getParentPathString();
     }
 
-    public void setParentPath(String parentPath) {
-        file.setParentPath(parentPath);
+    public void setParentPathString(String parentPath) {
+        file.setParentPathString(parentPath);
     }
 
     @Deprecated

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/io/PlayQueueInputStream.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/io/PlayQueueInputStream.java
@@ -158,7 +158,7 @@ public class PlayQueueInputStream extends InputStream {
                     delegate = new AtomicReference<>(transcodingService.getTranscodedInputStream(transParam));
                     if (!isEmpty(delegate) || player.getPlayQueue().getStatus() != PlayQueue.Status.STOPPED) {
                         currentFile = new AtomicReference<>(file);
-                        status.setFile(currentFile.get().getFile());
+                        status.setFile(currentFile.get().toPath().toFile());
                         return true;
                     }
                 } catch (IOException e) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/JMediaFileService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/JMediaFileService.java
@@ -51,7 +51,7 @@ public class JMediaFileService {
     }
 
     public List<MediaFile> getChildrenOf(MediaFile parent, long offset, long count, boolean byYear) {
-        return mediaFileDao.getChildrenOf(offset, count, parent.getPath(), byYear);
+        return mediaFileDao.getChildrenOf(offset, count, parent.getPathString(), byYear);
     }
 
     /**
@@ -60,7 +60,7 @@ public class JMediaFileService {
      * @return the number of child elements
      */
     public int getChildSizeOf(MediaFile mediaFile) {
-        return mediaFileDao.getChildSizeOf(mediaFile.getPath());
+        return mediaFileDao.getChildSizeOf(mediaFile.getPathString());
     }
 
     /**

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/JMediaFileService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/JMediaFileService.java
@@ -73,7 +73,7 @@ public class JMediaFileService {
     }
 
     public MediaFile getMediaFile(File file) {
-        return deligate.getMediaFile(file);
+        return deligate.getMediaFile(file.toPath());
 
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/LastFmCache.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/LastFmCache.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.Properties;
 
 import de.umass.lastfm.cache.Cache;
@@ -63,7 +63,7 @@ public class LastFmCache extends Cache {
 
     @Override
     public InputStream load(String cacheEntryName) {
-        try (InputStream in = Files.newInputStream(Paths.get(getXmlFile(cacheEntryName).toURI()))) {
+        try (InputStream in = Files.newInputStream(getXmlFile(cacheEntryName).toPath())) {
             return new ByteArrayInputStream(IOUtils.toByteArray(in));
         } catch (IOException e) {
             return null;
@@ -87,7 +87,7 @@ public class LastFmCache extends Cache {
         createCache();
 
         File xmlFile = getXmlFile(cacheEntryName);
-        try (OutputStream xmlOut = Files.newOutputStream(Paths.get(xmlFile.toURI()))) {
+        try (OutputStream xmlOut = Files.newOutputStream(Path.of(xmlFile.toURI()))) {
 
             IOUtils.copy(inputStream, xmlOut);
 
@@ -97,7 +97,7 @@ public class LastFmCache extends Cache {
             // Note: Ignore the given expirationDate, since Last.fm sets it to just one day ahead.
             properties.setProperty("expiration-date", Long.toString(getExpirationDate()));
 
-            try (OutputStream metaOut = Files.newOutputStream(Paths.get(metaFile.toURI()))) {
+            try (OutputStream metaOut = Files.newOutputStream(Path.of(metaFile.toURI()))) {
                 properties.store(metaOut, null);
             }
 
@@ -124,7 +124,7 @@ public class LastFmCache extends Cache {
         if (!f.exists()) {
             return false;
         }
-        try (InputStream in = Files.newInputStream(Paths.get(f.toURI()))) {
+        try (InputStream in = Files.newInputStream(Path.of(f.toURI()))) {
             Properties p = new Properties();
             p.load(in);
             long expirationDate = Long.parseLong(p.getProperty("expiration-date"));

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileCache.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileCache.java
@@ -19,7 +19,7 @@
 
 package com.tesshu.jpsonic.service;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.tesshu.jpsonic.domain.MediaFile;
@@ -51,18 +51,18 @@ public class MediaFileCache {
         }
     }
 
-    void put(File file, MediaFile mediaFile) {
+    void put(Path path, MediaFile mediaFile) {
         if (isEnabled()) {
-            mediaFileMemoryCache.put(new Element(file, mediaFile));
+            mediaFileMemoryCache.put(new Element(path, mediaFile));
         }
     }
 
     @Nullable
-    MediaFile get(File file) {
+    MediaFile get(Path path) {
         if (!isEnabled()) {
             return null;
         }
-        Element element = mediaFileMemoryCache.get(file);
+        Element element = mediaFileMemoryCache.get(path);
         return element == null ? null : (MediaFile) element.getObjectValue();
     }
 
@@ -70,7 +70,7 @@ public class MediaFileCache {
         mediaFileMemoryCache.removeAll();
     }
 
-    boolean remove(File file) {
-        return mediaFileMemoryCache.remove(file);
+    boolean remove(Path path) {
+        return mediaFileMemoryCache.remove(path);
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
@@ -149,10 +149,10 @@ public class MediaFileService {
     }
 
     public MediaFile getParentOf(MediaFile mediaFile) {
-        if (mediaFile.getParentPath() == null) {
+        if (mediaFile.getParentPathString() == null) {
             return null;
         }
-        return getMediaFile(mediaFile.getParentPath());
+        return getMediaFile(mediaFile.getParentPathString());
     }
 
     boolean isSchemeLastModified() {
@@ -224,7 +224,7 @@ public class MediaFileService {
         }
 
         List<MediaFile> result = new ArrayList<>();
-        for (MediaFile child : mediaFileDao.getChildrenOf(parent.getPath())) {
+        for (MediaFile child : mediaFileDao.getChildrenOf(parent.getPathString())) {
             MediaFile checked = checkLastModified(child, useFastCache, statistics);
             if (checked.isDirectory() && includeDirectories && includeMediaFile(checked)) {
                 result.add(checked);
@@ -243,7 +243,7 @@ public class MediaFileService {
 
     public boolean isRoot(MediaFile mediaFile) {
         for (MusicFolder musicFolder : musicFolderService.getAllMusicFolders(false, true)) {
-            if (mediaFile.getPath().equals(musicFolder.getPath().getPath())) {
+            if (mediaFile.getPathString().equals(musicFolder.getPath().getPath())) {
                 return true;
             }
         }
@@ -260,10 +260,10 @@ public class MediaFileService {
             return;
         }
 
-        List<MediaFile> storedChildren = mediaFileDao.getChildrenOf(parent.getPath());
+        List<MediaFile> storedChildren = mediaFileDao.getChildrenOf(parent.getPathString());
         Map<String, MediaFile> storedChildrenMap = new ConcurrentHashMap<>();
         for (MediaFile child : storedChildren) {
-            storedChildrenMap.put(child.getPath(), child);
+            storedChildrenMap.put(child.getPathString(), child);
         }
 
         List<File> children = filterMediaFiles(FileUtil.listFiles(parent.getFile()));
@@ -361,9 +361,9 @@ public class MediaFileService {
         mediaFile.setLastScanned(existingFile == null ? ZERO_DATE : existingFile.getLastScanned());
         mediaFile.setChildrenLastUpdated(ZERO_DATE);
 
-        mediaFile.setPath(file.getPath());
+        mediaFile.setPathString(file.getPath());
         mediaFile.setFolder(securityService.getRootFolderForFile(file));
-        mediaFile.setParentPath(file.getParent());
+        mediaFile.setParentPathString(file.getParent());
         mediaFile.setPlayCount(existingFile == null ? 0 : existingFile.getPlayCount());
         mediaFile.setLastPlayed(existingFile == null ? null : existingFile.getLastPlayed());
         mediaFile.setComment(existingFile == null ? null : existingFile.getComment());
@@ -410,7 +410,7 @@ public class MediaFileService {
             utils.analyze(to);
             to.setLastScanned(statistics.length == 0 ? new Date() : statistics[0].getScanDate());
         }
-        String format = StringUtils.trimToNull(StringUtils.lowerCase(FilenameUtils.getExtension(to.getPath())));
+        String format = StringUtils.trimToNull(StringUtils.lowerCase(FilenameUtils.getExtension(to.getPathString())));
         to.setFormat(format);
         to.setFileSize(FileUtil.length(file));
         to.setMediaType(getMediaType(to));
@@ -441,7 +441,7 @@ public class MediaFileService {
                 }
 
                 // Look for cover art.
-                findCoverArt(children).ifPresent(coverArtOEmbedded -> to.setCoverArtPath(coverArtOEmbedded.getPath()));
+                findCoverArt(children).ifPresent(coverArtOEmbedded -> to.setCoverArtPathString(coverArtOEmbedded.getPath()));
             }
             utils.analyze(to);
         }
@@ -461,7 +461,7 @@ public class MediaFileService {
         if (isVideoFile(mediaFile.getFormat())) {
             return MediaFile.MediaType.VIDEO;
         }
-        String path = mediaFile.getPath().toLowerCase();
+        String path = mediaFile.getPathString().toLowerCase();
         String genre = StringUtils.trimToEmpty(mediaFile.getGenre()).toLowerCase();
         if (path.contains("podcast") || genre.contains("podcast")) {
             return MediaFile.MediaType.PODCAST;
@@ -483,7 +483,7 @@ public class MediaFileService {
         if (mediaFile.getCoverArtFile() != null) {
             return mediaFile.getCoverArtFile();
         }
-        if (!securityService.isReadAllowed(mediaFile.getParentPath())) {
+        if (!securityService.isReadAllowed(mediaFile.getParentPathString())) {
             return null;
         }
         MediaFile parent = getParentOf(mediaFile);
@@ -629,7 +629,7 @@ public class MediaFileService {
 
     public void resetLastScanned(MediaFile album) {
         mediaFileDao.resetLastScanned(album.getId());
-        for (MediaFile child : mediaFileDao.getChildrenOf(album.getPath())) {
+        for (MediaFile child : mediaFileDao.getChildrenOf(album.getPathString())) {
             mediaFileDao.resetLastScanned(child.getId());
         }
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaScannerService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaScannerService.java
@@ -298,7 +298,7 @@ public class MediaScannerService {
         }
 
         updateGenres(file, genres);
-        mediaFileDao.markPresent(file.getPath(), statistics.getScanDate());
+        mediaFileDao.markPresent(file.getPathString(), statistics.getScanDate());
         artistDao.markPresent(file.getAlbumArtist(), statistics.getScanDate());
 
         if (file.getDurationSeconds() != null) {
@@ -319,7 +319,7 @@ public class MediaScannerService {
         if (LOG.isInfoEnabled() && scanCount.get() % 250 == 0) {
             writeInfo("Scanned media library with " + scanCount + " entries.");
         } else if (LOG.isTraceEnabled()) {
-            LOG.trace("Scanning file {}", file.getPath());
+            LOG.trace("Scanning file {}", file.getPathString());
         }
     }
 
@@ -393,7 +393,7 @@ public class MediaScannerService {
     }
 
     private boolean isNotAlbumUpdatable(MediaFile file) {
-        return file.getAlbumName() == null || file.getParentPath() == null || !file.isAudio()
+        return file.getAlbumName() == null || file.getParentPathString() == null || !file.isAudio()
                 || file.getArtist() == null && file.getAlbumArtist() == null;
     }
 
@@ -401,7 +401,7 @@ public class MediaScannerService {
         Album album = albumDao.getAlbumForFile(file);
         if (album == null) {
             album = new Album();
-            album.setPath(file.getParentPath());
+            album.setPath(file.getParentPathString());
             album.setName(file.getAlbumName());
             album.setNameReading(file.getAlbumReading());
             album.setNameSort(file.getAlbumSort());
@@ -414,8 +414,8 @@ public class MediaScannerService {
             album.setMusicBrainzReleaseId(file.getMusicBrainzReleaseId());
         }
         MediaFile parent = mediaFileService.getParentOf(file);
-        if (parent != null && parent.getCoverArtPath() != null) {
-            album.setCoverArtPath(parent.getCoverArtPath());
+        if (parent != null && parent.getCoverArtPathString() != null) {
+            album.setCoverArtPath(parent.getCoverArtPathString());
         }
         return album;
     }
@@ -435,7 +435,7 @@ public class MediaScannerService {
         if (artist.getCoverArtPath() == null) {
             MediaFile parent = mediaFileService.getParentOf(file);
             if (parent != null) {
-                artist.setCoverArtPath(parent.getCoverArtPath());
+                artist.setCoverArtPath(parent.getCoverArtPathString());
             }
         }
         final boolean firstEncounter = !lastScanned.equals(artist.getLastScanned());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaScannerService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaScannerService.java
@@ -24,7 +24,8 @@ package com.tesshu.jpsonic.service;
 import static org.apache.commons.lang.ObjectUtils.defaultIfNull;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Map;
@@ -191,15 +192,16 @@ public class MediaScannerService {
 
             // Recurse through all files on disk.
             for (MusicFolder musicFolder : musicFolderService.getAllMusicFolders()) {
-                MediaFile root = mediaFileService.getMediaFile(musicFolder.getPath(), false);
+                MediaFile root = mediaFileService.getMediaFile(musicFolder.getPath().toPath(), false);
                 scanFile(root, musicFolder, statistics, albumCount, genres, false);
             }
 
             // Scan podcast folder.
-            File podcastFolder = new File(settingsService.getPodcastFolder());
-            if (podcastFolder.exists()) {
-                scanFile(mediaFileService.getMediaFile(podcastFolder), new MusicFolder(podcastFolder, null, true, null),
-                        statistics, albumCount, genres, true);
+            Path podcastFolder = Path.of(settingsService.getPodcastFolder());
+            if (Files.exists(podcastFolder)) {
+                scanFile(mediaFileService.getMediaFile(podcastFolder),
+                        new MusicFolder(podcastFolder.toFile(), null, true, null), statistics, albumCount, genres,
+                        true);
             }
 
             writeInfo("Scanned media library with " + scanCount + " entries.");
@@ -319,7 +321,7 @@ public class MediaScannerService {
         if (LOG.isInfoEnabled() && scanCount.get() % 250 == 0) {
             writeInfo("Scanned media library with " + scanCount + " entries.");
         } else if (LOG.isTraceEnabled()) {
-            LOG.trace("Scanning file {}", file.getPathString());
+            LOG.trace("Scanning file {}", file.toPath());
         }
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicFolderService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicFolderService.java
@@ -19,6 +19,7 @@
 
 package com.tesshu.jpsonic.service;
 
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -27,7 +28,6 @@ import java.util.concurrent.ConcurrentMap;
 
 import com.tesshu.jpsonic.dao.MusicFolderDao;
 import com.tesshu.jpsonic.domain.MusicFolder;
-import com.tesshu.jpsonic.util.FileUtil;
 import net.sf.ehcache.Ehcache;
 import org.springframework.stereotype.Service;
 
@@ -72,7 +72,8 @@ public class MusicFolderService {
 
         List<MusicFolder> result = new ArrayList<>(cachedMusicFolders.size());
         for (MusicFolder folder : cachedMusicFolders) {
-            if ((includeDisabled || folder.isEnabled()) && (includeNonExisting || FileUtil.exists(folder.getPath()))) {
+            if ((includeDisabled || folder.isEnabled())
+                    && (includeNonExisting || Files.exists(folder.getPath().toPath()))) {
                 result.add(folder);
             }
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicIndexService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicIndexService.java
@@ -21,8 +21,9 @@
 
 package com.tesshu.jpsonic.service;
 
-import java.io.File;
 import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -37,7 +38,6 @@ import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.domain.MusicFolderContent;
 import com.tesshu.jpsonic.domain.MusicIndex;
 import com.tesshu.jpsonic.domain.MusicIndex.SortableArtist;
-import com.tesshu.jpsonic.util.FileUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -92,20 +92,19 @@ public class MusicIndexService {
     private List<MediaFile> getSingleSongs(List<MusicFolder> folders, boolean refresh) {
         List<MediaFile> result = new ArrayList<>();
         for (MusicFolder folder : folders) {
-            MediaFile parent = mediaFileService.getMediaFile(folder.getPath(), !refresh);
+            MediaFile parent = mediaFileService.getMediaFile(folder.getPath().toPath(), !refresh);
             result.addAll(mediaFileService.getChildrenOf(parent, true, false, true, !refresh));
         }
         return result;
     }
 
-    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops") // (File) Not reusable
     public List<MediaFile> getShortcuts(List<MusicFolder> musicFoldersToUse) {
         List<MediaFile> result = new ArrayList<>();
         for (String shortcut : settingsService.getShortcutsAsArray()) {
             for (MusicFolder musicFolder : musicFoldersToUse) {
-                File file = new File(musicFolder.getPath(), shortcut);
-                if (FileUtil.exists(file)) {
-                    result.add(mediaFileService.getMediaFile(file, true));
+                Path shortcutPath = Path.of(musicFolder.getPath().toString(), shortcut);
+                if (Files.exists(shortcutPath)) {
+                    result.add(mediaFileService.getMediaFile(shortcutPath, true));
                 }
             }
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicIndexServiceUtils.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicIndexServiceUtils.java
@@ -89,7 +89,7 @@ public class MusicIndexServiceUtils {
         Comparator<SortableArtist> c = comparators.sortableArtistOrder();
         for (MusicFolder folder : folders) {
 
-            MediaFile root = mediaFileService.getMediaFile(folder.getPath(), !refresh);
+            MediaFile root = mediaFileService.getMediaFile(folder.getPath().toPath(), !refresh);
             List<MediaFile> children = mediaFileService.getChildrenOf(root, false, true, true, !refresh);
             for (MediaFile child : children) {
                 if (shortcutSet.contains(child.getName())) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PlaylistService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PlaylistService.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -317,7 +316,7 @@ public class PlaylistService {
                 }
             }
         }
-        try (InputStream in = Files.newInputStream(Paths.get(file.toURI()))) {
+        try (InputStream in = Files.newInputStream(file.toPath())) {
             // With the transition away from a hardcoded admin account to Admin Roles, there is no longer
             // a specific account to use for auto-imported playlists, so use the first admin account
             importPlaylist(securityService.getAdminUsername(), FilenameUtils.getBaseName(fileName), fileName, in,

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PodcastService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PodcastService.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -218,11 +218,10 @@ public class PodcastService {
         }).collect(Collectors.toList());
     }
 
-    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops") // (File) Not reusable
     private List<PodcastEpisode> filterAllowed(List<PodcastEpisode> episodes) {
         List<PodcastEpisode> result = new ArrayList<>(episodes.size());
         for (PodcastEpisode episode : episodes) {
-            if (episode.getPath() == null || securityService.isReadAllowed(new File(episode.getPath()))) {
+            if (episode.getPath() == null || securityService.isReadAllowed(Path.of(episode.getPath()))) {
                 result.add(episode);
             }
         }
@@ -263,7 +262,7 @@ public class PodcastService {
                     continue;
                 }
                 File dir = getChannelDirectory(channel);
-                MediaFile mediaFile = mediaFileService.getMediaFile(dir);
+                MediaFile mediaFile = mediaFileService.getMediaFile(dir.toPath());
                 if (mediaFile != null) {
                     channel.setMediaFileId(mediaFile.getId());
                 }
@@ -355,8 +354,8 @@ public class PodcastService {
             }
 
             File dir = getChannelDirectory(channel);
-            MediaFile channelMediaFile = mediaFileService.getMediaFile(dir);
-            File existingCoverArt = mediaFileService.getCoverArt(channelMediaFile);
+            MediaFile channelMediaFile = mediaFileService.getMediaFile(dir.toPath());
+            Path existingCoverArt = mediaFileService.getCoverArt(channelMediaFile);
             boolean imageFileExists = existingCoverArt != null
                     && mediaFileService.getMediaFile(existingCoverArt) == null;
             if (imageFileExists) {
@@ -367,7 +366,7 @@ public class PodcastService {
             try (CloseableHttpResponse response = client.execute(method)) {
                 File f = new File(dir, "cover." + getCoverArtSuffix(response));
                 try (InputStream in = response.getEntity().getContent();
-                        OutputStream out = Files.newOutputStream(Paths.get(f.toURI()))) {
+                        OutputStream out = Files.newOutputStream(Path.of(f.toURI()))) {
                     IOUtils.copy(in, out);
                 }
                 mediaFileService.refreshMediaFile(channelMediaFile);
@@ -591,26 +590,27 @@ public class PodcastService {
 
                     synchronized (FILE_LOCK) {
 
-                        File file = getFile(channel, episode);
+                        Path path = getFile(channel, episode).toPath();
                         episode.setStatus(PodcastStatus.DOWNLOADING);
                         episode.setBytesDownloaded(0L);
                         episode.setErrorMessage(null);
-                        episode.setPath(file.getPath());
+                        episode.setPath(path.toString());
                         podcastDao.updateEpisode(episode);
 
-                        long bytesDownloaded = updateEpisode(episode, file, in);
+                        long bytesDownloaded = updateEpisode(episode, path, in);
 
                         if (isEpisodeDeleted(episode)) {
                             writeInfo("Podcast " + episode.getUrl() + " was deleted. Aborting download.");
-                            if (!file.delete() && LOG.isWarnEnabled()) {
-                                LOG.warn("Unable to delete " + file);
+
+                            if (!Files.deleteIfExists(path) && LOG.isWarnEnabled()) {
+                                LOG.warn("Unable to delete " + path);
                             }
                         } else {
                             addMediaFileIdToEpisodes(Arrays.asList(episode));
                             episode.setBytesDownloaded(bytesDownloaded);
                             podcastDao.updateEpisode(episode);
                             writeInfo("Downloaded " + bytesDownloaded + " bytes from Podcast " + episode.getUrl());
-                            updateTags(file, episode);
+                            updateTags(path, episode);
                             episode.setStatus(PodcastStatus.COMPLETED);
                             podcastDao.updateEpisode(episode);
                             deleteObsoleteEpisodes(channel);
@@ -625,11 +625,11 @@ public class PodcastService {
         }
     }
 
-    private long updateEpisode(PodcastEpisode episode, File file, InputStream in) throws IOException {
+    private long updateEpisode(PodcastEpisode episode, Path path, InputStream in) throws IOException {
         long bytesDownloaded = 0;
         byte[] buffer = new byte[4096];
         long nextLogCount = 30_000L;
-        try (OutputStream out = Files.newOutputStream(Paths.get(file.toURI()))) {
+        try (OutputStream out = Files.newOutputStream(path)) {
             for (int n = in.read(buffer); n != -1; n = in.read(buffer)) {
                 out.write(buffer, 0, n);
                 bytesDownloaded += n;
@@ -654,14 +654,14 @@ public class PodcastService {
         return e == null || e.getStatus() == PodcastStatus.DELETED;
     }
 
-    private void updateTags(File file, PodcastEpisode episode) {
-        MediaFile mediaFile = mediaFileService.getMediaFile(file, false);
+    private void updateTags(Path path, PodcastEpisode episode) {
+        MediaFile mediaFile = mediaFileService.getMediaFile(path, false);
         if (StringUtils.isNotBlank(episode.getTitle())) {
-            MetaDataParser parser = metaDataParserFactory.getParser(file);
-            if (parser == null || !parser.isEditingSupported(file)) {
+            MetaDataParser parser = metaDataParserFactory.getParser(path);
+            if (parser == null || !parser.isEditingSupported(path)) {
                 return;
             }
-            MetaData metaData = parser.getRawMetaData(file);
+            MetaData metaData = parser.getRawMetaData(path);
             metaData.setTitle(episode.getTitle());
             parser.setMetaData(mediaFile, metaData);
             mediaFileService.refreshMediaFile(mediaFile);
@@ -716,7 +716,7 @@ public class PodcastService {
             file = new File(channelDir, filename + i + "." + extension);
         }
 
-        if (!securityService.isWriteAllowed(file)) {
+        if (!securityService.isWriteAllowed(file.toPath())) {
             throw new SecurityException("Access denied to file " + file);
         }
         return file;
@@ -735,7 +735,7 @@ public class PodcastService {
                 throw new IllegalStateException("Failed to create directory " + channelDir);
             }
 
-            MediaFile mediaFile = mediaFileService.getMediaFile(channelDir);
+            MediaFile mediaFile = mediaFileService.getMediaFile(channelDir.toPath());
             mediaFile.setComment(channel.getDescription());
             mediaFileService.updateMediaFile(mediaFile);
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/RatingService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/RatingService.java
@@ -21,14 +21,14 @@
 
 package com.tesshu.jpsonic.service;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
 import com.tesshu.jpsonic.dao.RatingDao;
 import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.domain.MusicFolder;
-import com.tesshu.jpsonic.util.FileUtil;
 import org.springframework.stereotype.Service;
 
 /**
@@ -62,13 +62,12 @@ public class RatingService {
      *
      * @return The highest rated albums.
      */
-    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops") // (File) Not reusable
     public List<MediaFile> getHighestRatedAlbums(int offset, int count, List<MusicFolder> musicFolders) {
-        List<String> highestRated = ratingDao.getHighestRatedAlbums(offset, count, musicFolders);
+        List<String> highestRateds = ratingDao.getHighestRatedAlbums(offset, count, musicFolders);
         List<MediaFile> result = new ArrayList<>();
-        for (String path : highestRated) {
-            File file = new File(path);
-            if (FileUtil.exists(file) && securityService.isReadAllowed(file)) {
+        for (String highestRated : highestRateds) {
+            Path path = Path.of(highestRated);
+            if (Files.exists(path) && securityService.isReadAllowed(path)) {
                 result.add(mediaFileService.getMediaFile(path));
             }
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
@@ -23,7 +23,8 @@ package com.tesshu.jpsonic.service;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -40,7 +41,6 @@ import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.domain.SpeechToTextLangScheme;
 import com.tesshu.jpsonic.domain.User;
 import com.tesshu.jpsonic.domain.UserSettings;
-import com.tesshu.jpsonic.util.FileUtil;
 import net.sf.ehcache.Ehcache;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
@@ -399,14 +399,9 @@ public class SecurityService implements UserDetailsService {
      *
      * @return Whether the given file may be read.
      */
-    public boolean isReadAllowed(File file) {
+    public boolean isReadAllowed(Path path) {
         // Allowed to read from both music folder and podcast folder.
-        return isInMusicFolder(file) || isInPodcastFolder(file);
-    }
-
-    public boolean isReadAllowed(String path) {
-        // Allowed to read from both music folder and podcast folder.
-        return isInMusicFolder(path) || isInPodcastFolder(path);
+        return isInMusicFolder(path.toString()) || isInPodcastFolder(path);
     }
 
     public boolean isNoTraversal(String path) {
@@ -418,10 +413,10 @@ public class SecurityService implements UserDetailsService {
      *
      * @return Whether the given file may be written, created or deleted.
      */
-    public boolean isWriteAllowed(File file) {
+    public boolean isWriteAllowed(Path path) {
         // Only allowed to write podcasts or cover art.
-        boolean isPodcast = isInPodcastFolder(file);
-        boolean isCoverArt = isInMusicFolder(file) && file.getName().startsWith("cover.");
+        boolean isPodcast = isInPodcastFolder(path);
+        boolean isCoverArt = isInMusicFolder(path.toString()) && path.getFileName().toString().startsWith("cover.");
 
         return isPodcast || isCoverArt;
     }
@@ -431,22 +426,18 @@ public class SecurityService implements UserDetailsService {
      *
      * @return Whether the given file may be uploaded.
      */
-    public boolean isUploadAllowed(File file) {
-        return isInMusicFolder(file) && !FileUtil.exists(file);
+    public boolean isUploadAllowed(Path path) {
+        return isInMusicFolder(path.toString()) && !Files.exists(path);
     }
 
     /**
      * Returns whether the given file is located in one of the music folders (or any of their sub-folders).
      *
-     * @param file
+     * @param path
      *            The file in question.
      *
      * @return Whether the given file is located in one of the music folders.
      */
-    private boolean isInMusicFolder(File file) {
-        return getMusicFolderForFile(file) != null;
-    }
-
     private boolean isInMusicFolder(String path) {
         return getMusicFolderForFile(path) != null;
     }
@@ -461,28 +452,17 @@ public class SecurityService implements UserDetailsService {
         return null;
     }
 
-    private MusicFolder getMusicFolderForFile(File file) {
-        List<MusicFolder> folders = musicFolderService.getAllMusicFolders(false, true);
-        String path = file.getPath();
-        for (MusicFolder folder : folders) {
-            if (isFileInFolder(path, folder.getPath().getPath())) {
-                return folder;
-            }
-        }
-        return null;
-    }
-
     /**
      * Returns whether the given file is located in the Podcast folder (or any of its sub-folders).
      *
-     * @param file
+     * @param path
      *            The file in question.
      *
      * @return Whether the given file is located in the Podcast folder.
      */
-    public boolean isInPodcastFolder(File file) {
+    public boolean isInPodcastFolder(Path path) {
         String podcastFolder = settingsService.getPodcastFolder();
-        return isFileInFolder(file.getPath(), podcastFolder);
+        return isFileInFolder(path.toString(), podcastFolder);
     }
 
     private boolean isInPodcastFolder(String path) {
@@ -490,20 +470,32 @@ public class SecurityService implements UserDetailsService {
         return isFileInFolder(path, podcastFolder);
     }
 
-    public String getRootFolderForFile(File file) {
-        MusicFolder folder = getMusicFolderForFile(file);
+    public String getRootFolderForFile(String path) {
+        MusicFolder folder = getMusicFolderForFile(path);
         if (folder != null) {
             return folder.getPath().getPath();
         }
 
-        if (isInPodcastFolder(file)) {
+        if (isInPodcastFolder(path)) {
+            return settingsService.getPodcastFolder();
+        }
+        return null;
+    }
+
+    public String getRootFolderForFile(Path path) {
+        MusicFolder folder = getMusicFolderForFile(path.toString());
+        if (folder != null) {
+            return folder.getPath().getPath();
+        }
+
+        if (isInPodcastFolder(path)) {
             return settingsService.getPodcastFolder();
         }
         return null;
     }
 
     public boolean isFolderAccessAllowed(MediaFile file, String username) {
-        if (isInPodcastFolder(file.getFile())) {
+        if (isInPodcastFolder(file.toPath())) {
             return true;
         }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/ShareService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/ShareService.java
@@ -118,7 +118,7 @@ public class ShareService {
 
         shareDao.createShare(share);
         for (MediaFile file : files) {
-            shareDao.createSharedFiles(share.getId(), file.getPath());
+            shareDao.createSharedFiles(share.getId(), file.getPathString());
         }
         if (LOG.isInfoEnabled()) {
             LOG.info("Created share '" + share.getName() + "' with " + files.size() + " file(s).");

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/StatusService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/StatusService.java
@@ -207,7 +207,7 @@ public class StatusService {
                     if (file == null) {
                         continue;
                     }
-                    MediaFile mediaFile = mediaFileService.getMediaFile(file);
+                    MediaFile mediaFile = mediaFileService.getMediaFile(file.toPath());
                     if (player == null || mediaFile == null) {
                         continue;
                     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/TranscodingService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/TranscodingService.java
@@ -27,7 +27,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -336,10 +336,10 @@ public class TranscodingService {
             }
         } catch (IOException e) {
             // IOException : Process failure or Windows limited process(createTempFile, File copy)
-            throw new IOException("Transcoder failed: " + parameters.getMediaFile().getFile().getAbsolutePath(), e);
+            throw new IOException("Transcoder failed: " + parameters.getMediaFile().toPath(), e);
         }
         // IOException : InvalidPathException
-        return Files.newInputStream(Paths.get(parameters.getMediaFile().getFile().toURI()));
+        return Files.newInputStream(parameters.getMediaFile().toPath());
     }
 
     /**
@@ -426,7 +426,6 @@ public class TranscodingService {
      * @param in
      *            Data to feed to the process. May be {@code null}. @return The newly created input stream.
      */
-    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops") // (File) Not reusable
     TranscodeInputStream createTranscodeInputStream(@NonNull String command, Integer maxBitRate,
             VideoTranscodingSettings vts, @NonNull MediaFile mediaFile, InputStream in) throws IOException {
 
@@ -454,14 +453,14 @@ public class TranscodingService {
             if (cmd.contains("%s")) {
                 // Work-around for filename character encoding problem on Windows.
                 // Create temporary file, and feed this to the transcoder.
-                String path = mediaFile.getFile().getAbsolutePath();
-                if (PlayerUtils.isWindows() && !mediaFile.isVideo() && !StringUtils.isAsciiPrintable(path)) {
-                    tmpFile = File.createTempFile("jpsonic", "." + FilenameUtils.getExtension(path));
+                Path path = mediaFile.toPath();
+                if (PlayerUtils.isWindows() && !mediaFile.isVideo() && !StringUtils.isAsciiPrintable(path.toString())) {
+                    tmpFile = File.createTempFile("jpsonic", "." + FilenameUtils.getExtension(path.toString()));
                     tmpFile.deleteOnExit();
-                    FileUtils.copyFile(new File(path), tmpFile);
+                    FileUtils.copyFile(path.toFile(), tmpFile);
                     cmd = cmd.replace("%s", tmpFile.getPath());
                 } else {
-                    cmd = cmd.replace("%s", path);
+                    cmd = cmd.replace("%s", path.toString());
                 }
             }
             result.set(i, cmd);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/DefaultParser.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/DefaultParser.java
@@ -21,7 +21,8 @@
 
 package com.tesshu.jpsonic.service.metadata;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.service.MusicFolderService;
@@ -47,19 +48,19 @@ public class DefaultParser extends MetaDataParser {
     /**
      * Parses meta data for the given file.
      *
-     * @param file
+     * @param path
      *            The file to parse.
      *
      * @return Meta data for the file.
      */
     @Override
-    public MetaData getRawMetaData(File file) {
+    public MetaData getRawMetaData(Path path) {
         MetaData metaData = new MetaData();
-        String artist = guessArtist(file);
+        String artist = guessArtist(path);
         metaData.setArtist(artist);
         metaData.setAlbumArtist(artist);
-        metaData.setAlbumName(guessAlbum(file, artist));
-        metaData.setTitle(guessTitle(file));
+        metaData.setAlbumName(guessAlbum(path, artist));
+        metaData.setTitle(guessTitle(path));
         return metaData;
     }
 
@@ -82,7 +83,7 @@ public class DefaultParser extends MetaDataParser {
      * @return Always false.
      */
     @Override
-    public boolean isEditingSupported(File file) {
+    public boolean isEditingSupported(Path path) {
         return false;
     }
 
@@ -94,13 +95,13 @@ public class DefaultParser extends MetaDataParser {
     /**
      * Returns whether this parser is applicable to the given file.
      *
-     * @param file
+     * @param path
      *            The file in question.
      *
      * @return Whether this parser is applicable to the given file.
      */
     @Override
-    public boolean isApplicable(File file) {
-        return file.isFile();
+    public boolean isApplicable(Path path) {
+        return Files.isRegularFile(path);
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/FFmpeg.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/FFmpeg.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -71,7 +72,7 @@ public class FFmpeg {
         return null;
     }
 
-    public @Nullable BufferedImage createImage(@NonNull File file, int width, int height, int offset) {
+    public @Nullable BufferedImage createImage(@NonNull Path path, int width, int height, int offset) {
 
         String cmdPath = getCommandPath();
         if (isEmpty(cmdPath)) {
@@ -79,7 +80,7 @@ public class FFmpeg {
         }
 
         List<String> command = new ArrayList<>();
-        command.addAll(Arrays.asList(cmdPath, "-i", file.getAbsolutePath()));
+        command.addAll(Arrays.asList(cmdPath, "-i", path.toString()));
         String options = offset < 1 ? THUMBNAIL_OPTIONS : SEEKED_OPTIONS;
         Stream.of(options.split(" ")).forEach(c -> command.add(c //
                 .replaceAll("%w", Integer.toString(width)) //
@@ -97,7 +98,7 @@ public class FFmpeg {
                 process.destroy();
             }
         } catch (IOException e) {
-            String simplePath = createSimplePath(file);
+            String simplePath = createSimplePath(path);
             if (LOG.isWarnEnabled()) {
                 LOG.warn("Failed to create thumbnail({}): {}", simplePath, e.getMessage());
             }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/FFprobe.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/FFprobe.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -151,7 +152,7 @@ public class FFprobe {
     }
 
     @SafeVarargs
-    final MetaData parse(@NonNull File file, Consumer<Long>... startTimeCallback) {
+    final MetaData parse(@NonNull Path path, Consumer<Long>... startTimeCallback) {
 
         MetaData result = new MetaData();
         String cmdPath = getCommandPath();
@@ -162,7 +163,7 @@ public class FFprobe {
         List<String> command = new ArrayList<>();
         command.add(cmdPath);
         command.addAll(Arrays.asList(FFPROBE_OPTIONS));
-        command.add(file.getAbsolutePath());
+        command.add(path.toString());
 
         long start;
         JsonNode node;
@@ -177,7 +178,7 @@ public class FFprobe {
             }
         } catch (IOException e) {
             // Exceptions to this class are self-explanatory, avoiding redundant trace output
-            String simplePath = createSimplePath(file);
+            String simplePath = createSimplePath(path);
             if (LOG.isWarnEnabled()) {
                 LOG.warn("Failed to execute ffprobe({}): {}", simplePath, e.getMessage());
             }
@@ -190,7 +191,7 @@ public class FFprobe {
     }
 
     MetaData parse(@NonNull MediaFile mediaFile, @Nullable Map<String, MP4ParseStatistics> statistics) {
-        return parse(mediaFile.getFile(), (start) -> {
+        return parse(mediaFile.toPath(), (start) -> {
             if (!isEmpty(statistics) && statistics.containsKey(getFolder(mediaFile))) {
                 long readtime = System.currentTimeMillis() - start;
                 statistics.get(getFolder(mediaFile)).addCmdLeadTime(readtime);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MP4Parser.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MP4Parser.java
@@ -88,12 +88,12 @@ public class MP4Parser {
         BodyContentHandler handler = new BodyContentHandler();
         Metadata metadata = new Metadata();
         ParseContext ps = new ParseContext();
-        try (InputStream is = Files.newInputStream(mediaFile.getFile().toPath());
+        try (InputStream is = Files.newInputStream(mediaFile.toPath());
                 BufferedInputStream bid = new BufferedInputStream(is, 1_000_000);) {
             current = System.currentTimeMillis();
             tikaParser.parse(bid, handler, metadata, ps);
         } catch (IOException | SAXException | TikaException e) {
-            String simplePath = createSimplePath(mediaFile.getFile());
+            String simplePath = createSimplePath(mediaFile.toPath());
             if (LOG.isWarnEnabled()) {
                 LOG.warn("Failed to parse the tag({}): {}", simplePath, e.getMessage());
             }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MetaDataParser.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MetaDataParser.java
@@ -21,7 +21,7 @@
 
 package com.tesshu.jpsonic.service.metadata;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 
 import com.tesshu.jpsonic.domain.MediaFile;
@@ -40,30 +40,30 @@ public abstract class MetaDataParser {
     /**
      * Parses meta data for the given file.
      *
-     * @param file
+     * @param path
      *            The file to parse.
      *
      * @return Meta data for the file, never null.
      */
-    public MetaData getMetaData(File file) {
+    public MetaData getMetaData(Path path) {
 
-        MetaData metaData = getRawMetaData(file);
+        MetaData metaData = getRawMetaData(path);
 
         String artist = metaData.getArtist();
         if (artist == null) {
-            artist = guessArtist(file);
+            artist = guessArtist(path);
         }
         String albumArtist = metaData.getAlbumArtist();
         if (albumArtist == null) {
-            albumArtist = guessArtist(file);
+            albumArtist = guessArtist(path);
         }
         String album = metaData.getAlbumName();
         if (album == null) {
-            album = guessAlbum(file, artist);
+            album = guessAlbum(path, artist);
         }
         String title = metaData.getTitle();
         if (title == null) {
-            title = guessTitle(file);
+            title = guessTitle(path);
         }
 
         title = removeTrackNumberFromTitle(title, metaData.getTrackNumber());
@@ -79,12 +79,12 @@ public abstract class MetaDataParser {
      * Parses meta data for the given file. No guessing or reformatting is done.
      *
      *
-     * @param file
+     * @param path
      *            The file to parse.
      *
      * @return Meta data for the file.
      */
-    public abstract MetaData getRawMetaData(File file);
+    public abstract MetaData getRawMetaData(Path path);
 
     /**
      * Updates the given file with the given meta data.
@@ -99,38 +99,38 @@ public abstract class MetaDataParser {
     /**
      * Returns whether this parser is applicable to the given file.
      *
-     * @param file
+     * @param path
      *            The file in question.
      *
      * @return Whether this parser is applicable to the given file.
      */
-    public abstract boolean isApplicable(File file);
+    public abstract boolean isApplicable(Path path);
 
     /**
      * Returns whether this parser supports tag editing (using the {@link #setMetaData} method).
      *
      * @return Whether tag editing is supported.
      */
-    public abstract boolean isEditingSupported(File file);
+    public abstract boolean isEditingSupported(Path path);
 
     /**
      * Guesses the artist for the given file.
      */
-    protected final String guessArtist(File file) {
-        File parent = file.getParentFile();
+    protected final String guessArtist(Path path) {
+        Path parent = path.getParent();
         if (isRoot(parent)) {
             return null;
         }
-        File grandParent = parent.getParentFile();
-        return isRoot(grandParent) ? null : grandParent.getName();
+        Path grandParent = parent.getParent();
+        return isRoot(grandParent) ? null : grandParent.getFileName().toString();
     }
 
     /**
      * Guesses the album for the given file.
      */
-    protected final String guessAlbum(File file, String artist) {
-        File parent = file.getParentFile();
-        String album = isRoot(parent) ? null : parent.getName();
+    protected final String guessAlbum(Path path, String artist) {
+        Path parent = path.getParent();
+        String album = isRoot(parent) ? null : parent.getFileName().toString();
         if (artist != null && album != null) {
             album = album.replace(artist + " - ", "");
         }
@@ -140,14 +140,14 @@ public abstract class MetaDataParser {
     /**
      * Guesses the title for the given file.
      */
-    public String guessTitle(File file) {
-        return StringUtils.trim(FilenameUtils.getBaseName(file.getPath()));
+    public String guessTitle(Path path) {
+        return StringUtils.trim(FilenameUtils.getBaseName(path.toString()));
     }
 
-    private boolean isRoot(File file) {
+    private boolean isRoot(Path path) {
         List<MusicFolder> folders = getMusicFolderService().getAllMusicFolders(false, true);
         for (MusicFolder folder : folders) {
-            if (file.equals(folder.getPath())) {
+            if (path.toString().equals(folder.getPath().getAbsolutePath())) {
                 return true;
             }
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MetaDataParserFactory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MetaDataParserFactory.java
@@ -21,7 +21,7 @@
 
 package com.tesshu.jpsonic.service.metadata;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -45,14 +45,14 @@ public class MetaDataParserFactory {
     /**
      * Returns a meta-data parser for the given file.
      *
-     * @param file
+     * @param path
      *            The file in question.
      *
      * @return An applicable parser, or <code>null</code> if no parser is found.
      */
-    public @Nullable MetaDataParser getParser(File file) {
+    public @Nullable MetaDataParser getParser(Path path) {
         for (MetaDataParser parser : parsers) {
-            if (parser.isApplicable(file)) {
+            if (parser.isApplicable(path)) {
                 return parser;
             }
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MusicParser.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MusicParser.java
@@ -216,7 +216,7 @@ public class MusicParser extends MetaDataParser {
 
         } catch (IOException | CannotWriteException | KeyNotFoundException | TagException | CannotReadException
                 | ReadOnlyFileException | InvalidAudioFrameException e) {
-            throw new CompletionException("Failed to update tags for file: " + file.getPath(), e);
+            throw new CompletionException("Failed to update tags for file: " + file.getPathString(), e);
         }
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/VideoParser.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/VideoParser.java
@@ -21,7 +21,7 @@
 
 package com.tesshu.jpsonic.service.metadata;
 
-import java.io.File;
+import java.nio.file.Path;
 
 import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.service.MusicFolderService;
@@ -54,14 +54,14 @@ public class VideoParser extends MetaDataParser {
      * Parses meta data for the given music file. No guessing or reformatting is done.
      *
      *
-     * @param file
+     * @param path
      *            The music file to parse.
      *
      * @return Meta data for the file.
      */
     @Override
-    public MetaData getRawMetaData(File file) {
-        return ffprobe.parse(file);
+    public MetaData getRawMetaData(Path path) {
+        return ffprobe.parse(path);
     }
 
     /**
@@ -78,7 +78,7 @@ public class VideoParser extends MetaDataParser {
      * @return Always false.
      */
     @Override
-    public boolean isEditingSupported(File file) {
+    public boolean isEditingSupported(Path path) {
         return false;
     }
 
@@ -90,15 +90,15 @@ public class VideoParser extends MetaDataParser {
     /**
      * Returns whether this parser is applicable to the given file.
      *
-     * @param file
+     * @param path
      *            The file in question.
      *
      * @return Whether this parser is applicable to the given file.
      */
     @SuppressWarnings("PMD.UseLocaleWithCaseConversions")
     @Override
-    public boolean isApplicable(File file) {
-        String format = FilenameUtils.getExtension(file.getName()).toLowerCase();
+    public boolean isApplicable(Path path) {
+        String format = FilenameUtils.getExtension(path.getFileName().toString()).toLowerCase();
 
         for (String s : settingsService.getVideoFileTypesAsArray()) {
             if (format.equals(s)) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/playlist/DefaultPlaylistExportHandler.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/playlist/DefaultPlaylistExportHandler.java
@@ -68,7 +68,7 @@ public class DefaultPlaylistExportHandler implements PlaylistExportHandler {
         List<MediaFile> files = mediaFileDao.getFilesInPlaylist(id);
         files.forEach(file -> {
             Media component = new Media();
-            Content content = new Content(file.getPath());
+            Content content = new Content(file.getPathString());
             component.setSource(content);
             newPlaylist.getRootSequence().addComponent(component);
         });

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/playlist/DefaultPlaylistImportHandler.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/playlist/DefaultPlaylistImportHandler.java
@@ -21,9 +21,8 @@
 
 package com.tesshu.jpsonic.service.playlist;
 
-import java.io.File;
-import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -101,11 +100,10 @@ public class DefaultPlaylistImportHandler implements PlaylistImportHandler {
                 @Override
                 public void beginVisitMedia(Media media) {
                     try {
-                        URI uri = media.getSource().getURI();
-                        File file = new File(uri);
-                        MediaFile mediaFile = mediaFileService.getMediaFile(file);
+                        Path path = Path.of(media.getSource().getURI());
+                        MediaFile mediaFile = mediaFileService.getMediaFile(path);
                         if (mediaFile == null) {
-                            errors.add("Cannot find media file " + file);
+                            errors.add("Cannot find media file " + path);
                         } else {
                             mediaFiles.add(mediaFile);
                         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/playlist/XspfPlaylistExportHandler.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/playlist/XspfPlaylistExportHandler.java
@@ -72,9 +72,9 @@ public class XspfPlaylistExportHandler implements PlaylistExportHandler {
             track.setTitle(mediaFile.getTitle());
             track.setAlbum(mediaFile.getAlbumName());
             track.setDuration(mediaFile.getDurationSeconds());
-            track.setImage(mediaFile.getCoverArtPath());
+            track.setImage(mediaFile.getCoverArtPathString());
             Location location = new Location();
-            location.setText(mediaFile.getPath());
+            location.setText(mediaFile.getPathString());
             track.getStringContainers().add(location);
             return track;
         }).forEach(newPlaylist::addTrack);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/playlist/XspfPlaylistImportHandler.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/playlist/XspfPlaylistImportHandler.java
@@ -21,9 +21,7 @@
 
 package com.tesshu.jpsonic.service.playlist;
 
-import java.io.File;
-import java.net.URI;
-import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -84,13 +82,12 @@ public class XspfPlaylistImportHandler implements PlaylistImportHandler {
         if (sc instanceof Location) {
             Location location = (Location) sc;
             try {
-                File file = new File(new URI(location.getText()));
-                MediaFile mediaFile = mediaFileService.getMediaFile(file);
-                if (mediaFile == null && sc.getText() != null) {
-                    return mediaFileService.getMediaFile(new File(sc.getText()));
+                if (sc.getText() != null) {
+                    MediaFile mediaFile = mediaFileService.getMediaFile(Path.of(location.getText()));
+                    if (mediaFile == null) {
+                        return mediaFile;
+                    }
                 }
-            } catch (URISyntaxException e) {
-                LOG.error("Unable to generate URI.", e);
             } catch (SecurityException e) {
                 if (LOG.isTraceEnabled()) {
                     LOG.error("SecurityException will be ignored.", e);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/UpnpProcessorUtil.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/UpnpProcessorUtil.java
@@ -99,7 +99,7 @@ public class UpnpProcessorUtil {
     }
 
     public MimeType getMimeType(MediaFile song, Player player) {
-        String suffix = song.isVideo() ? FilenameUtils.getExtension(song.getPath())
+        String suffix = song.isVideo() ? FilenameUtils.getExtension(song.getPathString())
                 : transcodingService.getSuffix(player, song, null);
         String mimeTypeString = StringUtil.getMimeType(suffix);
         return mimeTypeString == null ? null : MimeType.valueOf(mimeTypeString);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/FileUtil.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/FileUtil.java
@@ -22,6 +22,7 @@
 package com.tesshu.jpsonic.util;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -115,15 +116,15 @@ public final class FileUtil {
      * Returns a short path for the given file. The path consists of the name of the parent directory and the given
      * file.
      */
-    public static String getShortPath(File file) {
-        if (file == null) {
+    public static String getShortPath(Path path) {
+        if (path == null) {
             return null;
         }
-        File parent = file.getParentFile();
+        Path parent = path.getParent();
         if (parent == null) {
-            return file.getName();
+            return path.getFileName().toString();
         }
-        return parent.getName() + File.separator + file.getName();
+        return parent.getFileName().toString() + File.separator + path.getFileName().toString();
     }
 
     private static <T> T timed(FileTask<T> task) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/FileUtil.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/FileUtil.java
@@ -24,9 +24,6 @@ package com.tesshu.jpsonic.util;
 import java.io.File;
 import java.nio.file.Path;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Miscellaneous file utility methods.
  *
@@ -34,89 +31,10 @@ import org.slf4j.LoggerFactory;
  */
 public final class FileUtil {
 
-    private static final Logger LOG = LoggerFactory.getLogger(FileUtil.class);
-
     /**
      * Disallow external instantiation.
      */
     private FileUtil() {
-    }
-
-    @Deprecated
-    public static boolean isFile(final File file) {
-        return timed(new FileTask<Boolean>("isFile", file) {
-            @Override
-            public Boolean execute() {
-                return file.isFile();
-            }
-        });
-    }
-
-    @Deprecated
-    public static boolean isDirectory(final File file) {
-        return timed(new FileTask<Boolean>("isDirectory", file) {
-            @Override
-            public Boolean execute() {
-                return file.isDirectory();
-            }
-        });
-    }
-
-    @Deprecated
-    public static boolean exists(final File file) {
-        return timed(new FileTask<Boolean>("exists", file) {
-            @Override
-            public Boolean execute() {
-                return file.exists();
-            }
-        });
-    }
-
-    @Deprecated
-    public static boolean exists(String path) {
-        return exists(new File(path));
-    }
-
-    @Deprecated
-    public static long lastModified(final File file) {
-        return timed(new FileTask<Long>("lastModified", file) {
-            @Override
-            public Long execute() {
-                return file.lastModified();
-            }
-        });
-    }
-
-    @Deprecated
-    public static long length(final File file) {
-        return timed(new FileTask<Long>("length", file) {
-            @Override
-            public Long execute() {
-                return file.length();
-            }
-        });
-    }
-
-    /**
-     * Similar to {@link File#listFiles()}, but never returns null. Instead a warning is logged, and an empty array is
-     * returned.
-     */
-    @Deprecated
-    public static File[] listFiles(final File dir) {
-        File[] files = timed(new FileTask<File[]>("listFiles", dir) {
-            @Override
-            public File[] execute() {
-                return dir.listFiles();
-            }
-        });
-
-        if (files == null) {
-            if (LOG.isWarnEnabled()) {
-                LOG.warn("Failed to list children for " + dir.getPath());
-            }
-            return new File[0];
-        }
-        return files;
     }
 
     /**
@@ -132,27 +50,5 @@ public final class FileUtil {
             return path.getFileName().toString();
         }
         return parent.getFileName().toString() + File.separator + path.getFileName().toString();
-    }
-
-    private static <T> T timed(FileTask<T> task) {
-        return task.execute();
-    }
-
-    private abstract static class FileTask<T> {
-
-        private final String name;
-        private final File file;
-
-        public FileTask(String name, File file) {
-            this.name = name;
-            this.file = file;
-        }
-
-        public abstract T execute();
-
-        @Override
-        public String toString() {
-            return name + ", " + file;
-        }
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/FileUtil.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/FileUtil.java
@@ -42,6 +42,7 @@ public final class FileUtil {
     private FileUtil() {
     }
 
+    @Deprecated
     public static boolean isFile(final File file) {
         return timed(new FileTask<Boolean>("isFile", file) {
             @Override
@@ -51,6 +52,7 @@ public final class FileUtil {
         });
     }
 
+    @Deprecated
     public static boolean isDirectory(final File file) {
         return timed(new FileTask<Boolean>("isDirectory", file) {
             @Override
@@ -60,6 +62,7 @@ public final class FileUtil {
         });
     }
 
+    @Deprecated
     public static boolean exists(final File file) {
         return timed(new FileTask<Boolean>("exists", file) {
             @Override
@@ -69,10 +72,12 @@ public final class FileUtil {
         });
     }
 
+    @Deprecated
     public static boolean exists(String path) {
         return exists(new File(path));
     }
 
+    @Deprecated
     public static long lastModified(final File file) {
         return timed(new FileTask<Long>("lastModified", file) {
             @Override
@@ -82,6 +87,7 @@ public final class FileUtil {
         });
     }
 
+    @Deprecated
     public static long length(final File file) {
         return timed(new FileTask<Long>("length", file) {
             @Override
@@ -95,6 +101,7 @@ public final class FileUtil {
      * Similar to {@link File#listFiles()}, but never returns null. Instead a warning is logged, and an empty array is
      * returned.
      */
+    @Deprecated
     public static File[] listFiles(final File dir) {
         File[] files = timed(new FileTask<File[]>("listFiles", dir) {
             @Override

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/createShare.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/createShare.jsp
@@ -26,7 +26,7 @@
 
 <div>
     <c:if test="${not empty model.dir}">
-        <sub:url value="main.view" var="backUrl"><sub:param name="path" value="${model.dir.path}"/></sub:url>
+        <sub:url value="main.view" var="backUrl"><sub:param name="path" value="${model.dir.pathString}"/></sub:url>
         <div><a href="${backUrl}"><fmt:message key="common.back"/></a></div>
     </c:if>
     <c:if test="${model.user.settingsRole}">

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/search.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/search.jsp
@@ -69,7 +69,7 @@ $(document).ready(function(){
             <tbody>
                 <c:forEach items="${command.artists}" var="match" varStatus="loopStatus">
                     <sub:url value="/main.view" var="mainUrl">
-                        <sub:param name="path" value="${match.path}"/>
+                        <sub:param name="path" value="${match.pathString}"/>
                     </sub:url>
                     <tr class="artistRow" ${loopStatus.count > 5 ? "style='display:none'" : ""}>
                         <c:import url="playButtons.jsp">
@@ -110,7 +110,7 @@ $(document).ready(function(){
             </thead>
             <c:forEach items="${command.albums}" var="match" varStatus="loopStatus">
                 <sub:url value="/main.view" var="mainUrl">
-                    <sub:param name="path" value="${match.path}"/>
+                    <sub:param name="path" value="${match.pathString}"/>
                 </sub:url>
                 <tr class="albumRow" ${loopStatus.count > 5 ? "style='display:none'" : ""}>
                     <c:import url="playButtons.jsp">
@@ -157,7 +157,7 @@ $(document).ready(function(){
 		<tbody>
 	        <c:forEach items="${command.songs}" var="match" varStatus="loopStatus">
 	            <sub:url value="/main.view" var="mainUrl">
-	            <sub:param name="path" value="${match.parentPath}"/>
+	            <sub:param name="path" value="${match.parentPathString}"/>
 	            </sub:url>
 	            <tr class="songRow" ${loopStatus.count > 15 ? "style='display:none'" : ""}>
 	                <c:import url="playButtons.jsp">

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/starred.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/starred.jsp
@@ -211,7 +211,7 @@ function onPlayAll() {
             <tbody>
                 <c:forEach items="${model.songs}" var="song">
                     <sub:url value="/main.view" var="mainUrl">
-                        <sub:param name="path" value="${song.parentPath}"/>
+                        <sub:param name="path" value="${song.parentPathString}"/>
                     </sub:url>
                     <tr>
                         <c:import url="playButtons.jsp">

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/CoverArtServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/CoverArtServiceTest.java
@@ -19,10 +19,16 @@
 
 package com.tesshu.jpsonic.ajax;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -33,6 +39,7 @@ import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.domain.MusicFolder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class CoverArtServiceTest extends AbstractNeedsScan {
@@ -72,5 +79,25 @@ class CoverArtServiceTest extends AbstractNeedsScan {
         msg = coverArtService.saveCoverArtImage(album.getId(), TEST_IMAGE_URL);
         assertNull(msg);
         // Failed to create image file backup....
+    }
+
+    @Test
+    void testRenameWithoutReplacement(@TempDir Path tmpDir) throws IOException, URISyntaxException {
+
+        Path res = Path.of(CoverArtServiceTest.class.getResource("/MEDIAS/Metadata/coverart/cover.jpg").toURI());
+        Path coverArt = Path.of(tmpDir.toString(), "cover.jpg");
+        Files.copy(res, coverArt);
+
+        MediaFile mediaFile = new MediaFile();
+        mediaFile.setPathString(tmpDir.toString());
+        mediaFile.setCoverArtPathString(coverArt.toString());
+
+        assertTrue(Files.exists(coverArt));
+        coverArtService.renameWithoutReplacement(mediaFile, Path.of(tmpDir.toString(), "dummy.jpg").toFile());
+        Path moved = Path.of(tmpDir.toString(), "cover.jpg.old");
+        assertFalse(Files.exists(coverArt));
+        assertTrue(Files.exists(moved));
+
+        Files.delete(moved);
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/CoverArtControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/CoverArtControllerTest.java
@@ -28,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.image.BufferedImage;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -85,10 +84,6 @@ class CoverArtControllerTest {
     private CoverArtController controller;
     private MockMvc mockMvc;
 
-    private static File createFile(String resourcePath) throws URISyntaxException {
-        return new File(CoverArtControllerTest.class.getResource(resourcePath).toURI());
-    }
-
     private static Path createPath(String resourcePath) throws URISyntaxException {
         return Path.of(CoverArtControllerTest.class.getResource(resourcePath).toURI());
     }
@@ -108,27 +103,27 @@ class CoverArtControllerTest {
     @Nested
     class GetTest {
 
-        private final BiConsumer<File, String> mediaFileStub = (file, id) -> {
+        private final BiConsumer<Path, String> mediaFileStub = (path, id) -> {
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPathString(file.getPath());
-            Mockito.when(mediaFileService.getMediaFile(file)).thenReturn(mediaFile);
-            Mockito.when(mediaFileService.getCoverArt(mediaFile)).thenReturn(mediaFile.getFile());
+            mediaFile.setPathString(path.toString());
+            Mockito.when(mediaFileService.getMediaFile(path.toString())).thenReturn(mediaFile);
+            Mockito.when(mediaFileService.getCoverArt(mediaFile)).thenReturn(path);
             Mockito.when(mediaFileService.getMediaFile(Integer.parseInt(id))).thenReturn(mediaFile);
             MediaFile parent = new MediaFile();
-            parent.setPathString(file.getParent());
+            parent.setPathString(path.getParent().toString());
             parent.setArtist("CoverArtControllerTest#GetTest");
             Mockito.when(mediaFileService.getParentOf(mediaFile)).thenReturn(parent);
         };
 
-        private final BiConsumer<File, String> videoStub = (file, id) -> {
+        private final BiConsumer<Path, String> videoStub = (path, id) -> {
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPathString(file.getPath());
+            mediaFile.setPathString(path.toString());
             mediaFile.setMediaType(MediaType.VIDEO);
-            Mockito.when(mediaFileService.getMediaFile(file)).thenReturn(mediaFile);
-            Mockito.when(mediaFileService.getCoverArt(mediaFile)).thenReturn(mediaFile.getFile());
+            Mockito.when(mediaFileService.getMediaFile(path)).thenReturn(mediaFile);
+            Mockito.when(mediaFileService.getCoverArt(mediaFile)).thenReturn(path);
             Mockito.when(mediaFileService.getMediaFile(Integer.parseInt(id))).thenReturn(mediaFile);
             MediaFile parent = new MediaFile();
-            parent.setPathString(file.getParent());
+            parent.setPathString(path.getParent().toString());
             parent.setArtist("CoverArtControllerTest#GetTest");
             Mockito.when(mediaFileService.getParentOf(mediaFile)).thenReturn(parent);
         };
@@ -150,7 +145,7 @@ class CoverArtControllerTest {
         @WithMockUser(username = "admin")
         void testWithEmbededImage() throws Exception {
             final String mediaFileId = "99";
-            mediaFileStub.accept(createFile("/MEDIAS/Metadata/tagger3/tagged/test.flac"), mediaFileId);
+            mediaFileStub.accept(createPath("/MEDIAS/Metadata/tagger3/tagged/test.flac"), mediaFileId);
             MvcResult result = mockMvc
                     .perform(MockMvcRequestBuilders.get("/" + ViewName.COVER_ART.value())
                             .param(Attributes.Request.ID.value(), "99").param(Attributes.Request.SIZE.value(), "150"))
@@ -161,7 +156,7 @@ class CoverArtControllerTest {
         @Test
         void testWithoutEmbededImage() throws Exception {
             final String mediaFileId = "99";
-            mediaFileStub.accept(createFile("/MEDIAS/Metadata/tagger3/testdata/01.mp3"), mediaFileId);
+            mediaFileStub.accept(createPath("/MEDIAS/Metadata/tagger3/testdata/01.mp3"), mediaFileId);
             MvcResult result = mockMvc
                     .perform(MockMvcRequestBuilders.get("/" + ViewName.COVER_ART.value())
                             .param(Attributes.Request.ID.value(), "99").param(Attributes.Request.SIZE.value(), "150"))
@@ -172,7 +167,7 @@ class CoverArtControllerTest {
         @Test
         void testWithImage() throws Exception {
             final String mediaFileId = "99";
-            mediaFileStub.accept(createFile("/MEDIAS/Metadata/coverart/album.jpeg"), mediaFileId);
+            mediaFileStub.accept(createPath("/MEDIAS/Metadata/coverart/album.jpeg"), mediaFileId);
             MvcResult result = mockMvc
                     .perform(MockMvcRequestBuilders.get("/" + ViewName.COVER_ART.value())
                             .param(Attributes.Request.ID.value(), "99").param(Attributes.Request.SIZE.value(), "150"))
@@ -183,7 +178,7 @@ class CoverArtControllerTest {
         @Test
         void testWithEmptyImage() throws Exception {
             final String mediaFileId = "99";
-            mediaFileStub.accept(createFile("/MEDIAS/Metadata/coverart/album.jpg"), mediaFileId);
+            mediaFileStub.accept(createPath("/MEDIAS/Metadata/coverart/album.jpg"), mediaFileId);
             MvcResult result = mockMvc
                     .perform(MockMvcRequestBuilders.get("/" + ViewName.COVER_ART.value())
                             .param(Attributes.Request.ID.value(), "99").param(Attributes.Request.SIZE.value(), "150"))
@@ -195,15 +190,15 @@ class CoverArtControllerTest {
         void testWithImageCannotRead() throws Exception {
 
             final String id = "99";
-            File file = new File("/MEDIAS/Metadata/coverart/unknown.gif");
+            Path path = Path.of("/MEDIAS/Metadata/coverart/unknown.gif");
 
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPathString(file.getPath());
-            Mockito.when(mediaFileService.getMediaFile(file)).thenReturn(mediaFile);
-            Mockito.when(mediaFileService.getCoverArt(mediaFile)).thenReturn(mediaFile.getFile());
+            mediaFile.setPathString(path.toString());
+            Mockito.when(mediaFileService.getMediaFile(path)).thenReturn(mediaFile);
+            Mockito.when(mediaFileService.getCoverArt(mediaFile)).thenReturn(path);
             Mockito.when(mediaFileService.getMediaFile(Integer.parseInt(id))).thenReturn(mediaFile);
             MediaFile parent = new MediaFile();
-            parent.setPathString(file.getParent());
+            parent.setPathString(path.getParent().toString());
             parent.setArtist("CoverArtControllerTest#GetTest");
             Mockito.when(mediaFileService.getParentOf(mediaFile)).thenReturn(parent);
 
@@ -217,7 +212,7 @@ class CoverArtControllerTest {
         @Test
         void testVideoThumbnail() throws Exception {
             final String mediaFileId = "99";
-            videoStub.accept(createFile("/MEDIAS/Metadata/tagger3/tagged/test.stem.mp4"), mediaFileId);
+            videoStub.accept(createPath("/MEDIAS/Metadata/tagger3/tagged/test.stem.mp4"), mediaFileId);
             MvcResult result = mockMvc
                     .perform(MockMvcRequestBuilders.get("/" + ViewName.COVER_ART.value())
                             .param(Attributes.Request.ID.value(), "99").param(Attributes.Request.SIZE.value(), "150"))
@@ -229,18 +224,18 @@ class CoverArtControllerTest {
     @Nested
     class SendUnscaledTest {
 
-        private final Function<File, File> mediaFileStub = (file) -> {
+        private final Function<Path, Path> mediaFileStub = (path) -> {
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPathString(file.getPath());
-            Mockito.when(mediaFileService.getMediaFile(file)).thenReturn(mediaFile);
-            Mockito.when(mediaFileService.getCoverArt(mediaFile)).thenReturn(mediaFile.getFile());
-            return file;
+            mediaFile.setPathString(path.toString());
+            Mockito.when(mediaFileService.getMediaFile(path)).thenReturn(mediaFile);
+            Mockito.when(mediaFileService.getCoverArt(mediaFile)).thenReturn(path);
+            return path;
         };
 
         @Test
         void testWithEmbededImage() throws Exception {
-            File file = mediaFileStub.apply(createFile("/MEDIAS/Metadata/tagger3/tagged/test.flac"));
-            MediaFile mediaFile = mediaFileService.getMediaFile(file);
+            Path path = mediaFileStub.apply(createPath("/MEDIAS/Metadata/tagger3/tagged/test.flac"));
+            MediaFile mediaFile = mediaFileService.getMediaFile(path);
             MediaFileCoverArtRequest req = controller.new MediaFileCoverArtRequest(mediaFile);
             HttpServletResponse res = new MockHttpServletResponse();
             controller.sendUnscaled(req, res);
@@ -252,8 +247,8 @@ class CoverArtControllerTest {
 
         @Test
         void testWithoutEmbededImage() throws Exception {
-            File file = mediaFileStub.apply(createFile("/MEDIAS/Metadata/tagger3/testdata/01.mp3"));
-            MediaFile mediaFile = mediaFileService.getMediaFile(file);
+            Path path = mediaFileStub.apply(createPath("/MEDIAS/Metadata/tagger3/testdata/01.mp3"));
+            MediaFile mediaFile = mediaFileService.getMediaFile(path);
             MediaFileCoverArtRequest req = controller.new MediaFileCoverArtRequest(mediaFile);
             HttpServletResponse res = new MockHttpServletResponse();
             assertThrows(ExecutionException.class, () -> controller.sendUnscaled(req, res));
@@ -261,8 +256,8 @@ class CoverArtControllerTest {
 
         @Test
         void testWithImage() throws Exception {
-            File file = mediaFileStub.apply(createFile("/MEDIAS/Metadata/coverart/album.gif"));
-            MediaFile mediaFile = mediaFileService.getMediaFile(file);
+            Path path = mediaFileStub.apply(createPath("/MEDIAS/Metadata/coverart/album.gif"));
+            MediaFile mediaFile = mediaFileService.getMediaFile(path);
             MediaFileCoverArtRequest req = controller.new MediaFileCoverArtRequest(mediaFile);
             HttpServletResponse res = new MockHttpServletResponse();
             controller.sendUnscaled(req, res);
@@ -274,8 +269,8 @@ class CoverArtControllerTest {
 
         @Test
         void testWithImageCannotRead() throws Exception {
-            File file = mediaFileStub.apply(new File("/MEDIAS/Metadata/coverart/unknown.gif"));
-            MediaFile mediaFile = mediaFileService.getMediaFile(file);
+            Path path = mediaFileStub.apply(Path.of("/MEDIAS/Metadata/coverart/unknown.gif"));
+            MediaFile mediaFile = mediaFileService.getMediaFile(path);
             MediaFileCoverArtRequest req = controller.new MediaFileCoverArtRequest(mediaFile);
             HttpServletResponse res = new MockHttpServletResponse();
             assertThrows(ExecutionException.class, () -> controller.sendUnscaled(req, res));
@@ -287,16 +282,16 @@ class CoverArtControllerTest {
 
         @Test
         void testWithEmbededImage() throws Exception {
-            File file = createFile("/MEDIAS/Metadata/tagger3/tagged/test.flac");
-            try (InputStream s = controller.getImageInputStream(file)) {
+            Path path = createPath("/MEDIAS/Metadata/tagger3/tagged/test.flac");
+            try (InputStream s = controller.getImageInputStream(path)) {
                 assertNotNull(s);
             }
         }
 
         @Test
         void testWithoutEmbededImage() throws Exception {
-            File file = createFile("/MEDIAS/Metadata/tagger3/testdata/01.mp3");
-            assertThrows(ExecutionException.class, () -> controller.getImageInputStream(file));
+            Path path = createPath("/MEDIAS/Metadata/tagger3/testdata/01.mp3");
+            assertThrows(ExecutionException.class, () -> controller.getImageInputStream(path));
         }
 
         @Test
@@ -305,20 +300,20 @@ class CoverArtControllerTest {
              * There is no check that the current resource is an image. (Only the image resource URI is registered in
              * the database)
              */
-            File file = createFile("/MEDIAS/Metadata/coverart/album.gif");
-            assertTrue(file.exists());
-            assertTrue(file.isFile());
-            try (InputStream s = controller.getImageInputStream(file)) {
+            Path path = createPath("/MEDIAS/Metadata/coverart/album.gif");
+            assertTrue(Files.exists(path));
+            assertFalse(Files.isDirectory(path));
+            try (InputStream s = controller.getImageInputStream(path)) {
                 assertNotNull(s);
             }
         }
 
         @Test
         void testWithImageCannotRead() throws Exception {
-            File file = new File("/MEDIAS/Metadata/coverart/unknown.gif");
-            assertFalse(file.exists());
-            assertFalse(file.isFile());
-            assertThrows(ExecutionException.class, () -> controller.getImageInputStream(file));
+            Path path = Path.of("/MEDIAS/Metadata/coverart/unknown.gif");
+            assertFalse(Files.exists(path));
+            assertFalse(Files.isDirectory(path));
+            assertThrows(ExecutionException.class, () -> controller.getImageInputStream(path));
         }
     }
 
@@ -327,8 +322,8 @@ class CoverArtControllerTest {
 
         @Test
         void testWithEmbededImage() throws Exception {
-            File file = createFile("/MEDIAS/Metadata/tagger3/tagged/test.flac");
-            Pair<InputStream, String> pair = controller.getImageInputStreamWithType(file);
+            Path path = createPath("/MEDIAS/Metadata/tagger3/tagged/test.flac");
+            Pair<InputStream, String> pair = controller.getImageInputStreamWithType(path);
             assertNotNull(pair.getLeft());
             assertEquals("image/png", pair.getRight());
             pair.getLeft().close();
@@ -336,16 +331,16 @@ class CoverArtControllerTest {
 
         @Test
         void testWithoutEmbededImage() throws Exception {
-            File file = createFile("/MEDIAS/Metadata/tagger3/testdata/01.mp3");
-            assertThrows(ExecutionException.class, () -> controller.getImageInputStreamWithType(file));
+            Path path = createPath("/MEDIAS/Metadata/tagger3/testdata/01.mp3");
+            assertThrows(ExecutionException.class, () -> controller.getImageInputStreamWithType(path));
         }
 
         @Test
         void testWithImage() throws Exception {
-            File file = createFile("/MEDIAS/Metadata/coverart/album.gif");
-            assertTrue(file.exists());
-            assertTrue(file.isFile());
-            Pair<InputStream, String> pair = controller.getImageInputStreamWithType(file);
+            Path path = createPath("/MEDIAS/Metadata/coverart/album.gif");
+            assertTrue(Files.exists(path));
+            assertFalse(Files.isDirectory(path));
+            Pair<InputStream, String> pair = controller.getImageInputStreamWithType(path);
             assertNotNull(pair.getLeft());
             assertEquals("image/gif", pair.getRight());
             pair.getLeft().close();
@@ -353,10 +348,10 @@ class CoverArtControllerTest {
 
         @Test
         void testWithImageCannotRead() throws Exception {
-            File file = new File("/MEDIAS/Metadata/coverart/unknown.gif");
-            assertFalse(file.exists());
-            assertFalse(file.isFile());
-            assertThrows(ExecutionException.class, () -> controller.getImageInputStreamWithType(file));
+            Path path = Path.of("/MEDIAS/Metadata/coverart/unknown.gif");
+            assertFalse(Files.exists(path));
+            assertFalse(Files.isDirectory(path));
+            assertThrows(ExecutionException.class, () -> controller.getImageInputStreamWithType(path));
         }
     }
 
@@ -365,10 +360,10 @@ class CoverArtControllerTest {
 
         @Test
         void testValidFile() throws URISyntaxException, IOException {
-            File file = createFile("/MEDIAS/Metadata/tagger3/tagged/test.stem.mp4");
-            assertTrue(file.exists());
+            Path path = createPath("/MEDIAS/Metadata/tagger3/tagged/test.stem.mp4");
+            assertTrue(Files.exists(path));
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPathString(file.getPath());
+            mediaFile.setPathString(path.toString());
             BufferedImage bi = controller.getImageInputStreamForVideo(mediaFile, 200, 160, 0);
             assertEquals(BufferedImage.TYPE_3BYTE_BGR, bi.getType());
             assertEquals(200, bi.getWidth());
@@ -377,10 +372,10 @@ class CoverArtControllerTest {
 
         @Test
         void testInValidFile() throws URISyntaxException, IOException {
-            File file = new File("/MEDIAS/Metadata/tagger3/tagged/test.unknown.mp4");
-            assertFalse(file.exists());
+            Path path = Path.of("/MEDIAS/Metadata/tagger3/tagged/test.unknown.mp4");
+            assertFalse(Files.exists(path));
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPathString(file.getPath());
+            mediaFile.setPathString(path.toString());
             assertNull(controller.getImageInputStreamForVideo(mediaFile, 200, 160, 0));
         }
     }
@@ -468,7 +463,7 @@ class CoverArtControllerTest {
             MediaFile song = new MediaFile();
             song.setMediaType(MediaType.MUSIC);
             Path songCoverArtPath = createPath("/MEDIAS/Metadata/coverart/cover.gif");
-            Mockito.when(mediaFileService.getCoverArt(song)).thenReturn(songCoverArtPath.toFile());
+            Mockito.when(mediaFileService.getCoverArt(song)).thenReturn(songCoverArtPath);
             request = controller.new MediaFileCoverArtRequest(song);
             assertEquals(Files.getLastModifiedTime(songCoverArtPath).toMillis(), request.lastModified());
         }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/CoverArtControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/CoverArtControllerTest.java
@@ -94,25 +94,25 @@ class CoverArtControllerTest {
 
         private final BiConsumer<File, String> mediaFileStub = (file, id) -> {
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPath(file.getPath());
+            mediaFile.setPathString(file.getPath());
             Mockito.when(mediaFileService.getMediaFile(file)).thenReturn(mediaFile);
             Mockito.when(mediaFileService.getCoverArt(mediaFile)).thenReturn(mediaFile.getFile());
             Mockito.when(mediaFileService.getMediaFile(Integer.parseInt(id))).thenReturn(mediaFile);
             MediaFile parent = new MediaFile();
-            parent.setPath(file.getParent());
+            parent.setPathString(file.getParent());
             parent.setArtist("CoverArtControllerTest#GetTest");
             Mockito.when(mediaFileService.getParentOf(mediaFile)).thenReturn(parent);
         };
 
         private final BiConsumer<File, String> videoStub = (file, id) -> {
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPath(file.getPath());
+            mediaFile.setPathString(file.getPath());
             mediaFile.setMediaType(MediaType.VIDEO);
             Mockito.when(mediaFileService.getMediaFile(file)).thenReturn(mediaFile);
             Mockito.when(mediaFileService.getCoverArt(mediaFile)).thenReturn(mediaFile.getFile());
             Mockito.when(mediaFileService.getMediaFile(Integer.parseInt(id))).thenReturn(mediaFile);
             MediaFile parent = new MediaFile();
-            parent.setPath(file.getParent());
+            parent.setPathString(file.getParent());
             parent.setArtist("CoverArtControllerTest#GetTest");
             Mockito.when(mediaFileService.getParentOf(mediaFile)).thenReturn(parent);
         };
@@ -182,12 +182,12 @@ class CoverArtControllerTest {
             File file = new File("/MEDIAS/Metadata/coverart/unknown.gif");
 
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPath(file.getPath());
+            mediaFile.setPathString(file.getPath());
             Mockito.when(mediaFileService.getMediaFile(file)).thenReturn(mediaFile);
             Mockito.when(mediaFileService.getCoverArt(mediaFile)).thenReturn(mediaFile.getFile());
             Mockito.when(mediaFileService.getMediaFile(Integer.parseInt(id))).thenReturn(mediaFile);
             MediaFile parent = new MediaFile();
-            parent.setPath(file.getParent());
+            parent.setPathString(file.getParent());
             parent.setArtist("CoverArtControllerTest#GetTest");
             Mockito.when(mediaFileService.getParentOf(mediaFile)).thenReturn(parent);
 
@@ -215,7 +215,7 @@ class CoverArtControllerTest {
 
         private final Function<File, File> mediaFileStub = (file) -> {
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPath(file.getPath());
+            mediaFile.setPathString(file.getPath());
             Mockito.when(mediaFileService.getMediaFile(file)).thenReturn(mediaFile);
             Mockito.when(mediaFileService.getCoverArt(mediaFile)).thenReturn(mediaFile.getFile());
             return file;
@@ -352,7 +352,7 @@ class CoverArtControllerTest {
             File file = createFile("/MEDIAS/Metadata/tagger3/tagged/test.stem.mp4");
             assertTrue(file.exists());
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPath(file.getPath());
+            mediaFile.setPathString(file.getPath());
             BufferedImage bi = controller.getImageInputStreamForVideo(mediaFile, 200, 160, 0);
             assertEquals(BufferedImage.TYPE_3BYTE_BGR, bi.getType());
             assertEquals(200, bi.getWidth());
@@ -364,7 +364,7 @@ class CoverArtControllerTest {
             File file = new File("/MEDIAS/Metadata/tagger3/tagged/test.unknown.mp4");
             assertFalse(file.exists());
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPath(file.getPath());
+            mediaFile.setPathString(file.getPath());
             assertNull(controller.getImageInputStreamForVideo(mediaFile, 200, 160, 0));
         }
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DownloadControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DownloadControllerTest.java
@@ -88,7 +88,7 @@ class DownloadControllerTest extends AbstractNeedsScan {
         playerService.createPlayer(player);
 
         MediaFile album = mediaFileDao.getNewestAlbums(0, 1, musicFolders).get(0);
-        MediaFile song = mediaFileDao.getChildrenOf(album.getPath()).get(0);
+        MediaFile song = mediaFileDao.getChildrenOf(album.getPathString()).get(0);
 
         MockHttpServletRequest req = new MockHttpServletRequest();
         req.addHeader("Range", "bytes=0-1023");

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MainControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MainControllerTest.java
@@ -72,7 +72,7 @@ class MainControllerTest {
         int rootId = 100;
         String rootPath = MainControllerTest.class.getResource("/MEDIAS").getPath();
         root.setId(rootId);
-        root.setPath(rootPath);
+        root.setPathString(rootPath);
         root.setMediaType(MediaType.DIRECTORY);
         Mockito.when(mediaFileService.getMediaFile(rootPath)).thenReturn(root);
         Mockito.when(mediaFileService.getMediaFile(rootId)).thenReturn(root);
@@ -82,7 +82,7 @@ class MainControllerTest {
         int artistId = 200;
         String artistPath = MainControllerTest.class.getResource("/MEDIAS/Music").getPath();
         artist.setId(artistId);
-        artist.setPath(artistPath);
+        artist.setPathString(artistPath);
         artist.setMediaType(MediaType.DIRECTORY);
 
         Mockito.when(mediaFileService.getMediaFile(artistPath)).thenReturn(artist);
@@ -97,7 +97,7 @@ class MainControllerTest {
         String albumPath = MainControllerTest.class
                 .getResource("/MEDIAS/Music/_DIR_ Ravel/_DIR_ Ravel - Chamber Music With Voice").getPath();
         album.setId(albumId);
-        album.setPath(albumPath);
+        album.setPathString(albumPath);
         album.setMediaType(MediaType.ALBUM);
 
         Mockito.when(mediaFileService.getMediaFile(albumPath)).thenReturn(album);
@@ -112,7 +112,7 @@ class MainControllerTest {
                 "/MEDIAS/Music/_DIR_ Ravel/_DIR_ Ravel - Chamber Music With Voice/01 - Sonata Violin & Cello I. Allegro.ogg")
                 .getPath();
         song.setId(songId);
-        song.setPath(songPath);
+        song.setPathString(songPath);
         song.setMediaType(MediaType.MUSIC);
         Mockito.when(mediaFileService.getMediaFile(songPath)).thenReturn(song);
         Mockito.when(mediaFileService.getMediaFile(songId)).thenReturn(song);
@@ -138,7 +138,7 @@ class MainControllerTest {
 
         // ... or path
         result = mockMvc.perform(MockMvcRequestBuilders.get("/" + ViewName.MAIN.value())
-                .param(Attributes.Request.PATH.value(), album.getPath()))
+                .param(Attributes.Request.PATH.value(), album.getPathString()))
                 .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
         assertNotNull(result);
         modelAndView = result.getModelAndView();

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MainControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MainControllerTest.java
@@ -24,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -59,7 +61,7 @@ class MainControllerTest {
     private MediaFile song;
 
     @BeforeEach
-    public void setup() throws ExecutionException {
+    public void setup() throws ExecutionException, URISyntaxException {
 
         securityService = mock(SecurityService.class);
         MediaFileService mediaFileService = mock(MediaFileService.class);
@@ -70,9 +72,9 @@ class MainControllerTest {
 
         root = new MediaFile();
         int rootId = 100;
-        String rootPath = MainControllerTest.class.getResource("/MEDIAS").getPath();
+        Path rootPath = Path.of(MainControllerTest.class.getResource("/MEDIAS").toURI());
         root.setId(rootId);
-        root.setPathString(rootPath);
+        root.setPathString(rootPath.toString());
         root.setMediaType(MediaType.DIRECTORY);
         Mockito.when(mediaFileService.getMediaFile(rootPath)).thenReturn(root);
         Mockito.when(mediaFileService.getMediaFile(rootId)).thenReturn(root);
@@ -80,7 +82,7 @@ class MainControllerTest {
 
         artist = new MediaFile();
         int artistId = 200;
-        String artistPath = MainControllerTest.class.getResource("/MEDIAS/Music").getPath();
+        String artistPath = Path.of(MainControllerTest.class.getResource("/MEDIAS/Music").toURI()).toString();
         artist.setId(artistId);
         artist.setPathString(artistPath);
         artist.setMediaType(MediaType.DIRECTORY);
@@ -94,8 +96,10 @@ class MainControllerTest {
 
         album = new MediaFile();
         int albumId = 300;
-        String albumPath = MainControllerTest.class
-                .getResource("/MEDIAS/Music/_DIR_ Ravel/_DIR_ Ravel - Chamber Music With Voice").getPath();
+        String albumPath = Path
+                .of(MainControllerTest.class
+                        .getResource("/MEDIAS/Music/_DIR_ Ravel/_DIR_ Ravel - Chamber Music With Voice").toURI())
+                .toString();
         album.setId(albumId);
         album.setPathString(albumPath);
         album.setMediaType(MediaType.ALBUM);
@@ -108,9 +112,9 @@ class MainControllerTest {
 
         song = new MediaFile();
         int songId = 400;
-        String songPath = MainControllerTest.class.getResource(
+        String songPath = Path.of(MainControllerTest.class.getResource(
                 "/MEDIAS/Music/_DIR_ Ravel/_DIR_ Ravel - Chamber Music With Voice/01 - Sonata Violin & Cello I. Allegro.ogg")
-                .getPath();
+                .toURI()).toString();
         song.setId(songId);
         song.setPathString(songPath);
         song.setMediaType(MediaType.MUSIC);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/StatusControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/StatusControllerTest.java
@@ -73,6 +73,6 @@ class StatusControllerTest {
                 .toURI());
         status.setFile(path.toFile());
         TransferStatusHolder holder = new TransferStatusHolder(status, false, false, false, 0, null);
-        assertEquals(FileUtil.getShortPath(path.toFile()), holder.getPath());
+        assertEquals(FileUtil.getShortPath(path), holder.getPath());
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/StatusControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/StatusControllerTest.java
@@ -23,12 +23,17 @@ import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.util.concurrent.ExecutionException;
 
+import com.tesshu.jpsonic.controller.StatusController.TransferStatusHolder;
+import com.tesshu.jpsonic.domain.TransferStatus;
 import com.tesshu.jpsonic.service.SecurityService;
 import com.tesshu.jpsonic.service.ServiceMockUtils;
 import com.tesshu.jpsonic.service.SettingsService;
 import com.tesshu.jpsonic.service.StatusService;
+import com.tesshu.jpsonic.util.FileUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -58,5 +63,16 @@ class StatusControllerTest {
 
         ModelAndView modelAndView = result.getModelAndView();
         assertEquals("status", modelAndView.getViewName());
+    }
+
+    @Test
+    void testTransferStatusHolderGetPath() throws URISyntaxException {
+        TransferStatus status = new TransferStatus();
+        Path path = Path.of(StatusControllerTest.class.getResource(
+                "/MEDIAS/Music/_DIR_ Céline Frisch- Café Zimmermann - Bach- Goldberg Variations, Canons [Disc 1]/01 - Bach- Goldberg Variations, BWV 988 - Aria.flac")
+                .toURI());
+        status.setFile(path.toFile());
+        TransferStatusHolder holder = new TransferStatusHolder(status, false, false, false, 0, null);
+        assertEquals(FileUtil.getShortPath(path.toFile()), holder.getPath());
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/StreamControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/StreamControllerTest.java
@@ -26,7 +26,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.lang.annotation.Documented;
+import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -35,7 +37,6 @@ import java.util.concurrent.ExecutionException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.tesshu.jpsonic.MusicFolderTestDataUtils;
 import com.tesshu.jpsonic.dao.TranscodingDao;
 import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.domain.MediaFile.MediaType;
@@ -711,11 +712,13 @@ class StreamControllerTest {
         private MediaFile song;
         private Player player;
 
-        private void initMocksWithTranscoding(boolean isSetTranscodingsAll, boolean isAnonymous) {
+        private void initMocksWithTranscoding(boolean isSetTranscodingsAll, boolean isAnonymous)
+                throws URISyntaxException {
             song = new MediaFile();
             song.setId(0);
-            song.setPathString(MusicFolderTestDataUtils.resolveMusicFolderPath()
-                    + "/_DIR_ Céline Frisch- Café Zimmermann - Bach- Goldberg Variations, Canons [Disc 1]/01 - Bach- Goldberg Variations, BWV 988 - Aria.flac");
+            song.setPathString(Path.of(StreamControllerTest.class.getResource(
+                    "/MEDIAS/Music/_DIR_ Céline Frisch- Café Zimmermann - Bach- Goldberg Variations, Canons [Disc 1]/01 - Bach- Goldberg Variations, BWV 988 - Aria.flac")
+                    .toURI()).toString());
             song.setMediaType(MediaType.MUSIC);
             song.setFormat("flac");
             song.setFileSize(358_406L);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/StreamControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/StreamControllerTest.java
@@ -185,7 +185,7 @@ class StreamControllerTest {
     @Order(1)
     void testGetMaxBitRate() throws Exception {
         MediaFile song = new MediaFile();
-        song.setPath(TEST_PATH);
+        song.setPathString(TEST_PATH);
         Mockito.when(streamService.getSingleFile(Mockito.any(HttpServletRequest.class))).thenReturn(song);
 
         ArgumentCaptor<Integer> maxBitRateCaptor = ArgumentCaptor.forClass(Integer.class);
@@ -237,7 +237,7 @@ class StreamControllerTest {
         @Order(0)
         void testAuthentication() throws Exception {
             MediaFile song = new MediaFile();
-            song.setPath(TEST_PATH);
+            song.setPathString(TEST_PATH);
             Mockito.when(streamService.getSingleFile(Mockito.any(HttpServletRequest.class))).thenReturn(song);
 
             // no-jwt with stream role(Pass the first certification check)
@@ -268,7 +268,7 @@ class StreamControllerTest {
         @Order(1)
         void testVideoTranscoding() throws Exception {
             MediaFile song = new MediaFile();
-            song.setPath(TEST_PATH);
+            song.setPathString(TEST_PATH);
             Mockito.when(streamService.getSingleFile(Mockito.any(HttpServletRequest.class))).thenReturn(song);
 
             ArgumentCaptor<VideoTranscodingSettings> vtsCaptor = ArgumentCaptor
@@ -416,7 +416,7 @@ class StreamControllerTest {
         @Test
         void na00() throws Exception {
             MediaFile song = new MediaFile();
-            song.setPath(TEST_PATH);
+            song.setPathString(TEST_PATH);
             song.setMediaType(MediaType.MUSIC);
             Mockito.when(streamService.getSingleFile(Mockito.any(HttpServletRequest.class))).thenReturn(song);
             mockMvc.perform(MockMvcRequestBuilders.get(TEST_URL)).andExpect(MockMvcResultMatchers.status().isOk())
@@ -433,7 +433,7 @@ class StreamControllerTest {
         @Test
         void na01() throws Exception {
             MediaFile song = new MediaFile();
-            song.setPath(TEST_PATH);
+            song.setPathString(TEST_PATH);
             song.setMediaType(MediaType.VIDEO);
             Mockito.when(streamService.getSingleFile(Mockito.any(HttpServletRequest.class))).thenReturn(song);
             mockMvc.perform(MockMvcRequestBuilders.get(TEST_URL)).andExpect(MockMvcResultMatchers.status().isOk())
@@ -454,7 +454,7 @@ class StreamControllerTest {
         @Test
         void cr00() throws Exception {
             MediaFile song = new MediaFile();
-            song.setPath(TEST_PATH);
+            song.setPathString(TEST_PATH);
             song.setMediaType(MediaType.MUSIC);
             song.setFileSize(3_200L);
             Mockito.when(streamService.getSingleFile(Mockito.any(HttpServletRequest.class))).thenReturn(song);
@@ -494,7 +494,7 @@ class StreamControllerTest {
         @Test
         void cr01() throws Exception {
             MediaFile song = new MediaFile();
-            song.setPath(TEST_PATH);
+            song.setPathString(TEST_PATH);
             song.setMediaType(MediaType.MUSIC);
             song.setDurationSeconds(10);
             song.setFileSize(3_200L);
@@ -536,7 +536,7 @@ class StreamControllerTest {
         @Test
         void cr02() throws Exception {
             MediaFile song = new MediaFile();
-            song.setPath(TEST_PATH);
+            song.setPathString(TEST_PATH);
             song.setMediaType(MediaType.MUSIC);
             song.setDurationSeconds(10);
             song.setFileSize(3_300L);
@@ -569,7 +569,7 @@ class StreamControllerTest {
         @Test
         void cr03() throws Exception {
             MediaFile song = new MediaFile();
-            song.setPath(TEST_PATH);
+            song.setPathString(TEST_PATH);
             song.setMediaType(MediaType.MUSIC);
             song.setDurationSeconds(10);
             song.setFileSize(3_300L);
@@ -602,7 +602,7 @@ class StreamControllerTest {
         @Test
         void cr04() throws Exception {
             MediaFile song = new MediaFile();
-            song.setPath(TEST_PATH);
+            song.setPathString(TEST_PATH);
             song.setMediaType(MediaType.MUSIC);
             song.setDurationSeconds(null);
             song.setFileSize(3_300L);
@@ -714,7 +714,7 @@ class StreamControllerTest {
         private void initMocksWithTranscoding(boolean isSetTranscodingsAll, boolean isAnonymous) {
             song = new MediaFile();
             song.setId(0);
-            song.setPath(MusicFolderTestDataUtils.resolveMusicFolderPath()
+            song.setPathString(MusicFolderTestDataUtils.resolveMusicFolderPath()
                     + "/_DIR_ Céline Frisch- Café Zimmermann - Bach- Goldberg Variations, Canons [Disc 1]/01 - Bach- Goldberg Variations, BWV 988 - Aria.flac");
             song.setMediaType(MediaType.MUSIC);
             song.setFormat("flac");
@@ -1005,7 +1005,7 @@ class StreamControllerTest {
         @Test
         void testHls() throws Exception {
             MediaFile song = new MediaFile();
-            song.setPath(TEST_PATH);
+            song.setPathString(TEST_PATH);
             Mockito.when(streamService.getSingleFile(Mockito.any(HttpServletRequest.class))).thenReturn(song);
 
             // hls
@@ -1043,7 +1043,7 @@ class StreamControllerTest {
     void testWriteVerboseLog() throws Exception {
         Mockito.when(settingsService.isVerboseLogPlaying()).thenReturn(true);
         MediaFile song = new MediaFile();
-        song.setPath(TEST_PATH);
+        song.setPathString(TEST_PATH);
         song.setDurationSeconds(10);
         song.setFileSize(3_300L);
         Mockito.when(streamService.getSingleFile(Mockito.any(HttpServletRequest.class))).thenReturn(song);
@@ -1074,7 +1074,7 @@ class StreamControllerTest {
     void testWriteErrorLog() throws Exception {
         Mockito.when(settingsService.isVerboseLogPlaying()).thenReturn(true);
         MediaFile song = new MediaFile();
-        song.setPath(TEST_PATH);
+        song.setPathString(TEST_PATH);
         song.setDurationSeconds(10);
         song.setFileSize(3_300L);
         Mockito.when(streamService.getSingleFile(Mockito.any(HttpServletRequest.class))).thenReturn(song);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/SubsonicRESTControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/SubsonicRESTControllerTest.java
@@ -1102,7 +1102,7 @@ class SubsonicRESTControllerTest extends AbstractNeedsScan {
                     musicFolderDao.getAllMusicFolders());
             MediaFile song = mediaFileDao.getRandomSongs(criteria, ServiceMockUtils.ADMIN_NAME).get(0);
             assertNotNull(song);
-            req.setParameter(Attributes.Request.PATH.value(), song.getPath());
+            req.setParameter(Attributes.Request.PATH.value(), song.getPathString());
             res = new MockHttpServletResponse();
             streamController.handleRequest(req, res, true);
             assertNotEquals(0, res.getContentLength());
@@ -1159,7 +1159,7 @@ class SubsonicRESTControllerTest extends AbstractNeedsScan {
                     musicFolderDao.getAllMusicFolders());
             MediaFile song = mediaFileDao.getRandomSongs(criteria, ServiceMockUtils.ADMIN_NAME).get(0);
             assertNotNull(song);
-            req.setParameter(Attributes.Request.PATH.value(), song.getPath());
+            req.setParameter(Attributes.Request.PATH.value(), song.getPathString());
             res = new MockHttpServletResponse();
             streamController.handleRequest(req, res, true);
             assertNotEquals(0, res.getContentLength());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/SubsonicRESTControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/SubsonicRESTControllerTest.java
@@ -1110,7 +1110,7 @@ class SubsonicRESTControllerTest extends AbstractNeedsScan {
             statusService.getAllStreamStatuses().stream().filter(t -> player.getId() == t.getPlayer().getId())
                     .findFirst().ifPresentOrElse((status) -> {
                         assertNotNull(status.getFile());
-                        assertEquals(song.getFile(), status.getFile());
+                        assertEquals(song.toPath(), status.getFile().toPath());
                     }, () -> Assertions.fail());
 
             res = new MockHttpServletResponse();
@@ -1130,7 +1130,7 @@ class SubsonicRESTControllerTest extends AbstractNeedsScan {
             statusService.getAllStreamStatuses().stream().filter(t -> player.getId() == t.getPlayer().getId())
                     .findFirst().ifPresentOrElse((status) -> {
                         assertNotNull(status.getFile());
-                        assertEquals(song.getFile(), status.getFile());
+                        assertEquals(song.toPath(), status.getFile().toPath());
                     }, () -> Assertions.fail());
 
             res.getOutputStream().close();
@@ -1167,7 +1167,7 @@ class SubsonicRESTControllerTest extends AbstractNeedsScan {
             statusService.getAllStreamStatuses().stream().filter(t -> player.getId() == t.getPlayer().getId())
                     .findFirst().ifPresentOrElse((status) -> {
                         assertNotNull(status.getFile());
-                        assertEquals(song.getFile(), status.getFile());
+                        assertEquals(song.toPath(), status.getFile().toPath());
                     }, () -> Assertions.fail());
 
             res = new MockHttpServletResponse();
@@ -1189,7 +1189,7 @@ class SubsonicRESTControllerTest extends AbstractNeedsScan {
             statusService.getAllStreamStatuses().stream().filter(t -> player.getId() == t.getPlayer().getId())
                     .findFirst().ifPresentOrElse((status) -> {
                         assertNotNull(status.getFile());
-                        assertEquals(song.getFile(), status.getFile());
+                        assertEquals(song.toPath(), status.getFile().toPath());
                     }, () -> Assertions.fail());
 
             res.getOutputStream().close();

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/UploadControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/UploadControllerTest.java
@@ -26,7 +26,6 @@ import java.io.File;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -82,7 +81,7 @@ class UploadControllerTest {
 
         MockMultipartHttpServletRequest req = new MockMultipartHttpServletRequest();
 
-        byte[] data = IOUtils.toByteArray(Files.newInputStream(Paths.get(url.toURI())));
+        byte[] data = IOUtils.toByteArray(Files.newInputStream(Path.of(url.toURI())));
         req.setContent(createFileContent(tempDirPath.toString(), FILE_NAME, FILE_CONTENT_TYPE, data));
         req.setContentType("multipart/form-data; boundary=" + BOUNDARY);
 
@@ -110,7 +109,7 @@ class UploadControllerTest {
 
         MockMultipartHttpServletRequest req = new MockMultipartHttpServletRequest();
 
-        byte[] data = IOUtils.toByteArray(Files.newInputStream(Paths.get(url.toURI())));
+        byte[] data = IOUtils.toByteArray(Files.newInputStream(Path.of(url.toURI())));
         byte[] fileContent = createFileContent(tempDirPath.toString(), ZIP_NAME, ZIP_CONTENT_TYPE, data);
 
         String zipField = "--" + BOUNDARY + SEPA + " Content-Disposition: form-data; name=\""

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/VideoPlayerControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/VideoPlayerControllerTest.java
@@ -54,7 +54,7 @@ class VideoPlayerControllerTest {
         file.setId(0);
         MediaFile dir = new MediaFile();
         dir.setId(1);
-        dir.setPath("");
+        dir.setPathString("");
 
         MediaFileService mediaFileService = mock(MediaFileService.class);
         Mockito.when(mediaFileService.getMediaFile(file.getId())).thenReturn(file);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/JMediaFileDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/JMediaFileDaoTest.java
@@ -307,7 +307,7 @@ class JMediaFileDaoTest extends AbstractNeedsScan {
         populateDatabaseOnlyOnce(null, () -> {
             List<MediaFile> albums = mediaFileDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, false, MUSIC_FOLDERS);
             albums.forEach(a -> {
-                List<MediaFile> files = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, a.getPath(), false);
+                List<MediaFile> files = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, a.getPathString(), false);
                 files.stream().filter(m -> "file10".equals(m.getName()) || "file12".equals(m.getName())
                         || "file14".equals(m.getName()) || "file17".equals(m.getName())).forEach(m -> {
                             m.setChanged(now);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JapaneseReadingUtilsTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JapaneseReadingUtilsTest.java
@@ -1467,7 +1467,7 @@ class JapaneseReadingUtilsTest {
             MediaFile mediaFile = new MediaFile();
             mediaFile.setArtist(name);
             mediaFile.setArtistSort(sort);
-            mediaFile.setPath(path);
+            mediaFile.setPathString(path);
             return mediaFile;
         }
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JpsonicComparatorsTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JpsonicComparatorsTest.java
@@ -1021,22 +1021,22 @@ class JpsonicComparatorsTest extends AbstractNeedsScan {
 
         MediaFile albumA2012 = new MediaFile();
         albumA2012.setMediaType(MediaFile.MediaType.ALBUM);
-        albumA2012.setPath("a");
+        albumA2012.setPathString("a");
         albumA2012.setYear(2012);
 
         MediaFile albumB2012 = new MediaFile();
         albumB2012.setMediaType(MediaFile.MediaType.ALBUM);
-        albumB2012.setPath("b");
+        albumB2012.setPathString("b");
         albumB2012.setYear(2012);
 
         MediaFile album2013 = new MediaFile();
         album2013.setMediaType(MediaFile.MediaType.ALBUM);
-        album2013.setPath("c");
+        album2013.setPathString("c");
         album2013.setYear(2013);
 
         MediaFile albumWithoutYear = new MediaFile();
         albumWithoutYear.setMediaType(MediaFile.MediaType.ALBUM);
-        albumWithoutYear.setPath("c");
+        albumWithoutYear.setPathString("c");
 
         assertEquals(0, comparator.compare(albumWithoutYear, albumWithoutYear));
         assertEquals(0, comparator.compare(albumA2012, albumA2012));
@@ -1066,35 +1066,35 @@ class JpsonicComparatorsTest extends AbstractNeedsScan {
 
         MediaFile discXtrack1 = new MediaFile();
         discXtrack1.setMediaType(MediaFile.MediaType.MUSIC);
-        discXtrack1.setPath("a");
+        discXtrack1.setPathString("a");
         discXtrack1.setTrackNumber(1);
 
         MediaFile discXtrack2 = new MediaFile();
         discXtrack2.setMediaType(MediaFile.MediaType.MUSIC);
-        discXtrack2.setPath("a");
+        discXtrack2.setPathString("a");
         discXtrack2.setTrackNumber(2);
 
         MediaFile disc5track1 = new MediaFile();
         disc5track1.setMediaType(MediaFile.MediaType.MUSIC);
-        disc5track1.setPath("a");
+        disc5track1.setPathString("a");
         disc5track1.setDiscNumber(5);
         disc5track1.setTrackNumber(1);
 
         MediaFile disc5track2 = new MediaFile();
         disc5track2.setMediaType(MediaFile.MediaType.MUSIC);
-        disc5track2.setPath("a");
+        disc5track2.setPathString("a");
         disc5track2.setDiscNumber(5);
         disc5track2.setTrackNumber(2);
 
         MediaFile disc6track1 = new MediaFile();
         disc6track1.setMediaType(MediaFile.MediaType.MUSIC);
-        disc6track1.setPath("a");
+        disc6track1.setPathString("a");
         disc6track1.setDiscNumber(6);
         disc6track1.setTrackNumber(1);
 
         MediaFile disc6track2 = new MediaFile();
         disc6track2.setMediaType(MediaFile.MediaType.MUSIC);
-        disc6track2.setPath("a");
+        disc6track2.setPathString("a");
         disc6track2.setDiscNumber(6);
         disc6track2.setTrackNumber(2);
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JpsonicComparatorsTestUtils.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JpsonicComparatorsTestUtils.java
@@ -85,7 +85,7 @@ public class JpsonicComparatorsTestUtils {
             file.setAlbumArtistSort("abcいうえおあ");
         }
         file.setTitle(name);
-        file.setPath(name);
+        file.setPathString(name);
         file.setMediaType(MediaType.DIRECTORY);
         utils.analyze(file);
         return file;
@@ -139,7 +139,7 @@ public class JpsonicComparatorsTestUtils {
             file.setTitleSort("abcいうえおあ");
         }
         file.setTrackNumber(trackNumber);
-        file.setPath(name);
+        file.setPathString(name);
         file.setMediaType(MediaType.MUSIC);
 
         utils.analyze(file);
@@ -173,7 +173,7 @@ public class JpsonicComparatorsTestUtils {
         }
 
         file.setTitle(name);
-        file.setPath(name);
+        file.setPathString(name);
         file.setMediaType(MediaType.ALBUM);
 
         utils.analyze(file);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/MediaFileTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/MediaFileTest.java
@@ -24,6 +24,10 @@ package com.tesshu.jpsonic.domain;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+
 import org.junit.jupiter.api.Test;
 
 /**
@@ -32,6 +36,16 @@ import org.junit.jupiter.api.Test;
  * @author Sindre Mehus
  */
 class MediaFileTest {
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void testGetfile() throws URISyntaxException {
+        MediaFile mediaFile = new MediaFile();
+        URL url = MediaFileTest.class.getResource("/MEDIAS/Music3/TestAlbum/01 - Aria.flac");
+        mediaFile.setPathString(url.toURI().toString().replace("file:/", ""));
+        File file = mediaFile.getFile();
+        assertEquals(file.toPath(), mediaFile.toPath());
+    }
 
     @Test
     void testGetDurationAsString() {

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/LegacyDatabaseStartupTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/LegacyDatabaseStartupTest.java
@@ -31,7 +31,7 @@ import java.net.JarURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.Enumeration;
 import java.util.Objects;
 import java.util.jar.JarEntry;
@@ -77,8 +77,8 @@ class LegacyDatabaseStartupTest {
     }
 
     private static boolean copyFile(final File toCopy, final File destFile) {
-        try (OutputStream os = Files.newOutputStream(Paths.get(destFile.toURI()));
-                InputStream is = Files.newInputStream(Paths.get(toCopy.toURI()))) {
+        try (OutputStream os = Files.newOutputStream(Path.of(destFile.toURI()));
+                InputStream is = Files.newInputStream(Path.of(toCopy.toURI()))) {
             return copyStream(is, os);
         } catch (IOException e) {
             LOG.error("Exception occurred while copying file.", e);
@@ -148,7 +148,7 @@ class LegacyDatabaseStartupTest {
     }
 
     private static boolean copyStream(final InputStream is, final File f) {
-        try (OutputStream os = Files.newOutputStream(Paths.get(f.toURI()))) {
+        try (OutputStream os = Files.newOutputStream(Path.of(f.toURI()))) {
             return copyStream(is, os);
         } catch (IOException e) {
             LOG.error("Exception occurred while copying stream.", e);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaFileServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaFileServiceTest.java
@@ -210,7 +210,7 @@ class MediaFileServiceTest {
             final boolean useFastCache = true;
             Mockito.when(settingsService.isIgnoreFileTimestamps()).thenReturn(false);
             MediaFile mediaFile = createMediaFile(MediaFileDao.VERSION);
-            mediaFile.setPath(dir.getPath());
+            mediaFile.setPathString(dir.getPath());
             mediaFile.setChanged(new Date(dir.lastModified()));
 
             assertEquals(mediaFile, mediaFileService.checkLastModified(mediaFile, useFastCache));
@@ -225,7 +225,7 @@ class MediaFileServiceTest {
             final boolean useFastCache = false;
             Mockito.when(settingsService.isIgnoreFileTimestamps()).thenReturn(false);
             MediaFile mediaFile = createMediaFile(MediaFileDao.VERSION - 1);
-            mediaFile.setPath(dir.getPath());
+            mediaFile.setPathString(dir.getPath());
             mediaFile.setChanged(new Date(dir.lastModified()));
 
             assertThat("mediaFile#version Lt MediaFileDao.VERSION", mediaFile.getVersion(),
@@ -246,7 +246,7 @@ class MediaFileServiceTest {
             final boolean useFastCache = false;
             Mockito.when(settingsService.isIgnoreFileTimestamps()).thenReturn(true);
             MediaFile mediaFile = createMediaFile(MediaFileDao.VERSION);
-            mediaFile.setPath(dir.getPath());
+            mediaFile.setPathString(dir.getPath());
             mediaFile.setChanged(new Date(dir.lastModified()));
             mediaFile.setLastScanned(ZERO_DATE);
 
@@ -276,7 +276,7 @@ class MediaFileServiceTest {
             final boolean useFastCache = false;
             Mockito.when(settingsService.isIgnoreFileTimestamps()).thenReturn(true);
             MediaFile mediaFile = createMediaFile(MediaFileDao.VERSION);
-            mediaFile.setPath(dir.getPath());
+            mediaFile.setPathString(dir.getPath());
             mediaFile.setChanged(new Date(dir.lastModified()));
             mediaFile.setLastScanned(new Date(mediaFile.getChanged().getTime() + 1));
 
@@ -305,7 +305,7 @@ class MediaFileServiceTest {
             final boolean useFastCache = false;
             Mockito.when(settingsService.isIgnoreFileTimestamps()).thenReturn(true);
             MediaFile mediaFile = createMediaFile(MediaFileDao.VERSION);
-            mediaFile.setPath(dir.getPath());
+            mediaFile.setPathString(dir.getPath());
             mediaFile.setChanged(new Date(dir.lastModified() - 1L));
             mediaFile.setLastScanned(ZERO_DATE);
 
@@ -328,7 +328,7 @@ class MediaFileServiceTest {
             final boolean useFastCache = false;
             Mockito.when(settingsService.isIgnoreFileTimestamps()).thenReturn(true);
             MediaFile mediaFile = createMediaFile(MediaFileDao.VERSION);
-            mediaFile.setPath(dir.getPath());
+            mediaFile.setPathString(dir.getPath());
             mediaFile.setChanged(new Date(dir.lastModified() - 1L));
             mediaFile.setLastScanned(mediaFile.getChanged());
 
@@ -351,7 +351,7 @@ class MediaFileServiceTest {
             final boolean useFastCache = false;
             Mockito.when(settingsService.isIgnoreFileTimestamps()).thenReturn(false);
             MediaFile mediaFile = createMediaFile(MediaFileDao.VERSION);
-            mediaFile.setPath(dir.getPath());
+            mediaFile.setPathString(dir.getPath());
             mediaFile.setChanged(new Date(dir.lastModified()));
             mediaFile.setLastScanned(ZERO_DATE);
 
@@ -381,7 +381,7 @@ class MediaFileServiceTest {
             final boolean useFastCache = false;
             Mockito.when(settingsService.isIgnoreFileTimestamps()).thenReturn(false);
             MediaFile mediaFile = createMediaFile(MediaFileDao.VERSION);
-            mediaFile.setPath(dir.getPath());
+            mediaFile.setPathString(dir.getPath());
             mediaFile.setChanged(new Date(dir.lastModified()));
             mediaFile.setLastScanned(mediaFile.getChanged());
 
@@ -411,7 +411,7 @@ class MediaFileServiceTest {
             final boolean useFastCache = false;
             Mockito.when(settingsService.isIgnoreFileTimestamps()).thenReturn(true);
             MediaFile mediaFile = createMediaFile(MediaFileDao.VERSION);
-            mediaFile.setPath(dir.getPath());
+            mediaFile.setPathString(dir.getPath());
             mediaFile.setChanged(new Date(dir.lastModified() - 1L));
             mediaFile.setLastScanned(ZERO_DATE);
 
@@ -434,7 +434,7 @@ class MediaFileServiceTest {
             final boolean useFastCache = false;
             Mockito.when(settingsService.isIgnoreFileTimestamps()).thenReturn(false);
             MediaFile mediaFile = createMediaFile(MediaFileDao.VERSION);
-            mediaFile.setPath(dir.getPath());
+            mediaFile.setPathString(dir.getPath());
             mediaFile.setChanged(new Date(dir.lastModified() - 1L));
             mediaFile.setLastScanned(mediaFile.getChanged());
 
@@ -458,7 +458,7 @@ class MediaFileServiceTest {
             Mockito.when(settingsService.getFileModifiedCheckSchemeName())
                     .thenReturn(FileModifiedCheckScheme.LAST_SCANNED.name());
             MediaFile mediaFile = createMediaFile(MediaFileDao.VERSION);
-            mediaFile.setPath(dir.getPath());
+            mediaFile.setPathString(dir.getPath());
             mediaFile.setChanged(new Date(dir.lastModified()));
             mediaFile.setLastScanned(ZERO_DATE);
 
@@ -480,7 +480,7 @@ class MediaFileServiceTest {
             Mockito.when(settingsService.getFileModifiedCheckSchemeName())
                     .thenReturn(FileModifiedCheckScheme.LAST_SCANNED.name());
             MediaFile mediaFile = createMediaFile(MediaFileDao.VERSION);
-            mediaFile.setPath(dir.getPath());
+            mediaFile.setPathString(dir.getPath());
             mediaFile.setChanged(new Date(dir.lastModified()));
             mediaFile.setLastScanned(mediaFile.getChanged());
 
@@ -511,7 +511,7 @@ class MediaFileServiceTest {
             Mockito.when(settingsService.getFileModifiedCheckSchemeName())
                     .thenReturn(FileModifiedCheckScheme.LAST_SCANNED.name());
             MediaFile mediaFile = createMediaFile(MediaFileDao.VERSION);
-            mediaFile.setPath(dir.getPath());
+            mediaFile.setPathString(dir.getPath());
             mediaFile.setChanged(new Date(dir.lastModified() - 1L));
             mediaFile.setLastScanned(ZERO_DATE);
 
@@ -535,7 +535,7 @@ class MediaFileServiceTest {
             Mockito.when(settingsService.getFileModifiedCheckSchemeName())
                     .thenReturn(FileModifiedCheckScheme.LAST_SCANNED.name());
             MediaFile mediaFile = createMediaFile(MediaFileDao.VERSION);
-            mediaFile.setPath(dir.getPath());
+            mediaFile.setPathString(dir.getPath());
             mediaFile.setChanged(new Date(dir.lastModified() - 1L));
             mediaFile.setLastScanned(mediaFile.getChanged());
 
@@ -810,7 +810,7 @@ class MediaFileServiceTest {
 
             Function<File, File> stub = (file) -> {
                 MediaFile mediaFile = new MediaFile();
-                mediaFile.setPath(file.getPath());
+                mediaFile.setPathString(file.getPath());
                 Mockito.when(mediaFileDao.getMediaFile(file.getPath())).thenReturn(mediaFile);
                 return file;
             };

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceGetChildrenOfTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceGetChildrenOfTest.java
@@ -97,13 +97,13 @@ class MediaScannerServiceGetChildrenOfTest extends AbstractNeedsScan {
     void testSpecialCharactersInDirName() throws URISyntaxException, IOException, InterruptedException {
 
         MediaFile artist = mediaFileDao.getMediaFile(this.artist.getPath());
-        assertEquals(this.artist.getPath(), artist.getPath());
+        assertEquals(this.artist.getPath(), artist.getPathString());
         assertEquals("ARTIST", artist.getName());
         MediaFile album = mediaFileDao.getMediaFile(this.album.getPath());
-        assertEquals(this.album.getPath(), album.getPath());
+        assertEquals(this.album.getPath(), album.getPathString());
         assertEquals("ALBUM", album.getName());
         MediaFile song = mediaFileDao.getMediaFile(this.song.getPath());
-        assertEquals(this.song.getPath(), song.getPath());
+        assertEquals(this.song.getPath(), song.getPathString());
         assertEquals("ARTIST", song.getArtist());
         assertEquals("ALBUM", song.getAlbumName());
 
@@ -123,7 +123,7 @@ class MediaScannerServiceGetChildrenOfTest extends AbstractNeedsScan {
         List<MediaFile> songs = mediaFileDao.getChildrenOf(this.album.getPath());
         assertEquals(1, songs.size());
         song = songs.get(0);
-        assertEquals(this.song.getPath(), song.getPath());
+        assertEquals(this.song.getPath(), song.getPathString());
         assertEquals("ARTIST", song.getArtist());
         assertEquals("ALBUM", song.getAlbumName());
 
@@ -143,15 +143,15 @@ class MediaScannerServiceGetChildrenOfTest extends AbstractNeedsScan {
 
         // Artist and Album are not subject to the update process
         artist = mediaFileDao.getMediaFile(this.artist.getPath());
-        assertEquals(this.artist.getPath(), artist.getPath());
+        assertEquals(this.artist.getPath(), artist.getPathString());
         assertEquals("ARTIST", artist.getName());
         album = mediaFileDao.getMediaFile(this.album.getPath());
-        assertEquals(this.album.getPath(), album.getPath());
+        assertEquals(this.album.getPath(), album.getPathString());
         assertEquals("ALBUM", album.getName());
 
         // Only songs are updated
         song = mediaFileDao.getMediaFile(this.song.getPath());
-        assertEquals(this.song.getPath(), song.getPath());
+        assertEquals(this.song.getPath(), song.getPathString());
         assertEquals("Edited artist!", song.getArtist());
         assertEquals("Edited album!", song.getAlbumName());
 
@@ -180,18 +180,18 @@ class MediaScannerServiceGetChildrenOfTest extends AbstractNeedsScan {
         }
 
         artist = mediaFileDao.getMediaFile(this.artist.getPath());
-        assertEquals(this.artist.getPath(), artist.getPath());
+        assertEquals(this.artist.getPath(), artist.getPathString());
         assertNull(artist.getTitle());
         assertEquals("ARTIST", artist.getName());
         assertEquals("ARTIST", artist.getArtist());
         album = mediaFileDao.getMediaFile(this.album.getPath());
-        assertEquals(this.album.getPath(), album.getPath());
+        assertEquals(this.album.getPath(), album.getPathString());
         assertNull(album.getTitle());
         assertEquals("ALBUM", album.getName());
         assertEquals("Edited album!", album.getAlbumName());
 
         song = mediaFileDao.getMediaFile(this.song.getPath());
-        assertEquals(this.song.getPath(), song.getPath());
+        assertEquals(this.song.getPath(), song.getPathString());
         assertEquals("Edited song!", song.getTitle());
         assertEquals("Edited song!", song.getName());
         assertEquals("Edited artist!", song.getArtist());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceGetChildrenOfTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceGetChildrenOfTest.java
@@ -97,10 +97,10 @@ class MediaScannerServiceGetChildrenOfTest extends AbstractNeedsScan {
     void testSpecialCharactersInDirName() throws URISyntaxException, IOException, InterruptedException {
 
         MediaFile artist = mediaFileDao.getMediaFile(this.artist.getPath());
-        assertEquals(this.artist.getPath(), artist.getPathString());
+        assertEquals(this.artist.toPath(), artist.toPath());
         assertEquals("ARTIST", artist.getName());
         MediaFile album = mediaFileDao.getMediaFile(this.album.getPath());
-        assertEquals(this.album.getPath(), album.getPathString());
+        assertEquals(this.album.toPath(), album.toPath());
         assertEquals("ALBUM", album.getName());
         MediaFile song = mediaFileDao.getMediaFile(this.song.getPath());
         assertEquals(this.song.getPath(), song.getPathString());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceTest.java
@@ -281,8 +281,8 @@ class MediaScannerServiceTest {
         assertEquals("TestArtist", file.getAlbumArtist());
         assertEquals(1, (long) file.getTrackNumber());
         assertEquals(2001, (long) file.getYear());
-        assertEquals(album.getPath(), file.getParentPath());
-        assertEquals(new File(album.getPath()).toPath().resolve("01 - Aria.flac").toString(), file.getPath());
+        assertEquals(album.getPath(), file.getParentPathString());
+        assertEquals(new File(album.getPath()).toPath().resolve("01 - Aria.flac").toString(), file.getPathString());
         assertEquals("0820752d-1043-4572-ab36-2df3b5cc15fa", file.getMusicBrainzReleaseId());
         assertEquals("831586f4-56f9-4785-ac91-447ae20af633", file.getMusicBrainzRecordingId());
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceUnitTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceUnitTest.java
@@ -134,7 +134,7 @@ class MediaScannerServiceUnitTest {
             Genres genres = new Genres();
 
             List<MediaFile> children = Arrays.asList(child);
-            Mockito.when(mediaFileDao.getChildrenOf(album.getPath())).thenReturn(children);
+            Mockito.when(mediaFileDao.getChildrenOf(album.getPathString())).thenReturn(children);
 
             mediaScannerService.scanFile(album, musicFolder, statistics, albumCount, genres, false);
         }
@@ -147,7 +147,7 @@ class MediaScannerServiceUnitTest {
             // nonull
             MediaFile song = new MediaFile();
             song.setAlbumName("albumName");
-            song.setParentPath("parentPath");
+            song.setParentPathString("parentPath");
             song.setMediaType(MediaType.MUSIC);
             song.setArtist("artist");
 
@@ -177,7 +177,7 @@ class MediaScannerServiceUnitTest {
             Mockito.verify(albumDao, Mockito.never()).createOrUpdateAlbum(Mockito.any(Album.class));
 
             song = createSong();
-            song.setParentPath(null);
+            song.setParentPathString(null);
             mediaScannerService.updateAlbum(song, musicFolder, statistics.getScanDate(), albumCount);
             Mockito.verify(albumDao, Mockito.never()).createOrUpdateAlbum(Mockito.any(Album.class));
 
@@ -301,7 +301,7 @@ class MediaScannerServiceUnitTest {
         void testGetMergedAlbum() {
 
             final MediaFile song1 = createSong();
-            song1.setCoverArtPath("coverArtPath1");
+            song1.setCoverArtPathString("coverArtPath1");
 
             song1.setMusicBrainzReleaseId("musicBrainzReleaseId1");
             MusicFolder musicFolder = createMusicFolder();
@@ -310,7 +310,7 @@ class MediaScannerServiceUnitTest {
 
             final MediaFile parent = createSong();
             Mockito.when(mediaFileService.getParentOf(Mockito.any(MediaFile.class))).thenReturn(parent);
-            parent.setCoverArtPath("parentCoverArtPath");
+            parent.setCoverArtPathString("parentCoverArtPath");
 
             // ## First run
             ArgumentCaptor<Album> albumCap = ArgumentCaptor.forClass(Album.class);
@@ -322,7 +322,7 @@ class MediaScannerServiceUnitTest {
             assertEquals("parentCoverArtPath", registeredAlbum.getCoverArtPath());
 
             final MediaFile song2 = createSong();
-            song2.setCoverArtPath("coverArtPath2");
+            song2.setCoverArtPathString("coverArtPath2");
 
             song2.setMusicBrainzReleaseId("musicBrainzReleaseId2");
             Mockito.when(albumDao.getAlbumForFile(song2)).thenReturn(registeredAlbum);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceUnitTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceUnitTest.java
@@ -29,6 +29,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
@@ -99,6 +101,10 @@ class MediaScannerServiceUnitTest {
             return new File(MediaFileServiceTest.class.getResource(path).toURI());
         }
 
+        private Path createPath(String path) throws URISyntaxException {
+            return Path.of(MediaFileServiceTest.class.getResource(path).toURI());
+        }
+
         @Test
         void testScanFile() throws URISyntaxException, ExecutionException {
 
@@ -116,14 +122,14 @@ class MediaScannerServiceUnitTest {
 
             Mockito.when(settingsService.getVideoFileTypesAsArray()).thenReturn(new String[0]);
             Mockito.when(settingsService.getMusicFileTypesAsArray()).thenReturn(new String[] { "mp3" });
-            Mockito.when(securityService.isReadAllowed(Mockito.any(File.class))).thenReturn(true);
+            Mockito.when(securityService.isReadAllowed(Mockito.any(Path.class))).thenReturn(true);
 
-            File dir = createFile("/MEDIAS/Music2/_DIR_ chrome hoof - 2004");
-            assertTrue(dir.isDirectory());
+            Path dir = createPath("/MEDIAS/Music2/_DIR_ chrome hoof - 2004");
+            assertTrue(Files.isDirectory(dir));
             MediaFile album = mediaFileService.createMediaFile(dir);
 
-            File file = createFile("/MEDIAS/Music2/_DIR_ chrome hoof - 2004/10 telegraph hill.mp3");
-            assertTrue(file.isFile());
+            Path file = createPath("/MEDIAS/Music2/_DIR_ chrome hoof - 2004/10 telegraph hill.mp3");
+            assertFalse(Files.isDirectory(file));
             MediaFile child = mediaFileService.createMediaFile(file);
             child.setLastScanned(MediaFileDao.ZERO_DATE);
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceUtilsCompensateSortOfArtistTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceUtilsCompensateSortOfArtistTest.java
@@ -84,8 +84,8 @@ class MediaScannerServiceUtilsCompensateSortOfArtistTest extends AbstractNeedsSc
         utils.copySortOfArtist();
 
         List<MediaFile> artists = mediaFileDao.getArtistAll(MUSIC_FOLDERS);
-        List<MediaFile> albums = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, artists.get(0).getPath(), false);
-        List<MediaFile> files = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, albums.get(0).getPath(), false);
+        List<MediaFile> albums = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, artists.get(0).getPathString(), false);
+        List<MediaFile> files = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, albums.get(0).getPathString(), false);
         assertEquals(3, files.size());
 
         files.forEach(m -> {
@@ -117,8 +117,8 @@ class MediaScannerServiceUtilsCompensateSortOfArtistTest extends AbstractNeedsSc
             }
         });
 
-        albums = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, artists.get(1).getPath(), false);
-        files = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, albums.get(0).getPath(), false);
+        albums = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, artists.get(1).getPathString(), false);
+        files = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, albums.get(0).getPathString(), false);
         assertEquals(1, files.size());
         assertEquals("file4", files.get(0).getName());
         assertEquals("山田耕筰", files.get(0).getArtist());
@@ -141,8 +141,8 @@ class MediaScannerServiceUtilsCompensateSortOfArtistTest extends AbstractNeedsSc
         utils.compensateSortOfArtist();
 
         artists = mediaFileDao.getArtistAll(MUSIC_FOLDERS);
-        albums = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, artists.get(0).getPath(), false);
-        files = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, albums.get(0).getPath(), false);
+        albums = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, artists.get(0).getPathString(), false);
+        files = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, albums.get(0).getPathString(), false);
         assertEquals(3, files.size());
 
         files.forEach(m -> {

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceUtilsCompensateSortOfArtistTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceUtilsCompensateSortOfArtistTest.java
@@ -84,7 +84,8 @@ class MediaScannerServiceUtilsCompensateSortOfArtistTest extends AbstractNeedsSc
         utils.copySortOfArtist();
 
         List<MediaFile> artists = mediaFileDao.getArtistAll(MUSIC_FOLDERS);
-        List<MediaFile> albums = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, artists.get(0).getPathString(), false);
+        List<MediaFile> albums = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, artists.get(0).getPathString(),
+                false);
         List<MediaFile> files = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, albums.get(0).getPathString(), false);
         assertEquals(3, files.size());
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceUtilsCopySortOfArtistTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceUtilsCopySortOfArtistTest.java
@@ -84,10 +84,10 @@ class MediaScannerServiceUtilsCopySortOfArtistTest extends AbstractNeedsScan {
 
         List<MediaFile> artists = mediaFileDao.getArtistAll(MUSIC_FOLDERS);
         assertEquals(1, artists.size());
-        List<MediaFile> albums = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, artists.get(0).getPath(), false);
+        List<MediaFile> albums = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, artists.get(0).getPathString(), false);
         assertEquals(1, albums.size());
         MediaFile album = albums.get(0);
-        List<MediaFile> files = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, album.getPath(), false);
+        List<MediaFile> files = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, album.getPathString(), false);
         assertEquals(2, files.size());
         List<Artist> artistID3s = artistDao.getAlphabetialArtists(0, Integer.MAX_VALUE, MUSIC_FOLDERS);
         assertEquals(1, artistID3s.size());
@@ -104,7 +104,7 @@ class MediaScannerServiceUtilsCopySortOfArtistTest extends AbstractNeedsScan {
 
         utils.copySortOfArtist();
 
-        files = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, album.getPath(), false);
+        files = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, album.getPathString(), false);
         artistID3s = artistDao.getAlphabetialArtists(0, Integer.MAX_VALUE, MUSIC_FOLDERS);
 
         assertEquals(2, files.size());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceUtilsCopySortOfArtistTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceUtilsCopySortOfArtistTest.java
@@ -84,7 +84,8 @@ class MediaScannerServiceUtilsCopySortOfArtistTest extends AbstractNeedsScan {
 
         List<MediaFile> artists = mediaFileDao.getArtistAll(MUSIC_FOLDERS);
         assertEquals(1, artists.size());
-        List<MediaFile> albums = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, artists.get(0).getPathString(), false);
+        List<MediaFile> albums = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, artists.get(0).getPathString(),
+                false);
         assertEquals(1, albums.size());
         MediaFile album = albums.get(0);
         List<MediaFile> files = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, album.getPathString(), false);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceUtilsMergeSortOfArtistTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceUtilsMergeSortOfArtistTest.java
@@ -87,7 +87,7 @@ class MediaScannerServiceUtilsMergeSortOfArtistTest extends AbstractNeedsScan {
         populateDatabaseOnlyOnce(null, () -> {
             List<MediaFile> albums = mediaFileDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, false, MUSIC_FOLDERS);
             albums.forEach(a -> {
-                List<MediaFile> files = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, a.getPath(), false);
+                List<MediaFile> files = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, a.getPathString(), false);
                 files.forEach(m -> {
                     if ("file10".equals(m.getName()) || "file12".equals(m.getName()) || "file14".equals(m.getName())
                             || "file17".equals(m.getName())) {
@@ -169,7 +169,7 @@ class MediaScannerServiceUtilsMergeSortOfArtistTest extends AbstractNeedsScan {
         assertEquals("artistU", artistID3s.get(9).getSort());
 
         artists.stream().filter(m -> "case10".equals(m.getName())).findFirst().ifPresent(m -> {
-            List<MediaFile> albums = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, m.getPath(), false);
+            List<MediaFile> albums = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, m.getPathString(), false);
             assertEquals(1, albums.size());
             MediaFile album = albums.get(0);
             assertEquals("case10", album.getArtist());
@@ -178,7 +178,7 @@ class MediaScannerServiceUtilsMergeSortOfArtistTest extends AbstractNeedsScan {
         });
 
         artists.stream().filter(m -> "case11".equals(m.getName())).findFirst().ifPresent(m -> {
-            List<MediaFile> albums = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, m.getPath(), false);
+            List<MediaFile> albums = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, m.getPathString(), false);
             assertEquals(1, albums.size());
             MediaFile album = albums.get(0);
             assertEquals("case11", album.getArtist());
@@ -187,7 +187,7 @@ class MediaScannerServiceUtilsMergeSortOfArtistTest extends AbstractNeedsScan {
         });
 
         artists.stream().filter(m -> "ARTIST".equals(m.getName())).findFirst().ifPresent(m -> {
-            List<MediaFile> albums = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, m.getPath(), false);
+            List<MediaFile> albums = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, m.getPathString(), false);
             assertEquals(9, albums.size());
 
             albums.forEach(album -> {
@@ -246,7 +246,7 @@ class MediaScannerServiceUtilsMergeSortOfArtistTest extends AbstractNeedsScan {
             });
 
             List<MediaFile> songs = albums.stream()
-                    .flatMap(al -> mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, al.getPath(), false).stream())
+                    .flatMap(al -> mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, al.getPathString(), false).stream())
                     .collect(Collectors.toList());
             assertEquals(15, songs.size());
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceUtilsUpdateSortOfAlbumTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceUtilsUpdateSortOfAlbumTest.java
@@ -81,7 +81,7 @@ class MediaScannerServiceUtilsUpdateSortOfAlbumTest extends AbstractNeedsScan {
             List<MediaFile> albums = mediaFileDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, false, MUSIC_FOLDERS);
             Date now = new Date();
             albums.forEach(a -> {
-                List<MediaFile> songs = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, a.getPath(), false);
+                List<MediaFile> songs = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, a.getPathString(), false);
                 songs.forEach(m -> {
                     if (latestMediaFileTitle1.equals(m.getTitle()) || latestMediaFileTitle2.equals(m.getTitle())) {
                         m.setChanged(now);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MusicIndexServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MusicIndexServiceTest.java
@@ -87,10 +87,10 @@ class MusicIndexServiceTest {
                 .thenReturn(new MediaFile());
         MediaFile child1 = new MediaFile();
         child1.setTitle("The Flipper's Guitar");
-        child1.setPath("path1");
+        child1.setPathString("path1");
         MediaFile child2 = new MediaFile();
         child2.setTitle("abcde");
-        child2.setPath("path2");
+        child2.setPathString("path2");
         List<MediaFile> children = Arrays.asList(child1, child2);
         Mockito.when(mediaFileService.getChildrenOf(Mockito.any(MediaFile.class), Mockito.anyBoolean(),
                 Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean())).thenReturn(children);
@@ -168,14 +168,14 @@ class MusicIndexServiceTest {
                 .thenReturn(new MediaFile());
         MediaFile child1 = new MediaFile();
         child1.setTitle("The Flipper's Guitar");
-        child1.setPath("path1");
+        child1.setPathString("path1");
         MediaFile child2 = new MediaFile();
         child2.setTitle("abcde");
-        child2.setPath("path2");
+        child2.setPathString("path2");
         List<MediaFile> children = Arrays.asList(child1, child2);
         MediaFile song = new MediaFile();
         song.setTitle("It's file directly under the music folder");
-        song.setPath("path3");
+        song.setPathString("path3");
         List<MediaFile> songs = Arrays.asList(song);
         Mockito.when(mediaFileService.getChildrenOf(Mockito.any(MediaFile.class), Mockito.anyBoolean(),
                 Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean())).thenReturn(children)
@@ -204,7 +204,7 @@ class MusicIndexServiceTest {
                 .thenReturn(StringUtil.split(SettingsConstants.General.Extension.SHORTCUTS.defaultValue + " Metadata"));
         MediaFile song = new MediaFile();
         song.setTitle("Files directly under the shortcut directory");
-        song.setPath("path");
+        song.setPathString("path");
         Mockito.when(mediaFileService.getMediaFile(Mockito.any(File.class), Mockito.anyBoolean())).thenReturn(song);
         File dummy = new File(MusicIndexServiceTest.class.getResource("/MEDIAS").toURI());
         MusicFolder folder = new MusicFolder(dummy, "Music", true, new Date());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MusicIndexServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MusicIndexServiceTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Iterator;
@@ -83,7 +84,7 @@ class MusicIndexServiceTest {
 
     @Test
     void testGetIndexedArtistsListOfMusicFolderBoolean() {
-        Mockito.when(mediaFileService.getMediaFile(Mockito.any(File.class), Mockito.anyBoolean()))
+        Mockito.when(mediaFileService.getMediaFile(Mockito.any(Path.class), Mockito.anyBoolean()))
                 .thenReturn(new MediaFile());
         MediaFile child1 = new MediaFile();
         child1.setTitle("The Flipper's Guitar");
@@ -164,7 +165,7 @@ class MusicIndexServiceTest {
 
     @Test
     void testGetMusicFolderContent() {
-        Mockito.when(mediaFileService.getMediaFile(Mockito.any(File.class), Mockito.anyBoolean()))
+        Mockito.when(mediaFileService.getMediaFile(Mockito.any(Path.class), Mockito.anyBoolean()))
                 .thenReturn(new MediaFile());
         MediaFile child1 = new MediaFile();
         child1.setTitle("The Flipper's Guitar");
@@ -180,7 +181,7 @@ class MusicIndexServiceTest {
         Mockito.when(mediaFileService.getChildrenOf(Mockito.any(MediaFile.class), Mockito.anyBoolean(),
                 Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean())).thenReturn(children)
                 .thenReturn(songs).thenThrow(new RuntimeException("Fail"));
-        Mockito.when(mediaFileService.getMediaFile(Mockito.any(File.class), Mockito.anyBoolean()))
+        Mockito.when(mediaFileService.getMediaFile(Mockito.any(Path.class), Mockito.anyBoolean()))
                 .thenReturn(new MediaFile());
         MusicFolder folder = new MusicFolder(0, new File("path"), "name", true, new Date());
 
@@ -205,7 +206,7 @@ class MusicIndexServiceTest {
         MediaFile song = new MediaFile();
         song.setTitle("Files directly under the shortcut directory");
         song.setPathString("path");
-        Mockito.when(mediaFileService.getMediaFile(Mockito.any(File.class), Mockito.anyBoolean())).thenReturn(song);
+        Mockito.when(mediaFileService.getMediaFile(Mockito.any(Path.class), Mockito.anyBoolean())).thenReturn(song);
         File dummy = new File(MusicIndexServiceTest.class.getResource("/MEDIAS").toURI());
         MusicFolder folder = new MusicFolder(dummy, "Music", true, new Date());
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PlaylistServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PlaylistServiceTest.java
@@ -82,20 +82,20 @@ class PlaylistServiceTest {
 
             MediaFile mf1 = new MediaFile();
             mf1.setId(142);
-            mf1.setPath("/some/path/to_album/to_artist/name - of - song.mp3");
+            mf1.setPathString("/some/path/to_album/to_artist/name - of - song.mp3");
             mf1.setPresent(true);
             List<MediaFile> mediaFiles = new ArrayList<>();
             mediaFiles.add(mf1);
 
             MediaFile mf2 = new MediaFile();
             mf2.setId(1235);
-            mf2.setPath("/some/path/to_album2/to_artist/another song.mp3");
+            mf2.setPathString("/some/path/to_album2/to_artist/another song.mp3");
             mf2.setPresent(true);
             mediaFiles.add(mf2);
 
             MediaFile mf3 = new MediaFile();
             mf3.setId(198_403);
-            mf3.setPath("/some/path/to_album2/to_artist/another song2.mp3");
+            mf3.setPathString("/some/path/to_album2/to_artist/another song2.mp3");
             mf3.setPresent(false);
             mediaFiles.add(mf3);
 
@@ -288,7 +288,7 @@ class PlaylistServiceTest {
         public Object answer(InvocationOnMock invocationOnMock) {
             File file = invocationOnMock.getArgument(0);
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPath(file.getPath());
+            mediaFile.setPathString(file.getPath());
             return mediaFile;
         }
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PlaylistServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PlaylistServiceTest.java
@@ -159,11 +159,12 @@ class PlaylistServiceTest {
                     .append(mf3.toURI().toString()).append('\n');
 
             doAnswer(new PersistPlayList(23)).when(playlistDao).createPlaylist(ArgumentMatchers.any());
-            doAnswer(new MediaFileHasEverything()).when(mediaFileService)
-                    .getMediaFile(ArgumentMatchers.any(File.class));
+            String path = Path.of("/path/to/" + playlistName + ".m3u").toString();
+            MediaFile mediaFile = new MediaFile();
+            mediaFile.setPathString(path);
+            Mockito.when(mediaFileService.getMediaFile(Mockito.any(Path.class))).thenReturn(new MediaFile());
 
             InputStream inputStream = new ByteArrayInputStream(builder.toString().getBytes(StandardCharsets.UTF_8));
-            String path = new File("/path/to/" + playlistName + ".m3u").toURI().toString();
 
             playlistService.importPlaylist(username, playlistName, path, inputStream, null);
 
@@ -200,11 +201,13 @@ class PlaylistServiceTest {
                     .append(mf2.toURI().toString()).append("\nFile3=").append(mf3.toURI().toString()).append('\n');
 
             doAnswer(new PersistPlayList(23)).when(playlistDao).createPlaylist(ArgumentMatchers.any());
-            doAnswer(new MediaFileHasEverything()).when(mediaFileService)
-                    .getMediaFile(ArgumentMatchers.any(File.class));
+
+            String path = Path.of("/path/to/" + playlistName + ".pls").toString();
+            MediaFile mediaFile = new MediaFile();
+            mediaFile.setPathString(path);
+            Mockito.when(mediaFileService.getMediaFile(Mockito.any(Path.class))).thenReturn(mediaFile);
 
             InputStream inputStream = new ByteArrayInputStream(builder.toString().getBytes(StandardCharsets.UTF_8));
-            String path = new File("/path/to/" + playlistName + ".pls").toURI().toString();
 
             playlistService.importPlaylist(username, playlistName, path, inputStream, null);
 
@@ -242,11 +245,12 @@ class PlaylistServiceTest {
                     .append(mf3.toURI().toString()).append("</location></track>\n</trackList>\n</playlist>\n");
 
             doAnswer(new PersistPlayList(23)).when(playlistDao).createPlaylist(ArgumentMatchers.any());
-            doAnswer(new MediaFileHasEverything()).when(mediaFileService)
-                    .getMediaFile(ArgumentMatchers.any(File.class));
+            String path = Path.of("/path/to/" + playlistName + ".xspf").toString();
+            MediaFile mediaFile = new MediaFile();
+            mediaFile.setPathString(path);
+            Mockito.when(mediaFileService.getMediaFile(Mockito.any(Path.class))).thenReturn(mediaFile);
 
             InputStream inputStream = new ByteArrayInputStream(builder.toString().getBytes(StandardCharsets.UTF_8));
-            String path = new File("/path/to/" + playlistName + ".xspf").toURI().toString();
 
             playlistService.importPlaylist(username, playlistName, path, inputStream, null);
 
@@ -281,16 +285,4 @@ class PlaylistServiceTest {
             return null;
         }
     }
-
-    private static class MediaFileHasEverything implements Answer<Object> {
-
-        @Override
-        public Object answer(InvocationOnMock invocationOnMock) {
-            File file = invocationOnMock.getArgument(0);
-            MediaFile mediaFile = new MediaFile();
-            mediaFile.setPathString(file.getPath());
-            return mediaFile;
-        }
-    }
-
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/RatingServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/RatingServiceTest.java
@@ -22,7 +22,6 @@ package com.tesshu.jpsonic.service;
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
@@ -57,10 +56,10 @@ class RatingServiceTest {
         Path albumPath = Path.of(RatingServiceTest.class.getResource("/MEDIAS/Music/_DIR_ Sixteen Horsepower").toURI());
         Mockito.when(ratingDao.getHighestRatedAlbums(Mockito.anyInt(), Mockito.anyInt(), Mockito.anyList()))
                 .thenReturn(Arrays.asList(albumPath.toString()));
-        Mockito.when(securityService.isReadAllowed(Mockito.any(File.class))).thenReturn(true);
+        Mockito.when(securityService.isReadAllowed(Mockito.any(Path.class))).thenReturn(true);
         MediaFile album = new MediaFile();
         album.setPathString(albumPath.toString());
-        Mockito.when(mediaFileService.getMediaFile(albumPath.toString())).thenReturn(album);
+        Mockito.when(mediaFileService.getMediaFile(albumPath)).thenReturn(album);
 
         MusicFolder musicFolder = new MusicFolder(0, Path.of("path").toFile(), "Music", true, new Date());
         List<MusicFolder> musicFolders = Arrays.asList(musicFolder);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/RatingServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/RatingServiceTest.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2022 tesshucom
+ */
+
+package com.tesshu.jpsonic.service;
+
+import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import com.tesshu.jpsonic.dao.RatingDao;
+import com.tesshu.jpsonic.domain.MediaFile;
+import com.tesshu.jpsonic.domain.MusicFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class RatingServiceTest {
+
+    private RatingDao ratingDao;
+    private SecurityService securityService;
+    private MediaFileService mediaFileService;
+    private RatingService ratingService;
+
+    @BeforeEach
+    public void setup() {
+        ratingDao = mock(RatingDao.class);
+        securityService = mock(SecurityService.class);
+        mediaFileService = mock(MediaFileService.class);
+        ratingService = new RatingService(ratingDao, securityService, mediaFileService);
+    }
+
+    @Test
+    void testGetHighestRatedAlbums() throws IOException, URISyntaxException {
+        Path albumPath = Path.of(RatingServiceTest.class.getResource("/MEDIAS/Music/_DIR_ Sixteen Horsepower").toURI());
+        Mockito.when(ratingDao.getHighestRatedAlbums(Mockito.anyInt(), Mockito.anyInt(), Mockito.anyList()))
+                .thenReturn(Arrays.asList(albumPath.toString()));
+        Mockito.when(securityService.isReadAllowed(Mockito.any(File.class))).thenReturn(true);
+        MediaFile album = new MediaFile();
+        album.setPathString(albumPath.toString());
+        Mockito.when(mediaFileService.getMediaFile(albumPath.toString())).thenReturn(album);
+
+        MusicFolder musicFolder = new MusicFolder(0, Path.of("path").toFile(), "Music", true, new Date());
+        List<MusicFolder> musicFolders = Arrays.asList(musicFolder);
+        List<MediaFile> highestRatedAlbums = ratingService.getHighestRatedAlbums(0, 0, musicFolders);
+        assertEquals(1, highestRatedAlbums.size());
+        assertEquals(albumPath.toString(), highestRatedAlbums.get(0).getPathString());
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/StreamServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/StreamServiceTest.java
@@ -368,7 +368,7 @@ class StreamServiceTest {
         song.setPathString("song");
 
         Mockito.when(mediaFileService.getMediaFile(song.getId())).thenReturn(song);
-        Mockito.when(mediaFileService.getMediaFile(song.getPathString())).thenReturn(song);
+        Mockito.when(mediaFileService.getMediaFile(song.toPath().toString())).thenReturn(song);
 
         MockHttpServletRequest request = new MockHttpServletRequest();
         assertNull(streamService.getSingleFile(request));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/StreamServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/StreamServiceTest.java
@@ -86,10 +86,10 @@ class StreamServiceTest {
         final int playlistId = 10;
 
         MediaFile song1 = new MediaFile();
-        song1.setPath("song1");
+        song1.setPathString("song1");
         song1.setFileSize(1024L);
         MediaFile song2 = new MediaFile();
-        song2.setPath("song2");
+        song2.setPathString("song2");
         song2.setFileSize(1024L);
         List<MediaFile> songs = Arrays.asList(song1, song2);
         Mockito.when(playlistService.getFilesInPlaylist(playlistId)).thenReturn(songs);
@@ -365,15 +365,15 @@ class StreamServiceTest {
     void testGetSingleFile() throws Exception {
 
         MediaFile song = new MediaFile();
-        song.setPath("song");
+        song.setPathString("song");
 
         Mockito.when(mediaFileService.getMediaFile(song.getId())).thenReturn(song);
-        Mockito.when(mediaFileService.getMediaFile(song.getPath())).thenReturn(song);
+        Mockito.when(mediaFileService.getMediaFile(song.getPathString())).thenReturn(song);
 
         MockHttpServletRequest request = new MockHttpServletRequest();
         assertNull(streamService.getSingleFile(request));
 
-        request.setParameter(Attributes.Request.PATH.value(), song.getPath());
+        request.setParameter(Attributes.Request.PATH.value(), song.getPathString());
         assertEquals(song, streamService.getSingleFile(request));
 
         request.removeAllParameters();
@@ -385,7 +385,7 @@ class StreamServiceTest {
     @Order(4)
     void testCreateVideoTranscodingSettings() throws Exception {
         MediaFile video = new MediaFile();
-        video.setPath("song");
+        video.setPathString("song");
         video.setWidth(300);
         video.setHeight(200);
         MockHttpServletRequest request = new MockHttpServletRequest();
@@ -559,7 +559,7 @@ class StreamServiceTest {
         Player player = new Player();
         PlayQueue playQueue = new PlayQueue();
         MediaFile song = new MediaFile();
-        song.setPath("path");
+        song.setPathString("path");
         playQueue.addFiles(false, song);
         player.setPlayQueue(playQueue);
         try (InputStream inputStream = streamService.createInputStream(player, null, null, null, null)) {

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/TranscodingServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/TranscodingServiceTest.java
@@ -378,7 +378,7 @@ class TranscodingServiceTest {
         @Order(2)
         void testGTI2() throws IOException {
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPath(fakePath);
+            mediaFile.setPathString(fakePath);
 
             Parameters parameters = new Parameters(mediaFile, null);
             Transcoding transcoding = new Transcoding(null, null, fmtMp3, fmtWav, step1, null, null, false);
@@ -394,7 +394,7 @@ class TranscodingServiceTest {
         @EnabledOnOs(OS.WINDOWS)
         void testGTI3Win() throws IOException {
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPath(fakePath);
+            mediaFile.setPathString(fakePath);
 
             Parameters parameters = new Parameters(mediaFile, null);
 
@@ -408,7 +408,7 @@ class TranscodingServiceTest {
         @EnabledOnOs(OS.LINUX)
         void testGTI3Linux() throws IOException {
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPath(fakePath);
+            mediaFile.setPathString(fakePath);
 
             Parameters parameters = new Parameters(mediaFile, null);
 
@@ -420,7 +420,7 @@ class TranscodingServiceTest {
         @Order(4)
         void testGTI4() throws IOException {
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPath(realPath);
+            mediaFile.setPathString(realPath);
             Parameters parameters = new Parameters(mediaFile, null);
 
             try (InputStream stream = transcodingService.getTranscodedInputStream(parameters)) {
@@ -441,7 +441,7 @@ class TranscodingServiceTest {
             mediaFile.setTitle("title");
             mediaFile.setAlbumName("album");
             mediaFile.setArtist("artist");
-            mediaFile.setPath(fakePath);
+            mediaFile.setPathString(fakePath);
             Parameters parameters = new Parameters(mediaFile, new VideoTranscodingSettings(640, 480, 0, 120, false));
             parameters.setExpectedLength(null);
             return parameters;
@@ -526,7 +526,7 @@ class TranscodingServiceTest {
             Integer maxBitRate = null;
             VideoTranscodingSettings videoTranscodingSettings = null;
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPath(realPath);
+            mediaFile.setPathString(realPath);
             InputStream in = null;
             try (TranscodeInputStream stream = transcodingService.createTranscodeInputStream(command, maxBitRate,
                     videoTranscodingSettings, mediaFile, in)) {
@@ -543,7 +543,7 @@ class TranscodingServiceTest {
             mediaFile.setTitle("Title");
             mediaFile.setAlbumName("Album");
             mediaFile.setArtist("Artist");
-            mediaFile.setPath(realPath);
+            mediaFile.setPathString(realPath);
             InputStream in = null;
 
             try (TranscodeInputStream stream = transcodingService.createTranscodeInputStream(command, maxBitRate,
@@ -986,7 +986,7 @@ class TranscodingServiceTest {
         void testGP1() {
 
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPath(fakePath);
+            mediaFile.setPathString(fakePath);
 
             Player player = new Player();
             player.setId(mockPlayerId);
@@ -1016,7 +1016,7 @@ class TranscodingServiceTest {
         void testGP2() {
 
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPath(fakePath);
+            mediaFile.setPathString(fakePath);
             mediaFile.setFormat(fmtFlac);
             mediaFile.setDurationSeconds(0);
 
@@ -1046,7 +1046,7 @@ class TranscodingServiceTest {
         @Order(3)
         void testGP3() {
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPath(fakePath);
+            mediaFile.setPathString(fakePath);
             mediaFile.setMediaType(MediaType.VIDEO);
             mediaFile.setFormat(fmtMpeg);
             mediaFile.setDurationSeconds(0);
@@ -1078,7 +1078,7 @@ class TranscodingServiceTest {
         @Order(4)
         void testGP4() {
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPath(fakePath);
+            mediaFile.setPathString(fakePath);
             mediaFile.setFormat(fmtFlac);
             mediaFile.setDurationSeconds(0);
 
@@ -1108,7 +1108,7 @@ class TranscodingServiceTest {
         @Order(5)
         void testGP5() {
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPath(fakePath);
+            mediaFile.setPathString(fakePath);
             mediaFile.setMediaType(MediaType.VIDEO);
             mediaFile.setFormat(fmtMpeg);
             mediaFile.setDurationSeconds(0);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/TranscodingServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/TranscodingServiceTest.java
@@ -28,8 +28,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Documented;
+import java.net.URISyntaxException;
 import java.nio.file.InvalidPathException;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,7 +41,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
-import com.tesshu.jpsonic.MusicFolderTestDataUtils;
 import com.tesshu.jpsonic.dao.PlayerDao;
 import com.tesshu.jpsonic.dao.TranscodingDao;
 import com.tesshu.jpsonic.domain.MediaFile;
@@ -92,10 +93,8 @@ class TranscodingServiceTest {
     private Transcoding inactiveTranscoding = new Transcoding(10, "aac",
             "mp3 ogg oga m4a flac wav wma aif aiff ape mpc shn", "aac", "ffmpeg -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -",
             null, null, false);
-    private String fakePath = "*fake-path*";
-    private String realPath = MusicFolderTestDataUtils.resolveMusicFolderPath()
-            + "/_DIR_ Céline Frisch- Café Zimmermann - Bach- Goldberg Variations, Canons [Disc 1]"
-            + "/01 - Bach- Goldberg Variations, BWV 988 - Aria.flac";
+    private String fakePath = "fake-path";
+    private String realPath;
 
     private TranscodingService transcodingService;
     private PlayerDao playerDao;
@@ -110,7 +109,11 @@ class TranscodingServiceTest {
     }
 
     @BeforeEach
-    public void setup() throws ExecutionException {
+    public void setup() throws ExecutionException, URISyntaxException {
+        realPath = Path.of(MediaFileServiceTest.class.getResource(
+                "/MEDIAS/Music/_DIR_ Céline Frisch- Café Zimmermann - Bach- Goldberg Variations, Canons [Disc 1]"
+                        + "/01 - Bach- Goldberg Variations, BWV 988 - Aria.flac")
+                .toURI()).toString();
         transcodingDao = mock(TranscodingDao.class);
         securityService = mock(SecurityService.class);
         Mockito.when(securityService.getUserSettings(Mockito.nullable(String.class))).thenReturn(new UserSettings());
@@ -394,7 +397,7 @@ class TranscodingServiceTest {
         @EnabledOnOs(OS.WINDOWS)
         void testGTI3Win() throws IOException {
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPathString(fakePath);
+            mediaFile.setPathString("*fake-path*");
 
             Parameters parameters = new Parameters(mediaFile, null);
 
@@ -408,7 +411,7 @@ class TranscodingServiceTest {
         @EnabledOnOs(OS.LINUX)
         void testGTI3Linux() throws IOException {
             MediaFile mediaFile = new MediaFile();
-            mediaFile.setPathString(fakePath);
+            mediaFile.setPathString("*fake-path*");
 
             Parameters parameters = new Parameters(mediaFile, null);
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/DefaultParserTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/DefaultParserTest.java
@@ -41,7 +41,7 @@ class DefaultParserTest {
     void testGetRawMetaData() {
         Path path = Path.of(
                 "/MEDIAS/Music/_DIR_ Céline Frisch- Café Zimmermann - Bach- Goldberg Variations, Canons [Disc 1]/01 - Bach- Goldberg Variations, BWV 988 - Aria.flac");
-        MetaData metaData = defaultParser.getRawMetaData(path.toFile());
+        MetaData metaData = defaultParser.getRawMetaData(path);
         assertEquals("Music", metaData.getArtist());
         assertEquals("Music", metaData.getAlbumArtist());
         assertEquals("_DIR_ Céline Frisch- Café Zimmermann - Bach- Goldberg Variations, Canons [Disc 1]",

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/DefaultParserTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/DefaultParserTest.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2022 tesshucom
+ */
+
+package com.tesshu.jpsonic.service.metadata;
+
+import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Path;
+
+import com.tesshu.jpsonic.service.MusicFolderService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DefaultParserTest {
+
+    private DefaultParser defaultParser;
+
+    @BeforeEach
+    void setUp() {
+        defaultParser = new DefaultParser(mock(MusicFolderService.class));
+    }
+
+    @Test
+    void testGetRawMetaData() {
+        Path path = Path.of(
+                "/MEDIAS/Music/_DIR_ Céline Frisch- Café Zimmermann - Bach- Goldberg Variations, Canons [Disc 1]/01 - Bach- Goldberg Variations, BWV 988 - Aria.flac");
+        MetaData metaData = defaultParser.getRawMetaData(path.toFile());
+        assertEquals("Music", metaData.getArtist());
+        assertEquals("Music", metaData.getAlbumArtist());
+        assertEquals("_DIR_ Céline Frisch- Café Zimmermann - Bach- Goldberg Variations, Canons [Disc 1]",
+                metaData.getAlbumName());
+        assertEquals("01 - Bach- Goldberg Variations, BWV 988 - Aria", metaData.getTitle());
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/FFmpegTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/FFmpegTest.java
@@ -25,9 +25,10 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.awt.image.BufferedImage;
-import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import com.tesshu.jpsonic.service.SettingsService;
 import com.tesshu.jpsonic.service.TranscodingService;
@@ -50,34 +51,34 @@ class FFmpegTest {
         ffmpeg = new FFmpeg(transcodingService);
     }
 
-    private File createFile(String path) throws URISyntaxException, IOException {
-        return new File(FFmpegTest.class.getResource(path).toURI());
+    private Path createPath(String path) throws URISyntaxException, IOException {
+        return Path.of(FFmpegTest.class.getResource(path).toURI());
     }
 
     @Test
     @Order(1)
     void testBlank() throws URISyntaxException, IOException {
-        File file = createFile("/MEDIAS/Metadata/tagger3/blank/blank.mp4");
-        assertTrue(file.exists());
-        BufferedImage bi = ffmpeg.createImage(file, 200, 160, 0);
+        Path path = createPath("/MEDIAS/Metadata/tagger3/blank/blank.mp4");
+        assertTrue(Files.exists(path));
+        BufferedImage bi = ffmpeg.createImage(path, 200, 160, 0);
         assertNull(bi);
     }
 
     @Test
     @Order(2)
     void testInvalidFile() throws URISyntaxException, IOException {
-        File file = createFile("/MEDIAS/Metadata/tagger3/testdata/test.stem.mp4");
-        assertTrue(file.exists());
-        BufferedImage bi = ffmpeg.createImage(file, 200, 160, 0);
+        Path path = createPath("/MEDIAS/Metadata/tagger3/testdata/test.stem.mp4");
+        assertTrue(Files.exists(path));
+        BufferedImage bi = ffmpeg.createImage(path, 200, 160, 0);
         assertNull(bi);
     }
 
     @Test
     @Order(3)
     void testThumbnailWithValidFile() throws URISyntaxException, IOException {
-        File file = createFile("/MEDIAS/Metadata/tagger3/tagged/test.stem.mp4");
-        assertTrue(file.exists());
-        BufferedImage bi = ffmpeg.createImage(file, 200, 160, 0);
+        Path path = createPath("/MEDIAS/Metadata/tagger3/tagged/test.stem.mp4");
+        assertTrue(Files.exists(path));
+        BufferedImage bi = ffmpeg.createImage(path, 200, 160, 0);
         assertEquals(BufferedImage.TYPE_3BYTE_BGR, bi.getType());
         assertEquals(200, bi.getWidth());
         assertEquals(160, bi.getHeight());
@@ -86,9 +87,9 @@ class FFmpegTest {
     @Test
     @Order(4)
     void testSeekedFrameWithValidFile() throws URISyntaxException, IOException {
-        File file = createFile("/MEDIAS/Metadata/tagger3/tagged/test.stem.mp4");
-        assertTrue(file.exists());
-        BufferedImage bi = ffmpeg.createImage(file, 200, 160, 1);
+        Path path = createPath("/MEDIAS/Metadata/tagger3/tagged/test.stem.mp4");
+        assertTrue(Files.exists(path));
+        BufferedImage bi = ffmpeg.createImage(path, 200, 160, 1);
         assertEquals(BufferedImage.TYPE_3BYTE_BGR, bi.getType());
         assertEquals(200, bi.getWidth());
         assertEquals(160, bi.getHeight());
@@ -97,18 +98,18 @@ class FFmpegTest {
     @Test
     @Order(5)
     void testOverFrameWithValidFile() throws URISyntaxException, IOException {
-        File file = createFile("/MEDIAS/Metadata/tagger3/tagged/test.stem.mp4");
-        assertTrue(file.exists());
-        BufferedImage bi = ffmpeg.createImage(file, 200, 160, Integer.MAX_VALUE);
+        Path path = createPath("/MEDIAS/Metadata/tagger3/tagged/test.stem.mp4");
+        assertTrue(Files.exists(path));
+        BufferedImage bi = ffmpeg.createImage(path, 200, 160, Integer.MAX_VALUE);
         assertNull(bi);
     }
 
     @Test
     @Order(6)
     void testZeroSizeWithValidFile() throws URISyntaxException, IOException {
-        File file = createFile("/MEDIAS/Metadata/tagger3/tagged/test.stem.mp4");
-        assertTrue(file.exists());
-        BufferedImage bi = ffmpeg.createImage(file, 0, 0, 0);
+        Path path = createPath("/MEDIAS/Metadata/tagger3/tagged/test.stem.mp4");
+        assertTrue(Files.exists(path));
+        BufferedImage bi = ffmpeg.createImage(path, 0, 0, 0);
         assertEquals(BufferedImage.TYPE_3BYTE_BGR, bi.getType());
         assertEquals(1920, bi.getWidth()); // original
         assertEquals(1080, bi.getHeight()); // original
@@ -117,9 +118,9 @@ class FFmpegTest {
     @Test
     @Order(6)
     void testNegativeWithValidFile() throws URISyntaxException, IOException {
-        File file = createFile("/MEDIAS/Metadata/tagger3/tagged/test.stem.mp4");
-        assertTrue(file.exists());
-        BufferedImage bi = ffmpeg.createImage(file, -1, -1, -1);
+        Path path = createPath("/MEDIAS/Metadata/tagger3/tagged/test.stem.mp4");
+        assertTrue(Files.exists(path));
+        BufferedImage bi = ffmpeg.createImage(path, -1, -1, -1);
         assertEquals(BufferedImage.TYPE_3BYTE_BGR, bi.getType());
         assertEquals(1920, bi.getWidth()); // original
         assertEquals(1080, bi.getHeight()); // original

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/FFprobeTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/FFprobeTest.java
@@ -57,7 +57,7 @@ class FFprobeTest {
     private MediaFile createTestMediafile(String path) throws URISyntaxException, IOException {
         MediaFile mediaFile = new MediaFile();
         File file = new File(MusicParserTest.class.getResource(path).toURI());
-        mediaFile.setPath(file.getAbsolutePath());
+        mediaFile.setPathString(file.getAbsolutePath());
         mediaFile.setFileSize(Files.size(file.toPath()));
         return mediaFile;
     }
@@ -140,7 +140,7 @@ class FFprobeTest {
     void testIllegalFilePath() throws URISyntaxException, IOException {
         MediaFile mediaFile = new MediaFile();
         File file = new File("fake");
-        mediaFile.setPath(file.getAbsolutePath());
+        mediaFile.setPathString(file.getAbsolutePath());
         mediaFile.setFileSize(Long.valueOf(5_000));
         MetaData metaData = ffprobe.parse(mediaFile, null);
         assertEmpty(metaData);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/MP4ParserTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/MP4ParserTest.java
@@ -59,7 +59,7 @@ class MP4ParserTest {
         MediaFile mediaFile = new MediaFile();
         File file = new File(
                 MusicParserTest.class.getResource("/MEDIAS/Metadata/tagger3/tagged/test.stem.mp4").toURI());
-        mediaFile.setPath(file.getAbsolutePath());
+        mediaFile.setPathString(file.getAbsolutePath());
         mediaFile.setFileSize(Files.size(file.toPath()));
         return mediaFile;
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/MP4ParserTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/MP4ParserTest.java
@@ -57,8 +57,7 @@ class MP4ParserTest {
 
     private MediaFile createTestMediafile() throws URISyntaxException, IOException {
         MediaFile mediaFile = new MediaFile();
-        File file = new File(
-                MusicParserTest.class.getResource("/MEDIAS/Metadata/tagger3/tagged/test.stem.mp4").toURI());
+        File file = new File(MP4ParserTest.class.getResource("/MEDIAS/Metadata/tagger3/tagged/test.stem.mp4").toURI());
         mediaFile.setPathString(file.getAbsolutePath());
         mediaFile.setFileSize(Files.size(file.toPath()));
         return mediaFile;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/MetaDataParserFactoryTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/MetaDataParserFactoryTest.java
@@ -24,8 +24,9 @@ package com.tesshu.jpsonic.service.metadata;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import com.tesshu.jpsonic.NeedsHome;
 import com.tesshu.jpsonic.service.SettingsService;
@@ -45,9 +46,9 @@ import org.springframework.test.annotation.DirtiesContext;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class MetaDataParserFactoryTest {
 
-    private static File someMp3;
-    private static File someFlv;
-    private static File someJunk;
+    private static Path someMp3;
+    private static Path someFlv;
+    private static Path someJunk;
 
     @Autowired
     private MetaDataParserFactory metaDataParserFactory;
@@ -57,17 +58,14 @@ class MetaDataParserFactoryTest {
 
     @BeforeAll
     public static void beforeAll() throws IOException {
-        String homePath = System.getProperty("jpsonic.home");
-        File home = new File(homePath);
-        if (!home.exists()) {
-            home.mkdir();
-        }
-        someMp3 = new File(homePath, "some.mp3");
-        someFlv = new File(homePath, "some.flv");
-        someJunk = new File(homePath, "some.junk");
-        someMp3.createNewFile();
-        someFlv.createNewFile();
-        someJunk.createNewFile();
+        Path homePath = Path.of(System.getProperty("jpsonic.home"));
+        Files.createDirectory(homePath);
+        someMp3 = Path.of(homePath.toString(), "some.mp3");
+        someFlv = Path.of(homePath.toString(), "some.flv");
+        someJunk = Path.of(homePath.toString(), "some.junk");
+        Files.createFile(someMp3);
+        Files.createFile(someFlv);
+        Files.createFile(someJunk);
     }
 
     @Test

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/MetaDataParserTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/MetaDataParserTest.java
@@ -23,7 +23,7 @@ package com.tesshu.jpsonic.service.metadata;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
+import java.nio.file.Path;
 
 import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.service.MusicFolderService;
@@ -42,7 +42,7 @@ class MetaDataParserTest {
 
         MetaDataParser parser = new MetaDataParser() {
             @Override
-            public MetaData getRawMetaData(File file) {
+            public MetaData getRawMetaData(Path path) {
                 return null;
             }
 
@@ -52,7 +52,7 @@ class MetaDataParserTest {
             }
 
             @Override
-            public boolean isEditingSupported(File file) {
+            public boolean isEditingSupported(Path path) {
                 return false;
             }
 
@@ -62,7 +62,7 @@ class MetaDataParserTest {
             }
 
             @Override
-            public boolean isApplicable(File file) {
+            public boolean isApplicable(Path path) {
                 return false;
             }
         };

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/MusicParserTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/MusicParserTest.java
@@ -30,6 +30,7 @@ import static org.springframework.util.ObjectUtils.isEmpty;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.util.function.Function;
 
 import org.apache.commons.io.FilenameUtils;
@@ -50,8 +51,8 @@ class MusicParserTest {
 
     private MusicParser parser = new MusicParser(null);
 
-    private static File createFile(String resourcePath) throws URISyntaxException {
-        return new File(MusicParserTest.class.getResource(resourcePath).toURI());
+    private static Path createPath(String resourcePath) throws URISyntaxException {
+        return Path.of(MusicParserTest.class.getResource(resourcePath).toURI());
     }
 
     @Nested
@@ -79,277 +80,277 @@ class MusicParserTest {
 
                 @Test
                 void testNoAudioHeader() throws URISyntaxException {
-                    assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/corrupt.mp3")));
-                    assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/Issue79.mp3")));
-                    assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/Issue81.mp3")));
+                    assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/corrupt.mp3")));
+                    assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/Issue79.mp3")));
+                    assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/Issue81.mp3")));
                 }
 
                 @Test
                 void testNoOggSHeader() throws URISyntaxException {
-                    assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test36.ogg")));
+                    assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test36.ogg")));
                 }
 
                 @Test
                 void testInvalidOggHeader() throws URISyntaxException {
-                    assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test508.ogg")));
+                    assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test508.ogg")));
                 }
 
                 @Test
                 void testInvalidRIFFHeader() throws URISyntaxException {
-                    assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV25.wav")));
+                    assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV25.wav")));
                 }
             }
 
             @Test
             void testMp3() throws URISyntaxException {
-                assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/01.mp3")));
+                assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/01.mp3")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/issue52.mp3")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/issue52.mp3")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test23.mp3")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test23.mp3")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test302.mp3")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test302.mp3")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test303.mp3")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test303.mp3")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test47.mp3")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test47.mp3")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test48.mp3")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test48.mp3")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test51.mp3")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test51.mp3")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test52.mp3")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test52.mp3")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test53.mp3")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test53.mp3")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test74.mp3")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test74.mp3")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1.mp3")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1Cbr128.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1Cbr128.mp3")));
                 // assertNotNull(parser.getRawMetaData(
-                // createFile("/MEDIAS/Metadata/tagger3/testdata/testV1Cbr128ID3v1.mp3")));
+                // createPath("/MEDIAS/Metadata/tagger3/testdata/testV1Cbr128ID3v1.mp3")));
                 // assertNotNull(parser.getRawMetaData(
-                // createFile("/MEDIAS/Metadata/tagger3/testdata/testV1Cbr128ID3v1v2.mp3")));
+                // createPath("/MEDIAS/Metadata/tagger3/testdata/testV1Cbr128ID3v1v2.mp3")));
                 // assertNotNull(parser.getRawMetaData(
-                // createFile("/MEDIAS/Metadata/tagger3/testdata/testV1Cbr128ID3v2.mp3")));
+                // createPath("/MEDIAS/Metadata/tagger3/testdata/testV1Cbr128ID3v2.mp3")));
                 // assertNotNull(parser.getRawMetaData(
-                // createFile("/MEDIAS/Metadata/tagger3/testdata/testV1Cbr128ID3v2pad.mp3")));
+                // createPath("/MEDIAS/Metadata/tagger3/testdata/testV1Cbr128ID3v2pad.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1Cbr192.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1Cbr192.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1L2mono.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1L2mono.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1L2stereo.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1L2stereo.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1vbrNew0.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1vbrNew0.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1vbrNew1.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1vbrNew1.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1vbrNew2.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1vbrNew2.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1vbrNew3.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1vbrNew3.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1vbrNew4.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1vbrNew4.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1vbrNew5.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1vbrNew5.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1vbrNew6.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1vbrNew6.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1vbrNew7.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1vbrNew7.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1vbrNew8.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1vbrNew8.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1vbrNew9.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1vbrNew9.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1vbrOld0.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1vbrOld0.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1vbrold1.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1vbrold1.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1vbrOld2.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1vbrOld2.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1vbrOld3.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1vbrOld3.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1vbrOld4.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1vbrOld4.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1vbrOld5.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1vbrOld5.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1vbrOld6.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1vbrOld6.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1vbrOld7.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1vbrOld7.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1vbrOld8.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1vbrOld8.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV1vbrOld9.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV1vbrOld9.mp3")));
                 // assertNotNull(parser.getRawMetaData(
-                // createFile("/MEDIAS/Metadata/tagger3/testdata/testV24-comments-utf8.mp3")));
+                // createPath("/MEDIAS/Metadata/tagger3/testdata/testV24-comments-utf8.mp3")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV25.mp3")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV25.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV2Cbr128.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV2Cbr128.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV25vbrNew0.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV25vbrNew0.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV25vbrOld0.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV25vbrOld0.mp3")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV2L2.mp3")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV2L2.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV2L3Stereo.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV2L3Stereo.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV2vbrNew0.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV2vbrNew0.mp3")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testV2vbrOld0.mp3")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testV2vbrOld0.mp3")));
             }
 
             @Test
             void testOgg() throws URISyntaxException {
-                assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test.ogg")));
+                assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test.ogg")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test3.ogg")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test3.ogg")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test5.ogg")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test5.ogg")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test76.ogg")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test76.ogg")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test77.ogg")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test77.ogg")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testlargeimage.ogg")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testlargeimage.ogg")));
                 // assertNotNull(parser
-                // .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/testsmallimage.ogg")));
+                // .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/testsmallimage.ogg")));
             }
 
             @Test
             void testFlac() throws URISyntaxException {
-                assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test.flac")));
+                assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test.flac")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test2.flac")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test2.flac")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test3.flac")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test3.flac")));
             }
 
             @Test
             void testM4a() throws URISyntaxException {
-                assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test.m4a")));
+                assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test.m4a")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test14.m4a")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test14.m4a")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test15.m4a")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test15.m4a")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test16.m4a")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test16.m4a")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test164.m4a")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test164.m4a")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test19.m4a")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test19.m4a")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test2.m4a")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test2.m4a")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test21.m4a")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test21.m4a")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test3.m4a")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test3.m4a")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test32.m4a")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test32.m4a")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test33.m4a")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test33.m4a")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test38.m4a")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test38.m4a")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test39.m4a")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test39.m4a")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test4.m4a")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test4.m4a")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test41.m4a")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test41.m4a")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test42.m4a")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test42.m4a")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test44.m4a")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test44.m4a")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test5.m4a")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test5.m4a")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test8.m4a")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test8.m4a")));
             }
 
             @Test
             void testWav() throws URISyntaxException {
 
                 // isExistingInfoTag
-                assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test123.wav")));
+                assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test123.wav")));
 
                 // !isExistingId3
-                assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test.wav")));
+                assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test.wav")));
 
                 // isExistingId3
-                assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test126.wav")));
+                assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test126.wav")));
 
-                // assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test125.wav")));
-                // assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test127.wav")));
-                // assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test128.wav")));
-                // assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test129.wav")));
-                // assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test130.wav")));
-                // assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test131.wav")));
-                // assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test153.wav")));
-                // assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/bug153.wav")));
+                // assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test125.wav")));
+                // assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test127.wav")));
+                // assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test128.wav")));
+                // assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test129.wav")));
+                // assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test130.wav")));
+                // assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test131.wav")));
+                // assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test153.wav")));
+                // assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/bug153.wav")));
             }
 
             @Test
             void testWma() throws URISyntaxException {
-                assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test1.wma")));
+                assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test1.wma")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test2.wma")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test2.wma")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test3.wma")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test3.wma")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test4.wma")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test4.wma")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test5.wma")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test5.wma")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test509.wma")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test509.wma")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test6.wma")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test6.wma")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test7.wma")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test7.wma")));
             }
 
             @Test
             void testAif() throws URISyntaxException {
 
-                assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test119.aif")));
+                assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test119.aif")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test120.aif")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test120.aif")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test121.aif")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test121.aif")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test124.aif")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test124.aif")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test132.aif")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test132.aif")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test133.aif")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test133.aif")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test134.aif")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test134.aif")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test135.aif")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test135.aif")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test136.aif")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test136.aif")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test137.aif")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test137.aif")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test151.aif")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test151.aif")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test157.aif")));
-                assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test138.aiff")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test157.aif")));
+                assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test138.aiff")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test152.aiff")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test152.aiff")));
             }
 
             @Test
             void testDsf() throws URISyntaxException {
-                assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test122.dsf")));
+                assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test122.dsf")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test156.dsf")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test156.dsf")));
             }
 
             @Test
             void testDff() throws URISyntaxException {
-                assertNotNull(parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test229.dff")));
+                assertNotNull(parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test229.dff")));
             }
 
             /*
@@ -400,7 +401,7 @@ class MusicParserTest {
                 @Test
                 void testOgg() throws URISyntaxException, CannotReadException, IOException, TagException,
                         ReadOnlyFileException, InvalidAudioFrameException {
-                    MetaData metaData = parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/tagged/test.ogg"));
+                    MetaData metaData = parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/tagged/test.ogg"));
                     assertNotNull(metaData);
                     assertTagsWrittenByMp3tag(metaData);
                     assertTrue(metaData.isVariableBitRate());
@@ -411,7 +412,7 @@ class MusicParserTest {
                 @Test
                 void testFlac() throws URISyntaxException, CannotReadException, IOException, TagException,
                         ReadOnlyFileException, InvalidAudioFrameException {
-                    MetaData metaData = parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/tagged/test.flac"));
+                    MetaData metaData = parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/tagged/test.flac"));
                     assertNotNull(metaData);
                     assertTagsWrittenByMC4PCAndMp3tag(metaData);
                     assertTrue(metaData.isVariableBitRate());
@@ -422,7 +423,7 @@ class MusicParserTest {
                 @Test
                 void testMp3() throws URISyntaxException, CannotReadException, IOException, TagException,
                         ReadOnlyFileException, InvalidAudioFrameException {
-                    MetaData metaData = parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/tagged/01.mp3"));
+                    MetaData metaData = parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/tagged/01.mp3"));
                     assertNotNull(metaData);
                     assertTagsWrittenByMp3tag(metaData);
                     assertFalse(metaData.isVariableBitRate());
@@ -433,7 +434,7 @@ class MusicParserTest {
                 @Test
                 void testMp3v1() throws URISyntaxException, CannotReadException, IOException, TagException,
                         ReadOnlyFileException, InvalidAudioFrameException {
-                    MetaData metaData = parser.getRawMetaData(createFile("/MEDIAS/Metadata/v1/Mp3tag3.12.mp3"));
+                    MetaData metaData = parser.getRawMetaData(createPath("/MEDIAS/Metadata/v1/Mp3tag3.12.mp3"));
                     assertNotNull(metaData);
 
                     assertEquals("Mp3tag:Artist", metaData.getAlbumArtist()); // Because the value is copied
@@ -461,7 +462,7 @@ class MusicParserTest {
                 @Test
                 void testM4a() throws URISyntaxException, CannotReadException, IOException, TagException,
                         ReadOnlyFileException, InvalidAudioFrameException {
-                    MetaData metaData = parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/tagged/test.m4a"));
+                    MetaData metaData = parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/tagged/test.m4a"));
                     assertNotNull(metaData);
                     assertTagsWrittenByMp3tag(metaData);
                     assertTrue(metaData.isVariableBitRate());
@@ -477,7 +478,7 @@ class MusicParserTest {
                 @Test
                 void testWavMC4PCTag() throws CannotReadException, IOException, TagException, ReadOnlyFileException,
                         InvalidAudioFrameException, URISyntaxException {
-                    MetaData metaData = parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/tagged/mc4pc.wav"));
+                    MetaData metaData = parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/tagged/mc4pc.wav"));
                     assertNotNull(metaData);
                     // Tags are not loaded.
                     assertTrue(isEmptyMetaData(metaData));
@@ -489,7 +490,7 @@ class MusicParserTest {
 
                 @Test
                 void testWavTag() throws URISyntaxException {
-                    MetaData metaData = parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/tagged/test.wav"));
+                    MetaData metaData = parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/tagged/test.wav"));
                     assertNotNull(metaData);
                     assertFalse(isEmptyMetaData(metaData));
                     assertFalse(metaData.isVariableBitRate());
@@ -500,7 +501,7 @@ class MusicParserTest {
                 @Test
                 void testWma() throws CannotReadException, IOException, TagException, ReadOnlyFileException,
                         InvalidAudioFrameException, URISyntaxException {
-                    MetaData metaData = parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/tagged/test1.wma"));
+                    MetaData metaData = parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/tagged/test1.wma"));
                     assertNotNull(metaData);
                     assertTagsWrittenByMC4PCAndMp3tag(metaData);
                     assertFalse(metaData.isVariableBitRate());
@@ -512,7 +513,7 @@ class MusicParserTest {
                 void testAif() throws CannotReadException, IOException, TagException, ReadOnlyFileException,
                         InvalidAudioFrameException, URISyntaxException {
                     MetaData metaData = parser
-                            .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/tagged/test119.aif"));
+                            .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/tagged/test119.aif"));
                     assertNotNull(metaData);
                     assertFalse(isEmptyMetaData(metaData));
                     assertFalse(metaData.isVariableBitRate());
@@ -524,7 +525,7 @@ class MusicParserTest {
                 void testDsf() throws URISyntaxException, CannotReadException, IOException, TagException,
                         ReadOnlyFileException, InvalidAudioFrameException {
                     MetaData metaData = parser
-                            .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/tagged/test122.dsf"));
+                            .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/tagged/test122.dsf"));
                     assertNotNull(metaData);
                     assertTagsWrittenByMC4PCAndMp3tag(metaData);
                     assertFalse(metaData.isVariableBitRate());
@@ -536,7 +537,7 @@ class MusicParserTest {
                 void testDff() throws URISyntaxException, CannotReadException, IOException, TagException,
                         ReadOnlyFileException, InvalidAudioFrameException {
                     MetaData metaData = parser
-                            .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/tagged/test229.dff"));
+                            .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/tagged/test229.dff"));
                     // Tags are not loaded.
                     assertNotNull(metaData);
                     assertTrue(isEmptyMetaData(metaData));
@@ -554,11 +555,11 @@ class MusicParserTest {
             @Test
             void testMp4() throws URISyntaxException {
                 MetaData metaData = parser
-                        .getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test.stem.mp4"));
+                        .getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test.stem.mp4"));
                 assertNotNull(metaData);
                 assertTrue(isEmptyMetaData(metaData));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test218.mp4")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test218.mp4")));
             }
 
             /*
@@ -568,19 +569,19 @@ class MusicParserTest {
              */
             @Test
             void testRm() throws URISyntaxException {
-                MetaData metaData = parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test05.rm"));
+                MetaData metaData = parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test05.rm"));
                 assertNotNull(metaData);
                 assertTrue(isEmptyMetaData(metaData));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test06.rm")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test06.rm")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test07.rm")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test07.rm")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test08.rm")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test08.rm")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test09.rm")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test09.rm")));
                 // assertNotNull(
-                // parser.getRawMetaData(createFile("/MEDIAS/Metadata/tagger3/testdata/test10.rm")));
+                // parser.getRawMetaData(createPath("/MEDIAS/Metadata/tagger3/testdata/test10.rm")));
             }
         }
     }
@@ -588,58 +589,58 @@ class MusicParserTest {
     @Test
     void testIsApplicable() throws URISyntaxException {
 
-        assertFalse(parser.isApplicable(createFile("/MEDIAS/Metadata/tagger3/blank/")));
+        assertFalse(parser.isApplicable(createPath("/MEDIAS/Metadata/tagger3/blank/")));
 
         // @see SettingsConstants.General.Extension.MUSIC_FILE_TYPES
         // mp3 ogg oga aac m4a m4b flac wav wma aif aiff ape mpc shn mka opus
 
-        assertTrue(parser.isApplicable(createFile("/MEDIAS/Metadata/tagger3/blank/blank.mp3")));
-        assertTrue(parser.isApplicable(createFile("/MEDIAS/Metadata/tagger3/blank/blank.ogg")));
-        assertTrue(parser.isApplicable(createFile("/MEDIAS/Metadata/tagger3/blank/blank.oga")));
-        assertFalse(parser.isApplicable(createFile("/MEDIAS/Metadata/tagger3/blank/blank.aac")));
-        assertTrue(parser.isApplicable(createFile("/MEDIAS/Metadata/tagger3/blank/blank.m4a")));
-        assertTrue(parser.isApplicable(createFile("/MEDIAS/Metadata/tagger3/blank/blank.m4b")));
-        assertTrue(parser.isApplicable(createFile("/MEDIAS/Metadata/tagger3/blank/blank.flac")));
-        assertTrue(parser.isApplicable(createFile("/MEDIAS/Metadata/tagger3/blank/blank.wav")));
-        assertTrue(parser.isApplicable(createFile("/MEDIAS/Metadata/tagger3/blank/blank.wma")));
-        assertTrue(parser.isApplicable(createFile("/MEDIAS/Metadata/tagger3/blank/blank.aif")));
-        assertTrue(parser.isApplicable(createFile("/MEDIAS/Metadata/tagger3/blank/blank.aiff")));
-        assertFalse(parser.isApplicable(createFile("/MEDIAS/Metadata/tagger3/blank/blank.ape")));
-        assertFalse(parser.isApplicable(createFile("/MEDIAS/Metadata/tagger3/blank/blank.mpc")));
-        assertFalse(parser.isApplicable(createFile("/MEDIAS/Metadata/tagger3/blank/blank.shn")));
-        assertFalse(parser.isApplicable(createFile("/MEDIAS/Metadata/tagger3/blank/blank.mka")));
-        assertFalse(parser.isApplicable(createFile("/MEDIAS/Metadata/tagger3/blank/blank.opus")));
+        assertTrue(parser.isApplicable(createPath("/MEDIAS/Metadata/tagger3/blank/blank.mp3")));
+        assertTrue(parser.isApplicable(createPath("/MEDIAS/Metadata/tagger3/blank/blank.ogg")));
+        assertTrue(parser.isApplicable(createPath("/MEDIAS/Metadata/tagger3/blank/blank.oga")));
+        assertFalse(parser.isApplicable(createPath("/MEDIAS/Metadata/tagger3/blank/blank.aac")));
+        assertTrue(parser.isApplicable(createPath("/MEDIAS/Metadata/tagger3/blank/blank.m4a")));
+        assertTrue(parser.isApplicable(createPath("/MEDIAS/Metadata/tagger3/blank/blank.m4b")));
+        assertTrue(parser.isApplicable(createPath("/MEDIAS/Metadata/tagger3/blank/blank.flac")));
+        assertTrue(parser.isApplicable(createPath("/MEDIAS/Metadata/tagger3/blank/blank.wav")));
+        assertTrue(parser.isApplicable(createPath("/MEDIAS/Metadata/tagger3/blank/blank.wma")));
+        assertTrue(parser.isApplicable(createPath("/MEDIAS/Metadata/tagger3/blank/blank.aif")));
+        assertTrue(parser.isApplicable(createPath("/MEDIAS/Metadata/tagger3/blank/blank.aiff")));
+        assertFalse(parser.isApplicable(createPath("/MEDIAS/Metadata/tagger3/blank/blank.ape")));
+        assertFalse(parser.isApplicable(createPath("/MEDIAS/Metadata/tagger3/blank/blank.mpc")));
+        assertFalse(parser.isApplicable(createPath("/MEDIAS/Metadata/tagger3/blank/blank.shn")));
+        assertFalse(parser.isApplicable(createPath("/MEDIAS/Metadata/tagger3/blank/blank.mka")));
+        assertFalse(parser.isApplicable(createPath("/MEDIAS/Metadata/tagger3/blank/blank.opus")));
 
-        assertTrue(parser.isApplicable(createFile("/MEDIAS/Metadata/tagger3/blank/blank.aifc")));
-        assertTrue(parser.isApplicable(createFile("/MEDIAS/Metadata/tagger3/blank/blank.dsf")));
-        assertTrue(parser.isApplicable(createFile("/MEDIAS/Metadata/tagger3/blank/blank.dff")));
+        assertTrue(parser.isApplicable(createPath("/MEDIAS/Metadata/tagger3/blank/blank.aifc")));
+        assertTrue(parser.isApplicable(createPath("/MEDIAS/Metadata/tagger3/blank/blank.dsf")));
+        assertTrue(parser.isApplicable(createPath("/MEDIAS/Metadata/tagger3/blank/blank.dff")));
     }
 
     @Test
     void testIsEditingSupported() throws URISyntaxException {
 
-        assertFalse(parser.isEditingSupported(createFile("/MEDIAS/Metadata/tagger3/blank/")));
+        assertFalse(parser.isEditingSupported(createPath("/MEDIAS/Metadata/tagger3/blank/")));
 
-        assertTrue(parser.isEditingSupported(createFile("/MEDIAS/Metadata/tagger3/blank/blank.mp3")));
-        assertTrue(parser.isEditingSupported(createFile("/MEDIAS/Metadata/tagger3/blank/blank.ogg")));
-        assertTrue(parser.isEditingSupported(createFile("/MEDIAS/Metadata/tagger3/blank/blank.oga")));
-        assertFalse(parser.isEditingSupported(createFile("/MEDIAS/Metadata/tagger3/blank/blank.aac")));
-        assertTrue(parser.isEditingSupported(createFile("/MEDIAS/Metadata/tagger3/blank/blank.m4a")));
-        assertTrue(parser.isEditingSupported(createFile("/MEDIAS/Metadata/tagger3/blank/blank.m4b")));
-        assertTrue(parser.isEditingSupported(createFile("/MEDIAS/Metadata/tagger3/blank/blank.flac")));
-        assertTrue(parser.isEditingSupported(createFile("/MEDIAS/Metadata/tagger3/blank/blank.wav")));
-        assertTrue(parser.isEditingSupported(createFile("/MEDIAS/Metadata/tagger3/blank/blank.wma")));
-        assertTrue(parser.isEditingSupported(createFile("/MEDIAS/Metadata/tagger3/blank/blank.aif")));
-        assertTrue(parser.isEditingSupported(createFile("/MEDIAS/Metadata/tagger3/blank/blank.aiff")));
-        assertFalse(parser.isEditingSupported(createFile("/MEDIAS/Metadata/tagger3/blank/blank.ape")));
-        assertFalse(parser.isEditingSupported(createFile("/MEDIAS/Metadata/tagger3/blank/blank.mpc")));
-        assertFalse(parser.isEditingSupported(createFile("/MEDIAS/Metadata/tagger3/blank/blank.shn")));
-        assertFalse(parser.isEditingSupported(createFile("/MEDIAS/Metadata/tagger3/blank/blank.mka")));
-        assertFalse(parser.isEditingSupported(createFile("/MEDIAS/Metadata/tagger3/blank/blank.opus")));
+        assertTrue(parser.isEditingSupported(createPath("/MEDIAS/Metadata/tagger3/blank/blank.mp3")));
+        assertTrue(parser.isEditingSupported(createPath("/MEDIAS/Metadata/tagger3/blank/blank.ogg")));
+        assertTrue(parser.isEditingSupported(createPath("/MEDIAS/Metadata/tagger3/blank/blank.oga")));
+        assertFalse(parser.isEditingSupported(createPath("/MEDIAS/Metadata/tagger3/blank/blank.aac")));
+        assertTrue(parser.isEditingSupported(createPath("/MEDIAS/Metadata/tagger3/blank/blank.m4a")));
+        assertTrue(parser.isEditingSupported(createPath("/MEDIAS/Metadata/tagger3/blank/blank.m4b")));
+        assertTrue(parser.isEditingSupported(createPath("/MEDIAS/Metadata/tagger3/blank/blank.flac")));
+        assertTrue(parser.isEditingSupported(createPath("/MEDIAS/Metadata/tagger3/blank/blank.wav")));
+        assertTrue(parser.isEditingSupported(createPath("/MEDIAS/Metadata/tagger3/blank/blank.wma")));
+        assertTrue(parser.isEditingSupported(createPath("/MEDIAS/Metadata/tagger3/blank/blank.aif")));
+        assertTrue(parser.isEditingSupported(createPath("/MEDIAS/Metadata/tagger3/blank/blank.aiff")));
+        assertFalse(parser.isEditingSupported(createPath("/MEDIAS/Metadata/tagger3/blank/blank.ape")));
+        assertFalse(parser.isEditingSupported(createPath("/MEDIAS/Metadata/tagger3/blank/blank.mpc")));
+        assertFalse(parser.isEditingSupported(createPath("/MEDIAS/Metadata/tagger3/blank/blank.shn")));
+        assertFalse(parser.isEditingSupported(createPath("/MEDIAS/Metadata/tagger3/blank/blank.mka")));
+        assertFalse(parser.isEditingSupported(createPath("/MEDIAS/Metadata/tagger3/blank/blank.opus")));
 
-        assertTrue(parser.isEditingSupported(createFile("/MEDIAS/Metadata/tagger3/blank/blank.aifc")));
-        assertTrue(parser.isEditingSupported(createFile("/MEDIAS/Metadata/tagger3/blank/blank.dsf")));
-        assertFalse(parser.isEditingSupported(createFile("/MEDIAS/Metadata/tagger3/blank/blank.dff"))); // false
+        assertTrue(parser.isEditingSupported(createPath("/MEDIAS/Metadata/tagger3/blank/blank.aifc")));
+        assertTrue(parser.isEditingSupported(createPath("/MEDIAS/Metadata/tagger3/blank/blank.dsf")));
+        assertFalse(parser.isEditingSupported(createPath("/MEDIAS/Metadata/tagger3/blank/blank.dff"))); // false
     }
 
     /*
@@ -651,6 +652,10 @@ class MusicParserTest {
         private String createTooSmallMessage(File file) {
             return "Unable to read file because it is too small to be valid audio file: "
                     .concat(file.getAbsolutePath());
+        }
+
+        private File createFile(String resourcePath) throws URISyntaxException {
+            return new File(MusicParserTest.class.getResource(resourcePath).toURI());
         }
 
         @Test
@@ -935,8 +940,8 @@ class MusicParserTest {
 
         private MusicParser parser = new MusicParser(null);
 
-        private void assertITunesEN(File file, boolean isAlbumArtist) {
-            MetaData metaData = parser.getRawMetaData(file);
+        private void assertITunesEN(Path path, boolean isAlbumArtist) {
+            MetaData metaData = parser.getRawMetaData(path);
             assertEquals("iTunes-Name", metaData.getTitle());
             assertEquals("iTunes-Artist", metaData.getArtist());
             if (isAlbumArtist) {
@@ -956,8 +961,8 @@ class MusicParserTest {
             assertEquals(Integer.valueOf(320), metaData.getBitRate());
         }
 
-        private void assertITunesJP(File file, boolean isAlbumArtist) {
-            MetaData metaData = parser.getRawMetaData(file);
+        private void assertITunesJP(Path path, boolean isAlbumArtist) {
+            MetaData metaData = parser.getRawMetaData(path);
             assertEquals("iTunes～名前", metaData.getTitle());
             assertEquals("iTunes～アーティスト", metaData.getArtist());
             if (isAlbumArtist) {
@@ -979,103 +984,103 @@ class MusicParserTest {
 
         @Test
         void testGetMetaDataForITunes4EN() throws URISyntaxException {
-            assertITunesEN(createFile("/MEDIAS/Metadata/v2.2/iTunes4.1.0.52.mp3"), false);
+            assertITunesEN(createPath("/MEDIAS/Metadata/v2.2/iTunes4.1.0.52.mp3"), false);
         }
 
         /** v2.2, UTF-16 */
         @Test
         void testGetMetaDataForITunes4JP() throws URISyntaxException {
-            assertITunesJP(createFile("/MEDIAS/Metadata/v2.2/UTF-16/iTunes4.1.0.52JP.mp3"), false);
+            assertITunesJP(createPath("/MEDIAS/Metadata/v2.2/UTF-16/iTunes4.1.0.52JP.mp3"), false);
         }
 
         /** v2.2 */
         @Test
         void testGetMetaDataForiTunes5() throws URISyntaxException {
-            assertITunesEN(createFile("/MEDIAS/Metadata/v2.2/iTunes5.0.1.4.mp3"), false);
+            assertITunesEN(createPath("/MEDIAS/Metadata/v2.2/iTunes5.0.1.4.mp3"), false);
         }
 
         /** v2.2, UTF-16 */
         @Test
         void testGetMetaDataForiTunes5JP() throws URISyntaxException {
-            assertITunesJP(createFile("/MEDIAS/Metadata/v2.2/UTF-16/iTunes5.0.1.4JP.mp3"), false);
+            assertITunesJP(createPath("/MEDIAS/Metadata/v2.2/UTF-16/iTunes5.0.1.4JP.mp3"), false);
         }
 
         /** v2.2 */
         @Test
         void testGetMetaDataForiTunes6() throws URISyntaxException {
-            assertITunesEN(createFile("/MEDIAS/Metadata/v2.2/iTunes6.0.0.18.mp3"), false);
+            assertITunesEN(createPath("/MEDIAS/Metadata/v2.2/iTunes6.0.0.18.mp3"), false);
         }
 
         /** v2.2, UTF-16 */
         @Test
         void testGetMetaDataForiTunes6JP() throws URISyntaxException {
-            assertITunesJP(createFile("/MEDIAS/Metadata/v2.2/UTF-16/iTunes6.0.0.18JP.mp3"), false);
+            assertITunesJP(createPath("/MEDIAS/Metadata/v2.2/UTF-16/iTunes6.0.0.18JP.mp3"), false);
         }
 
         /** v2.2 */
         @Test
         void testGetMetaDataForiTunes7() throws URISyntaxException {
-            assertITunesEN(createFile("/MEDIAS/Metadata/v2.2/iTunes7.0.0.70.mp3"), true);
+            assertITunesEN(createPath("/MEDIAS/Metadata/v2.2/iTunes7.0.0.70.mp3"), true);
         }
 
         /** v2.2, UTF-16 */
         @Test
         void testGetMetaDataForiTunes7JP() throws URISyntaxException {
-            assertITunesJP(createFile("/MEDIAS/Metadata/v2.2/UTF-16/iTunes7.0.0.70JP.mp3"), true);
+            assertITunesJP(createPath("/MEDIAS/Metadata/v2.2/UTF-16/iTunes7.0.0.70JP.mp3"), true);
         }
 
         /** v2.2 */
         @Test
         void testGetMetaDataForiTunes8() throws URISyntaxException {
-            assertITunesEN(createFile("/MEDIAS/Metadata/v2.2/iTunes8.1.0.52.mp3"), true);
+            assertITunesEN(createPath("/MEDIAS/Metadata/v2.2/iTunes8.1.0.52.mp3"), true);
         }
 
         /** v2.2, UTF-16 */
         @Test
         void testGetMetaDataForiTunes8JP() throws URISyntaxException {
-            assertITunesJP(createFile("/MEDIAS/Metadata/v2.2/UTF-16/iTunes8.1.0.52JP.mp3"), true);
+            assertITunesJP(createPath("/MEDIAS/Metadata/v2.2/UTF-16/iTunes8.1.0.52JP.mp3"), true);
         }
 
         /** v2.2 */
         @Test
         void testGetMetaDataForiTunes10() throws URISyntaxException {
-            assertITunesEN(createFile("/MEDIAS/Metadata/v2.2/iTunes10.0.0.68.mp3"), true);
+            assertITunesEN(createPath("/MEDIAS/Metadata/v2.2/iTunes10.0.0.68.mp3"), true);
         }
 
         /** v2.2, UTF-16 */
         @Test
         void testGetMetaDataForiTunes10JP() throws URISyntaxException {
-            assertITunesJP(createFile("/MEDIAS/Metadata/v2.2/UTF-16/iTunes10.0.0.68JP.mp3"), true);
+            assertITunesJP(createPath("/MEDIAS/Metadata/v2.2/UTF-16/iTunes10.0.0.68JP.mp3"), true);
         }
 
         /** v2.2 */
         @Test
         void testGetMetaDataForiTunes11() throws URISyntaxException {
-            assertITunesEN(createFile("/MEDIAS/Metadata/v2.2/iTunes11.0.0.163.mp3"), true);
+            assertITunesEN(createPath("/MEDIAS/Metadata/v2.2/iTunes11.0.0.163.mp3"), true);
         }
 
         /** v2.2, UTF-16 */
         @Test
         void testGetMetaDataForiTunes11JP() throws URISyntaxException {
-            assertITunesJP(createFile("/MEDIAS/Metadata/v2.2/UTF-16/iTunes11.0.0.163JP.mp3"), true);
+            assertITunesJP(createPath("/MEDIAS/Metadata/v2.2/UTF-16/iTunes11.0.0.163JP.mp3"), true);
         }
 
         /** v2.2 */
         @Test
         void testGetMetaDataForiTunes12() throws URISyntaxException {
-            assertITunesEN(createFile("/MEDIAS/Metadata/v2.2/iTunes12.9.6.3.mp3"), true);
+            assertITunesEN(createPath("/MEDIAS/Metadata/v2.2/iTunes12.9.6.3.mp3"), true);
         }
 
         /** v2.2, UTF-16 */
         @Test
         void testGetMetaDataForiTunes12JP() throws URISyntaxException {
-            assertITunesJP(createFile("/MEDIAS/Metadata/v2.2/UTF-16/iTunes12.9.6.3JP.mp3"), true);
+            assertITunesJP(createPath("/MEDIAS/Metadata/v2.2/UTF-16/iTunes12.9.6.3JP.mp3"), true);
         }
 
         /** v2.3 v1.0 */
         @Test
         void testGetMetaDataForMusicCenter() throws URISyntaxException {
-            MetaData metaData = parser.getRawMetaData(createFile("/MEDIAS/Metadata/v2.3+v1.0/MusicCenter2.1.0.mp3"));
+            MetaData metaData = parser.getRawMetaData(createPath("/MEDIAS/Metadata/v2.3+v1.0/MusicCenter2.1.0.mp3"));
             assertEquals("MusicCenter-Title", metaData.getTitle());
             assertEquals("MusicCenter-Title(Reading)", metaData.getTitleSort());
             assertEquals("MusicCenter-Artist", metaData.getArtist());
@@ -1100,7 +1105,7 @@ class MusicParserTest {
         /** v2.3 v1.1 */
         @Test
         void testGetMetaDataForMusicCenterJP() throws URISyntaxException {
-            MetaData metaData = parser.getRawMetaData(createFile("/MEDIAS/Metadata/v2.3+v1.1/MusicCenter2.1.0JP.mp3"));
+            MetaData metaData = parser.getRawMetaData(createPath("/MEDIAS/Metadata/v2.3+v1.1/MusicCenter2.1.0JP.mp3"));
             assertEquals("MusicCenter～タイトル", metaData.getTitle());
             assertEquals("MusicCenter～タイトル(読み)", metaData.getTitleSort());
             assertEquals("MusicCenter～アーティスト", metaData.getArtist());
@@ -1125,7 +1130,7 @@ class MusicParserTest {
         /** v2.3 */
         @Test
         void testGetMetaDataForV23WithMp3TagJP() throws URISyntaxException {
-            MetaData metaData = parser.getRawMetaData(createFile("/MEDIAS/Metadata/v2.3/Mp3tag2.9.7.mp3"));
+            MetaData metaData = parser.getRawMetaData(createPath("/MEDIAS/Metadata/v2.3/Mp3tag2.9.7.mp3"));
             assertEquals("MusicCenter～タイトル", metaData.getTitle());
             assertEquals("MusicCenter～タイトル(読み)", metaData.getTitleSort());
             assertEquals("MusicCenter～アーティスト", metaData.getArtist());
@@ -1150,7 +1155,7 @@ class MusicParserTest {
         /** v2.4 */
         @Test
         void testGetMetaDataForv24WithMp3TagJP() throws URISyntaxException {
-            MetaData metaData = parser.getRawMetaData(createFile("/MEDIAS/Metadata/v2.4/Mp3tag2.9.7.mp3"));
+            MetaData metaData = parser.getRawMetaData(createPath("/MEDIAS/Metadata/v2.4/Mp3tag2.9.7.mp3"));
             assertEquals("MusicCenter～タイトル", metaData.getTitle());
             assertEquals("MusicCenter～タイトル(読み)", metaData.getTitleSort());
             assertEquals("MusicCenter～アーティスト", metaData.getArtist());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/ParserUtilsTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/ParserUtilsTest.java
@@ -24,9 +24,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
 import java.lang.annotation.Documented;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.util.Optional;
 
 import org.jaudiotagger.tag.images.Artwork;
@@ -36,8 +36,8 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("PMD.TooManyStaticImports")
 class ParserUtilsTest {
 
-    private File createFile(String resourcePath) throws URISyntaxException {
-        return new File(MusicParserTest.class.getResource(resourcePath).toURI());
+    private Path createPath(String resourcePath) throws URISyntaxException {
+        return Path.of(ParserUtilsTest.class.getResource(resourcePath).toURI());
     }
 
     @Documented
@@ -112,26 +112,26 @@ class ParserUtilsTest {
     @Test
     void isEmbeddedArtworkApplicableTest() throws URISyntaxException {
 
-        assertFalse(ParserUtils.isEmbeddedArtworkApplicable(createFile("/MEDIAS/Metadata/tagger3/testdata")));
+        assertFalse(ParserUtils.isEmbeddedArtworkApplicable(createPath("/MEDIAS/Metadata/tagger3/testdata")));
 
         // (Data formats for which no test resources currently exist are omitted)
-        assertTrue(ParserUtils.isEmbeddedArtworkApplicable(createFile("/MEDIAS/Metadata/tagger3/testdata/test.ogg")));
+        assertTrue(ParserUtils.isEmbeddedArtworkApplicable(createPath("/MEDIAS/Metadata/tagger3/testdata/test.ogg")));
         // oga
-        assertTrue(ParserUtils.isEmbeddedArtworkApplicable(createFile("/MEDIAS/Metadata/tagger3/testdata/test.flac")));
-        assertTrue(ParserUtils.isEmbeddedArtworkApplicable(createFile("/MEDIAS/Metadata/tagger3/testdata/01.mp3")));
-        assertTrue(ParserUtils.isEmbeddedArtworkApplicable(createFile("/MEDIAS/Metadata/tagger3/testdata/test.m4a")));
+        assertTrue(ParserUtils.isEmbeddedArtworkApplicable(createPath("/MEDIAS/Metadata/tagger3/testdata/test.flac")));
+        assertTrue(ParserUtils.isEmbeddedArtworkApplicable(createPath("/MEDIAS/Metadata/tagger3/testdata/01.mp3")));
+        assertTrue(ParserUtils.isEmbeddedArtworkApplicable(createPath("/MEDIAS/Metadata/tagger3/testdata/test.m4a")));
         // m4b
         assertTrue(
-                ParserUtils.isEmbeddedArtworkApplicable(createFile("/MEDIAS/Metadata/tagger3/testdata/test123.wav")));
-        assertTrue(ParserUtils.isEmbeddedArtworkApplicable(createFile("/MEDIAS/Metadata/tagger3/testdata/test1.wma")));
+                ParserUtils.isEmbeddedArtworkApplicable(createPath("/MEDIAS/Metadata/tagger3/testdata/test123.wav")));
+        assertTrue(ParserUtils.isEmbeddedArtworkApplicable(createPath("/MEDIAS/Metadata/tagger3/testdata/test1.wma")));
         assertTrue(
-                ParserUtils.isEmbeddedArtworkApplicable(createFile("/MEDIAS/Metadata/tagger3/testdata/test138.aiff")));
+                ParserUtils.isEmbeddedArtworkApplicable(createPath("/MEDIAS/Metadata/tagger3/testdata/test138.aiff")));
         // aifc
         // aiff
         assertTrue(
-                ParserUtils.isEmbeddedArtworkApplicable(createFile("/MEDIAS/Metadata/tagger3/testdata/test122.dsf")));
+                ParserUtils.isEmbeddedArtworkApplicable(createPath("/MEDIAS/Metadata/tagger3/testdata/test122.dsf")));
 
-        assertFalse(ParserUtils.isEmbeddedArtworkApplicable(createFile("/MEDIAS/Metadata/tagger3/dummy/empty.opus")));
+        assertFalse(ParserUtils.isEmbeddedArtworkApplicable(createPath("/MEDIAS/Metadata/tagger3/dummy/empty.opus")));
     }
 
     @Nested
@@ -141,7 +141,7 @@ class ParserUtilsTest {
         @GetArtworkDecision.Results.Empty
         @Test
         void c01() throws URISyntaxException {
-            Optional<Artwork> artwork = ParserUtils.getEmbeddedArtwork(createFile("/MEDIAS/Metadata/tagger3/testdata"));
+            Optional<Artwork> artwork = ParserUtils.getEmbeddedArtwork(createPath("/MEDIAS/Metadata/tagger3/testdata"));
             assertTrue(artwork.isEmpty());
         }
 
@@ -151,7 +151,7 @@ class ParserUtilsTest {
         @Test
         void c02() throws URISyntaxException {
             Optional<Artwork> artwork = ParserUtils
-                    .getEmbeddedArtwork(createFile("/MEDIAS/Metadata/tagger3/testdata/test.stem.mp4"));
+                    .getEmbeddedArtwork(createPath("/MEDIAS/Metadata/tagger3/testdata/test.stem.mp4"));
             assertTrue(artwork.isEmpty());
         }
 
@@ -162,7 +162,7 @@ class ParserUtilsTest {
         @Test
         void c03() throws URISyntaxException {
             Optional<Artwork> artwork = ParserUtils
-                    .getEmbeddedArtwork(createFile("/MEDIAS/Metadata/tagger3/testdata/testV25.wav"));
+                    .getEmbeddedArtwork(createPath("/MEDIAS/Metadata/tagger3/testdata/testV25.wav"));
             assertTrue(artwork.isEmpty());
         }
 
@@ -174,7 +174,7 @@ class ParserUtilsTest {
         @Test
         void c04() throws URISyntaxException {
             Optional<Artwork> artwork = ParserUtils
-                    .getEmbeddedArtwork(createFile("/MEDIAS/Metadata/tagger3/testdata/01.mp3"));
+                    .getEmbeddedArtwork(createPath("/MEDIAS/Metadata/tagger3/testdata/01.mp3"));
             assertTrue(artwork.isEmpty());
         }
 
@@ -186,7 +186,7 @@ class ParserUtilsTest {
         @Test
         void c05() throws URISyntaxException {
             Optional<Artwork> artwork = ParserUtils
-                    .getEmbeddedArtwork(createFile("/MEDIAS/Metadata/tagger3/tagged/mc4pc.wav"));
+                    .getEmbeddedArtwork(createPath("/MEDIAS/Metadata/tagger3/tagged/mc4pc.wav"));
             assertTrue(artwork.isEmpty());
         }
 
@@ -199,7 +199,7 @@ class ParserUtilsTest {
         @Test
         void c06() throws URISyntaxException {
             Optional<Artwork> artwork = ParserUtils
-                    .getEmbeddedArtwork(createFile("/MEDIAS/Metadata/tagger3/tagged/test.wav"));
+                    .getEmbeddedArtwork(createPath("/MEDIAS/Metadata/tagger3/tagged/test.wav"));
             assertTrue(artwork.isEmpty());
         }
 
@@ -213,7 +213,7 @@ class ParserUtilsTest {
         @Test
         void c07() throws URISyntaxException {
             Optional<Artwork> artwork = ParserUtils
-                    .getEmbeddedArtwork(createFile("/MEDIAS/Metadata/tagger3/tagged/test-with-coverart.wav"));
+                    .getEmbeddedArtwork(createPath("/MEDIAS/Metadata/tagger3/tagged/test-with-coverart.wav"));
             assertFalse(artwork.isEmpty());
         }
 
@@ -226,7 +226,7 @@ class ParserUtilsTest {
         @Test
         void c08() throws URISyntaxException {
             Optional<Artwork> artwork = ParserUtils
-                    .getEmbeddedArtwork(createFile("/MEDIAS/Metadata/tagger3/tagged/01.mp3"));
+                    .getEmbeddedArtwork(createPath("/MEDIAS/Metadata/tagger3/tagged/01.mp3"));
             assertTrue(artwork.isEmpty());
         }
 
@@ -240,7 +240,7 @@ class ParserUtilsTest {
         @Test
         void c09() throws URISyntaxException {
             Optional<Artwork> artwork = ParserUtils
-                    .getEmbeddedArtwork(createFile("/MEDIAS/Metadata/tagger3/tagged/test_rm_img.flac"));
+                    .getEmbeddedArtwork(createPath("/MEDIAS/Metadata/tagger3/tagged/test_rm_img.flac"));
             assertTrue(artwork.isEmpty());
         }
 
@@ -254,7 +254,7 @@ class ParserUtilsTest {
         @Test
         void c10() throws URISyntaxException {
             Optional<Artwork> artwork = ParserUtils
-                    .getEmbeddedArtwork(createFile("/MEDIAS/Metadata/tagger3/tagged/test.flac"));
+                    .getEmbeddedArtwork(createPath("/MEDIAS/Metadata/tagger3/tagged/test.flac"));
             assertFalse(artwork.isEmpty());
         }
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
@@ -116,7 +116,7 @@ class IndexManagerTest extends AbstractNeedsScan {
         List<Integer> candidates = mediaFileDao.getArtistExpungeCandidates();
         assertEquals(0, candidates.size());
 
-        result.getMediaFiles().forEach(a -> mediaFileDao.deleteMediaFile(a.getPath()));
+        result.getMediaFiles().forEach(a -> mediaFileDao.deleteMediaFile(a.getPathString()));
 
         candidates = mediaFileDao.getArtistExpungeCandidates();
         assertEquals(1, candidates.size());
@@ -129,7 +129,7 @@ class IndexManagerTest extends AbstractNeedsScan {
         candidates = mediaFileDao.getAlbumExpungeCandidates();
         assertEquals(0, candidates.size());
 
-        result.getMediaFiles().forEach(a -> mediaFileDao.deleteMediaFile(a.getPath()));
+        result.getMediaFiles().forEach(a -> mediaFileDao.deleteMediaFile(a.getPathString()));
 
         candidates = mediaFileDao.getAlbumExpungeCandidates();
         assertEquals(1, candidates.size());
@@ -148,7 +148,7 @@ class IndexManagerTest extends AbstractNeedsScan {
         candidates = mediaFileDao.getSongExpungeCandidates();
         assertEquals(0, candidates.size());
 
-        result.getMediaFiles().forEach(a -> mediaFileDao.deleteMediaFile(a.getPath()));
+        result.getMediaFiles().forEach(a -> mediaFileDao.deleteMediaFile(a.getPathString()));
 
         candidates = mediaFileDao.getSongExpungeCandidates();
         assertEquals(2, candidates.size());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/WMPProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/WMPProcessorTest.java
@@ -84,7 +84,7 @@ class WMPProcessorTest {
     void testCreateMusicTrack() {
 
         MediaFile m = new MediaFile();
-        m.setPath("path1");
+        m.setPathString("path1");
         Mockito.when(mediaFileUpnpProcessor.createResourceForSong(m)).thenReturn(null);
         Mockito.when(mediaFileUpnpProcessor.createAlbumArtURI(m)).thenReturn(null);
 
@@ -98,7 +98,7 @@ class WMPProcessorTest {
         int parentId = 200;
         MediaFile parent = new MediaFile();
         parent.setId(parentId);
-        parent.setPath("parentPath");
+        parent.setPathString("parentPath");
         Mockito.when(mediaFileService.getParentOf(m)).thenReturn(parent);
         m.setAlbumArtist("albumArtist");
         m.setGenre("genre");
@@ -140,7 +140,7 @@ class WMPProcessorTest {
             Mockito.when(util.getGuestMusicFolders()).thenReturn(Collections.emptyList());
 
             MediaFile m = new MediaFile();
-            m.setPath("path2");
+            m.setPathString("path2");
             m.setTitle("dummy title");
             List<MediaFile> songs = Arrays.asList(m);
             MusicFolder mf = new MusicFolder(0, new File("path3"), "dummy", true, null);
@@ -153,7 +153,7 @@ class WMPProcessorTest {
             int parentId = 200;
             MediaFile parent = new MediaFile();
             parent.setId(parentId);
-            parent.setPath("parentPath2");
+            parent.setPathString("parentPath2");
             Mockito.when(mediaFileService.getParentOf(m)).thenReturn(parent);
             Mockito.when(mediaFileService.countSongs(Mockito.anyList())).thenReturn(20L);
 
@@ -185,7 +185,7 @@ class WMPProcessorTest {
             Mockito.when(util.getGuestMusicFolders()).thenReturn(Collections.emptyList());
 
             MediaFile m = new MediaFile();
-            m.setPath("path5");
+            m.setPathString("path5");
             m.setTitle("dummy title");
             List<MediaFile> songs = Arrays.asList(m);
             MusicFolder mf = new MusicFolder(0, new File("path6"), "dummy", true, null);
@@ -198,7 +198,7 @@ class WMPProcessorTest {
             int parentId = 200;
             MediaFile parent = new MediaFile();
             parent.setId(parentId);
-            parent.setPath("parentPath1");
+            parent.setPathString("parentPath1");
             Mockito.when(mediaFileService.getParentOf(m)).thenReturn(parent);
             Mockito.when(mediaFileService.countVideos(Mockito.anyList())).thenReturn(20L);
 
@@ -227,7 +227,7 @@ class WMPProcessorTest {
             int id = 99;
             MediaFile m = new MediaFile();
             m.setId(id);
-            m.setPath("path4");
+            m.setPathString("path4");
             m.setTitle("dummy title");
             Mockito.when(mediaFileService.getMediaFile(id)).thenReturn(m);
             assertEmpty(wmpProcessor.getBrowseResult("dc:title = \"99\"", "*", 0, 0));
@@ -236,7 +236,7 @@ class WMPProcessorTest {
             int parentId = 200;
             MediaFile parent = new MediaFile();
             parent.setId(parentId);
-            parent.setPath("parentPath4");
+            parent.setPathString("parentPath4");
             Mockito.when(mediaFileService.getParentOf(m)).thenReturn(parent);
             BrowseResult result = wmpProcessor.getBrowseResult("dc:title = \"99\"", "*", 0, 0);
             assertEquals(


### PR DESCRIPTION
Fix the code involved in the scan flow

 - Fix code related to MediaFile#File, to Path
 - Fix MediaScannerService/MediaFileService not to use File in paramater
 - Fix not to use File method of FileUtil

____

sonatype : The Date Type policy is the same as #1434. Since rewriting can be done collectively, adding tests is currently prioritized.
