### PR TITLE
Fix null dereference

### DIFF
--- a/jpsonic-main/findbugs-excludes.xml
+++ b/jpsonic-main/findbugs-excludes.xml
@@ -15,7 +15,10 @@
         Author: tesshucom
         -->
     <Match>
-        <Bug pattern="EQ_DOESNT_OVERRIDE_EQUALS" /><!-- It is a bug rule. -->
+        <Bug pattern="EQ_DOESNT_OVERRIDE_EQUALS" /><!-- It is a bug rule. -->                   
+    </Match>
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" /><!-- It is a bug rule. -->
     </Match>
     <Match>
         <Bug pattern="EI_EXPOSE_REP" />            <!-- *** Should be triaged! *** -->

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/CoverArtService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/CoverArtService.java
@@ -151,8 +151,7 @@ public class CoverArtService {
                 break;
             }
 
-            Path oldPath = Path.of(coverArtPath.getParent().toString(),
-                    coverArtPath.getFileName().normalize().toString() + ".old");
+            Path oldPath = createOldPath(coverArtPath);
             Path movedPath = Files.move(coverArtPath, oldPath);
             boolean renamed = movedPath.equals(oldPath);
             if (!renamed && LOG.isWarnEnabled()) {
@@ -167,6 +166,15 @@ public class CoverArtService {
                 dir = mediaFileService.getMediaFile(dir.getId());
             }
         }
+    }
+
+    private Path createOldPath(Path coverArtPath) throws IOException {
+        Path parent = coverArtPath.getParent();
+        Path fileName = coverArtPath.getFileName();
+        if (parent == null || fileName == null) {
+            throw new IOException("Illegal cover art path has specified: " + coverArtPath);
+        }
+        return Path.of(parent.toString(), fileName.normalize().toString() + ".old");
     }
 
     private String getProperSuffix(String url) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/MultiService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/MultiService.java
@@ -76,7 +76,7 @@ public class MultiService {
         MediaFile mediaFile = mediaFileService.getMediaFile(mediaFileId);
         List<SimilarArtist> similarArtists = getSimilarArtists(mediaFileId, maxSimilarArtists);
 
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         UserSettings userSettings = securityService.getUserSettings(user.getUsername());
         Locale locale = userSettings.isForceBio2Eng() ? Locale.ENGLISH : airsonicLocaleResolver.resolveLocale(request);
         ArtistBio artistBio = lastFmService.getArtistBio(mediaFile, locale);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/StarService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/StarService.java
@@ -56,7 +56,7 @@ public class StarService {
     }
 
     private String getUser() {
-        User user = securityService.getCurrentUser(ajaxHelper.getHttpServletRequest());
+        User user = securityService.getCurrentUserStrict(ajaxHelper.getHttpServletRequest());
         return user.getUsername();
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/AdvancedSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/AdvancedSettingsController.java
@@ -109,7 +109,7 @@ public class AdvancedSettingsController {
         // for view page control
         command.setUseRadio(settingsService.isUseRadio());
         command.setShareCount(shareService.getAllShares().size());
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         command.setShowOutlineHelp(outlineHelpSelector.isShowOutlineHelp(request, user.getUsername()));
         UserSettings userSettings = securityService.getUserSettings(user.getUsername());
         command.setOpenDetailSetting(userSettings.isOpenDetailSetting());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/CoverArtController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/CoverArtController.java
@@ -327,7 +327,11 @@ public class CoverArtController {
             } catch (IOException e) {
                 throw new ExecutionException("Image cannot be read: " + path, e);
             }
-            String mimeType = StringUtil.getMimeType(FilenameUtils.getExtension(path.getFileName().toString()));
+            Path fileName = path.getFileName();
+            if (fileName == null) {
+                throw new IllegalArgumentException("Image cannot be read: The root path was specified");
+            }
+            String mimeType = StringUtil.getMimeType(FilenameUtils.getExtension(fileName.toString()));
             return Pair.of(is, mimeType);
         }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DLNASettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DLNASettingsController.java
@@ -129,7 +129,7 @@ public class DLNASettingsController {
         command.setDlnaGuestPublish(settingsService.isDlnaGuestPublish());
 
         // for view page control
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         UserSettings userSettings = securityService.getUserSettings(user.getUsername());
         command.setOpenDetailSetting(userSettings.isOpenDetailSetting());
         command.setShareCount(shareService.getAllShares().size());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DatabaseSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DatabaseSettingsController.java
@@ -80,7 +80,7 @@ public class DatabaseSettingsController {
         // for view page control
         command.setUseRadio(settingsService.isUseRadio());
         command.setShareCount(shareService.getAllShares().size());
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         command.setShowOutlineHelp(outlineHelpSelector.isShowOutlineHelp(request, user.getUsername()));
         model.addAttribute(Attributes.Model.Command.VALUE, command);
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DownloadController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DownloadController.java
@@ -217,8 +217,12 @@ public class DownloadController {
         status.setFile(path.toFile());
 
         response.setContentType("application/x-download");
+        Path fileName = path.getFileName();
+        if (fileName == null) {
+            throw new IllegalArgumentException("Illegal path specified: " + path);
+        }
         response.setHeader("Content-Disposition",
-                "attachment; filename*=UTF-8''" + encodeAsRFC5987(path.getFileName().toString()));
+                "attachment; filename*=UTF-8''" + encodeAsRFC5987(fileName.toString()));
         if (range == null) {
             PlayerUtils.setContentLength(response, Files.size(path));
         }
@@ -410,7 +414,8 @@ public class DownloadController {
             throws IOException {
 
         // Exclude all hidden files starting with a "."
-        if (!path.getFileName().toString().isEmpty() && path.getFileName().toString().charAt(0) == '.') {
+        Path fileName = path.getFileName();
+        if (fileName == null || fileName.toString().charAt(0) == '.') {
             return;
         }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/GeneralSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/GeneralSettingsController.java
@@ -165,7 +165,7 @@ public class GeneralSettingsController {
 
         // for view page control
         command.setUseRadio(settingsService.isUseRadio());
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         command.setShowOutlineHelp(outlineHelpSelector.isShowOutlineHelp(request, user.getUsername()));
         toast.ifPresent(command::setShowToast);
         command.setShareCount(shareService.getAllShares().size());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/HelpController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/HelpController.java
@@ -90,7 +90,7 @@ public class HelpController {
 
         String serverInfo = request.getSession().getServletContext().getServerInfo() + ", java "
                 + System.getProperty("java.version") + ", " + System.getProperty("os.name");
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         map.put("user", user);
         map.put("admin", securityService.isAdmin(user.getUsername()));
         map.put("brand", SettingsService.getBrand());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/HomeController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/HomeController.java
@@ -94,7 +94,7 @@ public class HomeController {
     @GetMapping
     protected ModelAndView handleRequestInternal(HttpServletRequest request) throws ServletRequestBindingException {
 
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         if (user.isAdminRole() && settingsService.isGettingStartedEnabled()) {
             return new ModelAndView(new RedirectView(ViewName.GETTING_STARTED.value()));
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/InternalHelpController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/InternalHelpController.java
@@ -113,7 +113,7 @@ public class InternalHelpController {
     protected ModelAndView handleRequestInternal(HttpServletRequest request) {
         Map<String, Object> map = LegacyMap.of();
 
-        map.put("admin", securityService.isAdmin(securityService.getCurrentUser(request).getUsername()));
+        map.put("admin", securityService.isAdmin(securityService.getCurrentUserStrict(request).getUsername()));
         map.put("showStatus", settingsService.isShowStatus());
 
         if (versionService.isNewFinalVersionAvailable()) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MoreController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MoreController.java
@@ -70,7 +70,7 @@ public class MoreController {
     protected ModelAndView handleRequestInternal(HttpServletRequest request, HttpServletResponse response)
             throws ServletRequestBindingException {
 
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
 
         String uploadDirectory = null;
         List<MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(user.getUsername());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PasswordSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PasswordSettingsController.java
@@ -66,7 +66,7 @@ public class PasswordSettingsController {
     @GetMapping
     protected ModelAndView get(HttpServletRequest request) {
         PasswordSettingsCommand command = new PasswordSettingsCommand();
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         command.setUsername(user.getUsername());
         command.setLdapAuthenticated(user.isLdapAuthenticated());
         return new ModelAndView("passwordSettings", Attributes.Model.Command.VALUE, command);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PersonalSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PersonalSettingsController.java
@@ -84,7 +84,7 @@ public class PersonalSettingsController {
             @RequestParam(Attributes.Request.NameConstants.TOAST) Optional<Boolean> toast) {
         PersonalSettingsCommand command = new PersonalSettingsCommand();
 
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         UserSettings userSettings = securityService.getUserSettings(user.getUsername());
         command.setUser(user);
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PlayQueueController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PlayQueueController.java
@@ -59,7 +59,7 @@ public class PlayQueueController {
     protected ModelAndView handleRequestInternal(HttpServletRequest request, HttpServletResponse response)
             throws ServletRequestBindingException {
 
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         UserSettings userSettings = securityService.getUserSettings(user.getUsername());
         Player player = playerService.getPlayer(request, response);
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PlayerSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PlayerSettingsController.java
@@ -96,7 +96,7 @@ public class PlayerSettingsController {
         PlayerSettingsCommand command = new PlayerSettingsCommand();
         List<Player> players = getPlayers(request);
         command.setPlayers(players.stream().toArray(Player[]::new));
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         command.setAdmin(user.isAdminRole());
         command.setTranscodingSupported(transcodingService.isTranscodingSupported(null));
 
@@ -178,7 +178,7 @@ public class PlayerSettingsController {
     }
 
     private List<Player> getPlayers(HttpServletRequest request) {
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         String username = user.getUsername();
         List<Player> players = playerService.getAllPlayers();
         List<Player> authorizedPlayers = new ArrayList<>();

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PlaylistController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PlaylistController.java
@@ -72,7 +72,7 @@ public class PlaylistController {
             return new ModelAndView(new RedirectView("notFound"));
         }
 
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         String username = user.getUsername();
         UserSettings userSettings = securityService.getUserSettings(username);
         Player player = playerService.getPlayer(request, response);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PlaylistsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PlaylistsController.java
@@ -62,7 +62,7 @@ public class PlaylistsController {
 
     @GetMapping
     public String doGet(HttpServletRequest request, Model model) {
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         List<Playlist> playlists = playlistService.getReadablePlaylistsForUser(user.getUsername());
         model.addAttribute("model",
                 LegacyMap.of("playlists", playlists, "viewAsList",

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/RandomPlayQueueController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/RandomPlayQueueController.java
@@ -121,7 +121,7 @@ public class RandomPlayQueueController {
                 playCount.getMaxPlayCount(), rating.isDoesShowStarredSongs(), rating.isDoesShowUnstarredSongs(),
                 format);
 
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         Player player = playerService.getPlayer(request, response);
         PlayQueue playQueue = player.getPlayQueue();
         // Do we add to the current playlist or do we replace it?

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SearchController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SearchController.java
@@ -94,7 +94,7 @@ public class SearchController {
             @ModelAttribute(Attributes.Model.Command.VALUE) SearchCommand command)
             throws ServletRequestBindingException, IOException {
 
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         UserSettings userSettings = securityService.getUserSettings(user.getUsername());
         command.setUser(user);
         command.setPartyModeEnabled(userSettings.isPartyModeEnabled());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SettingsController.java
@@ -49,7 +49,7 @@ public class SettingsController {
 
     @GetMapping
     protected ModelAndView handleRequestInternal(HttpServletRequest request) {
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         // Redirect to music folder settings if admin.
         return new ModelAndView(new RedirectView(
                 user.isAdminRole() ? ViewName.MUSIC_FOLDER_SETTINGS.value() : ViewName.PERSONAL_SETTINGS.value()));

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/ShareSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/ShareSettingsController.java
@@ -125,7 +125,7 @@ public class ShareSettingsController {
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops") // (ShareInfo) Not reusable
     private List<ShareInfo> getShareInfos(HttpServletRequest request) {
         List<ShareInfo> result = new ArrayList<>();
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         List<MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(user.getUsername());
 
         for (Share share : shareService.getSharesForUser(user)) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StarredController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StarredController.java
@@ -76,7 +76,7 @@ public class StarredController {
     protected ModelAndView handleRequestInternal(HttpServletRequest request, HttpServletResponse response)
             throws ServletRequestBindingException {
 
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         String username = user.getUsername();
         List<MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(username);
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StatusController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StatusController.java
@@ -87,11 +87,10 @@ public class StatusController {
         for (int i = 0; i < uploadStatuses.size(); i++) {
             transferStatuses.add(new TransferStatusHolder(uploadStatuses.get(i), false, false, true, i, locale));
         }
-        return new ModelAndView("status", "model",
-                LegacyMap.of("brand", SettingsService.getBrand(), "admin",
-                        securityService.isAdmin(securityService.getCurrentUser(request).getUsername()), "showStatus",
-                        settingsService.isShowStatus(), "transferStatuses", transferStatuses, "chartWidth",
-                        StatusChartController.IMAGE_WIDTH, "chartHeight", StatusChartController.IMAGE_HEIGHT));
+        return new ModelAndView("status", "model", LegacyMap.of("brand", SettingsService.getBrand(), "admin",
+                securityService.isAdmin(securityService.getCurrentUserStrict(request).getUsername()), "showStatus",
+                settingsService.isShowStatus(), "transferStatuses", transferStatuses, "chartWidth",
+                StatusChartController.IMAGE_WIDTH, "chartHeight", StatusChartController.IMAGE_HEIGHT));
     }
 
     public static class TransferStatusHolder {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/TopController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/TopController.java
@@ -107,7 +107,7 @@ public class TopController {
 
         Map<String, Object> map = LegacyMap.of();
 
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         UserSettings userSettings = securityService.getUserSettings(user.getUsername());
         map.put("user", user);
         map.put("othersPlayingEnabled", settingsService.isOthersPlayingEnabled());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/TranscodingSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/TranscodingSettingsController.java
@@ -72,7 +72,7 @@ public class TranscodingSettingsController {
     @GetMapping
     public String doGet(HttpServletRequest request, Model model) {
 
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         UserSettings userSettings = securityService.getUserSettings(user.getUsername());
 
         model.addAttribute("model",

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/UploadEntryController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/UploadEntryController.java
@@ -50,7 +50,7 @@ public class UploadEntryController {
     @GetMapping
     protected ModelAndView handleRequestInternal(HttpServletRequest request) {
 
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
 
         String uploadDirectory = null;
         List<MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(user.getUsername());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/UserSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/UserSettingsController.java
@@ -119,7 +119,7 @@ public class UserSettingsController {
                 command.setTranscodeScheme(userSettings.getTranscodeScheme());
                 command.setAllowedMusicFolderIds(PlayerUtils.toIntArray(getAllowedMusicFolderIds(user)));
                 command.setCurrentUser(
-                        securityService.getCurrentUser(request).getUsername().equals(user.getUsername()));
+                        securityService.getCurrentUserStrict(request).getUsername().equals(user.getUsername()));
             }
         }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/VideoPlayerController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/VideoPlayerController.java
@@ -81,7 +81,7 @@ public class VideoPlayerController {
             return new ModelAndView(new RedirectView(ViewName.ACCESS_DENIED.value()));
         }
 
-        User user = securityService.getCurrentUser(request);
+        User user = securityService.getCurrentUserStrict(request);
         mediaFileService.populateStarredDate(file, user.getUsername());
         Integer duration = file.getDurationSeconds();
         Integer playerId = playerService.getPlayer(request, response).getId();

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
@@ -303,7 +303,11 @@ public class MediaFileService {
 
     @SuppressWarnings("PMD.UseLocaleWithCaseConversions")
     public boolean includeMediaFile(Path candidate) {
-        String suffix = FilenameUtils.getExtension(candidate.getFileName().toString()).toLowerCase();
+        Path fileName = candidate.getFileName();
+        if (fileName == null) {
+            return false;
+        }
+        String suffix = FilenameUtils.getExtension(fileName.toString()).toLowerCase();
         return !isExcluded(candidate) && (Files.isDirectory(candidate) || isAudioFile(suffix) || isVideoFile(suffix));
     }
 
@@ -334,7 +338,11 @@ public class MediaFileService {
             }
             return true;
         }
-        String name = path.getFileName().toString();
+        Path fileName = path.getFileName();
+        if (fileName == null) {
+            return true;
+        }
+        String name = fileName.toString();
         if (settingsService.getExcludePattern() != null && settingsService.getExcludePattern().matcher(name).find()) {
             if (LOG.isInfoEnabled()) {
                 LOG.info("excluding file which matches exclude pattern " + settingsService.getExcludePatternString()
@@ -364,7 +372,12 @@ public class MediaFileService {
 
         mediaFile.setPathString(path.toString());
         mediaFile.setFolder(securityService.getRootFolderForFile(path));
-        mediaFile.setParentPathString(path.getParent().toString());
+
+        Path parent = path.getParent();
+        if (parent == null) {
+            throw new IllegalArgumentException("Illegal path specified: " + path);
+        }
+        mediaFile.setParentPathString(parent.toString());
         mediaFile.setPlayCount(existingFile == null ? 0 : existingFile.getPlayCount());
         mediaFile.setLastPlayed(existingFile == null ? null : existingFile.getLastPlayed());
         mediaFile.setComment(existingFile == null ? null : existingFile.getComment());
@@ -483,7 +496,7 @@ public class MediaFileService {
         mediaFileCache.remove(path);
     }
 
-    public Path getCoverArt(MediaFile mediaFile) {
+    public @Nullable Path getCoverArt(MediaFile mediaFile) {
         if (mediaFile.getCoverArtPathString() != null) {
             return Path.of(mediaFile.getCoverArtPathString());
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicIndexService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicIndexService.java
@@ -89,7 +89,7 @@ public class MusicIndexService {
         return new MusicFolderContent(indexedArtists, singleSongs);
     }
 
-    private List<MediaFile> getSingleSongs(List<MusicFolder> folders, boolean refresh) {
+    List<MediaFile> getSingleSongs(List<MusicFolder> folders, boolean refresh) {
         List<MediaFile> result = new ArrayList<>();
         for (MusicFolder folder : folders) {
             MediaFile parent = mediaFileService.getMediaFile(folder.getPath().toPath(), !refresh);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicIndexService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicIndexService.java
@@ -93,7 +93,9 @@ public class MusicIndexService {
         List<MediaFile> result = new ArrayList<>();
         for (MusicFolder folder : folders) {
             MediaFile parent = mediaFileService.getMediaFile(folder.getPath().toPath(), !refresh);
-            result.addAll(mediaFileService.getChildrenOf(parent, true, false, true, !refresh));
+            if (parent != null) {
+                result.addAll(mediaFileService.getChildrenOf(parent, true, false, true, !refresh));
+            }
         }
         return result;
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicIndexServiceUtils.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicIndexServiceUtils.java
@@ -90,6 +90,9 @@ public class MusicIndexServiceUtils {
         for (MusicFolder folder : folders) {
 
             MediaFile root = mediaFileService.getMediaFile(folder.getPath().toPath(), !refresh);
+            if (root == null) {
+                continue;
+            }
             List<MediaFile> children = mediaFileService.getChildrenOf(root, false, true, true, !refresh);
             for (MediaFile child : children) {
                 if (shortcutSet.contains(child.getName())) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PodcastService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PodcastService.java
@@ -355,6 +355,9 @@ public class PodcastService {
 
             File dir = getChannelDirectory(channel);
             MediaFile channelMediaFile = mediaFileService.getMediaFile(dir.toPath());
+            if (channelMediaFile == null) {
+                return;
+            }
             Path existingCoverArt = mediaFileService.getCoverArt(channelMediaFile);
             boolean imageFileExists = existingCoverArt != null
                     && mediaFileService.getMediaFile(existingCoverArt) == null;
@@ -736,8 +739,10 @@ public class PodcastService {
             }
 
             MediaFile mediaFile = mediaFileService.getMediaFile(channelDir.toPath());
-            mediaFile.setComment(channel.getDescription());
-            mediaFileService.updateMediaFile(mediaFile);
+            if (mediaFile != null) {
+                mediaFile.setComment(channel.getDescription());
+                mediaFileService.updateMediaFile(mediaFile);
+            }
         }
         return channelDir;
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
@@ -226,20 +226,13 @@ public class SecurityService implements UserDetailsService {
         return authorities;
     }
 
-    /**
-     * Returns the currently logged-in user for the given HTTP request.
-     *
-     * @param request
-     *            The HTTP request.
-     *
-     * @return The logged-in user, or <code>null</code>.
-     */
-    public @Nullable User getCurrentUser(HttpServletRequest request) {
+    @Deprecated
+    public @Nullable User getCurrentUser(@NonNull HttpServletRequest request) {
         String username = getCurrentUsername(request);
         return username == null ? null : getUserByName(username);
     }
 
-    public @NonNull User getCurrentUserStrict(HttpServletRequest request) {
+    public @NonNull User getCurrentUserStrict(@NonNull HttpServletRequest request) {
         String username = getCurrentUsername(request);
         if (username == null) {
             throw new IllegalArgumentException("User not found");
@@ -427,11 +420,17 @@ public class SecurityService implements UserDetailsService {
      *
      * @return Whether the given file may be written, created or deleted.
      */
-    public boolean isWriteAllowed(Path path) {
+    public boolean isWriteAllowed(@NonNull Path path) {
+        if (path == null) {
+            throw new IllegalArgumentException("Illegal path specified: " + path);
+        }
+        Path fileName = path.getFileName();
+        if (fileName == null) {
+            throw new IllegalArgumentException("Illegal path specified: " + path);
+        }
         // Only allowed to write podcasts or cover art.
         boolean isPodcast = isInPodcastFolder(path);
-        boolean isCoverArt = isInMusicFolder(path.toString()) && path.getFileName().toString().startsWith("cover.");
-
+        boolean isCoverArt = isInMusicFolder(path.toString()) && fileName.toString().startsWith("cover.");
         return isPodcast || isCoverArt;
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/FFmpeg.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/FFmpeg.java
@@ -19,7 +19,7 @@
 
 package com.tesshu.jpsonic.service.metadata;
 
-import static com.tesshu.jpsonic.service.metadata.ParserUtils.createSimplePath;
+import static com.tesshu.jpsonic.util.FileUtil.getShortPath;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
 import java.awt.image.BufferedImage;
@@ -98,9 +98,8 @@ public class FFmpeg {
                 process.destroy();
             }
         } catch (IOException e) {
-            String simplePath = createSimplePath(path);
             if (LOG.isWarnEnabled()) {
-                LOG.warn("Failed to create thumbnail({}): {}", simplePath, e.getMessage());
+                LOG.warn("Failed to create thumbnail({}): {}", getShortPath(path), e.getMessage());
             }
             return null;
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/FFprobe.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/FFprobe.java
@@ -19,11 +19,11 @@
 
 package com.tesshu.jpsonic.service.metadata;
 
-import static com.tesshu.jpsonic.service.metadata.ParserUtils.createSimplePath;
 import static com.tesshu.jpsonic.service.metadata.ParserUtils.getFolder;
 import static com.tesshu.jpsonic.service.metadata.ParserUtils.parseInt;
 import static com.tesshu.jpsonic.service.metadata.ParserUtils.parseTrackNumber;
 import static com.tesshu.jpsonic.service.metadata.ParserUtils.parseYear;
+import static com.tesshu.jpsonic.util.FileUtil.getShortPath;
 import static org.apache.commons.lang.StringUtils.trimToNull;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
@@ -178,9 +178,8 @@ public class FFprobe {
             }
         } catch (IOException e) {
             // Exceptions to this class are self-explanatory, avoiding redundant trace output
-            String simplePath = createSimplePath(path);
             if (LOG.isWarnEnabled()) {
-                LOG.warn("Failed to execute ffprobe({}): {}", simplePath, e.getMessage());
+                LOG.warn("Failed to execute ffprobe({}): {}", getShortPath(path), e.getMessage());
             }
             return result;
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MP4Parser.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MP4Parser.java
@@ -19,12 +19,12 @@
 
 package com.tesshu.jpsonic.service.metadata;
 
-import static com.tesshu.jpsonic.service.metadata.ParserUtils.createSimplePath;
 import static com.tesshu.jpsonic.service.metadata.ParserUtils.getFolder;
 import static com.tesshu.jpsonic.service.metadata.ParserUtils.parseDoubleToInt;
 import static com.tesshu.jpsonic.service.metadata.ParserUtils.parseInt;
 import static com.tesshu.jpsonic.service.metadata.ParserUtils.parseTrackNumber;
 import static com.tesshu.jpsonic.service.metadata.ParserUtils.parseYear;
+import static com.tesshu.jpsonic.util.FileUtil.getShortPath;
 import static org.apache.commons.lang.StringUtils.trimToNull;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
@@ -93,9 +93,8 @@ public class MP4Parser {
             current = System.currentTimeMillis();
             tikaParser.parse(bid, handler, metadata, ps);
         } catch (IOException | SAXException | TikaException e) {
-            String simplePath = createSimplePath(mediaFile.toPath());
             if (LOG.isWarnEnabled()) {
-                LOG.warn("Failed to parse the tag({}): {}", simplePath, e.getMessage());
+                LOG.warn("Failed to parse the tag({}): {}", getShortPath(mediaFile.toPath()), e.getMessage());
             }
             return result;
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MetaDataParser.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MetaDataParser.java
@@ -122,7 +122,11 @@ public abstract class MetaDataParser {
             return null;
         }
         Path grandParent = parent.getParent();
-        return isRoot(grandParent) ? null : grandParent.getFileName().toString();
+        Path grandParentFilename = grandParent.getFileName();
+        if (grandParentFilename == null) {
+            return "";
+        }
+        return isRoot(grandParent) ? null : grandParentFilename.toString();
     }
 
     /**
@@ -130,7 +134,12 @@ public abstract class MetaDataParser {
      */
     protected final String guessAlbum(Path path, String artist) {
         Path parent = path.getParent();
-        String album = isRoot(parent) ? null : parent.getFileName().toString();
+        Path parentFileName = parent.getFileName();
+        if (parentFileName == null) {
+            return "";
+        }
+
+        String album = isRoot(parent) ? null : parentFileName.toString();
         if (artist != null && album != null) {
             album = album.replace(artist + " - ", "");
         }
@@ -144,10 +153,10 @@ public abstract class MetaDataParser {
         return StringUtils.trim(FilenameUtils.getBaseName(path.toString()));
     }
 
-    private boolean isRoot(Path path) {
+    protected boolean isRoot(Path path) {
         List<MusicFolder> folders = getMusicFolderService().getAllMusicFolders(false, true);
         for (MusicFolder folder : folders) {
-            if (path.toString().equals(folder.getPath().getAbsolutePath())) {
+            if (path.equals(folder.getPath().toPath())) {
                 return true;
             }
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MetaDataParser.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MetaDataParser.java
@@ -29,6 +29,7 @@ import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.service.MusicFolderService;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * Parses meta data from media files.
@@ -104,7 +105,7 @@ public abstract class MetaDataParser {
      *
      * @return Whether this parser is applicable to the given file.
      */
-    public abstract boolean isApplicable(Path path);
+    public abstract boolean isApplicable(@NonNull Path path);
 
     /**
      * Returns whether this parser supports tag editing (using the {@link #setMetaData} method).
@@ -116,12 +117,18 @@ public abstract class MetaDataParser {
     /**
      * Guesses the artist for the given file.
      */
-    protected final String guessArtist(Path path) {
+    protected final String guessArtist(@NonNull Path path) {
         Path parent = path.getParent();
+        if (parent == null) {
+            throw new IllegalArgumentException("Illegal path specified: " + path);
+        }
         if (isRoot(parent)) {
             return null;
         }
         Path grandParent = parent.getParent();
+        if (grandParent == null) {
+            throw new IllegalArgumentException("Illegal path specified: " + path);
+        }
         Path grandParentFilename = grandParent.getFileName();
         if (grandParentFilename == null) {
             return "";
@@ -132,8 +139,11 @@ public abstract class MetaDataParser {
     /**
      * Guesses the album for the given file.
      */
-    protected final String guessAlbum(Path path, String artist) {
+    protected final String guessAlbum(@NonNull Path path, String artist) {
         Path parent = path.getParent();
+        if (parent == null) {
+            throw new IllegalArgumentException("Illegal path specified: " + path);
+        }
         Path parentFileName = parent.getFileName();
         if (parentFileName == null) {
             return "";
@@ -149,7 +159,7 @@ public abstract class MetaDataParser {
     /**
      * Guesses the title for the given file.
      */
-    public String guessTitle(Path path) {
+    public String guessTitle(@NonNull Path path) {
         return StringUtils.trim(FilenameUtils.getBaseName(path.toString()));
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/VideoParser.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/VideoParser.java
@@ -22,6 +22,8 @@
 package com.tesshu.jpsonic.service.metadata;
 
 import java.nio.file.Path;
+import java.util.Locale;
+import java.util.stream.Stream;
 
 import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.service.MusicFolderService;
@@ -87,24 +89,21 @@ public class VideoParser extends MetaDataParser {
         return musicFolderService;
     }
 
-    /**
-     * Returns whether this parser is applicable to the given file.
-     *
-     * @param path
-     *            The file in question.
-     *
-     * @return Whether this parser is applicable to the given file.
-     */
-    @SuppressWarnings("PMD.UseLocaleWithCaseConversions")
     @Override
     public boolean isApplicable(Path path) {
-        String format = FilenameUtils.getExtension(path.getFileName().toString()).toLowerCase();
-
-        for (String s : settingsService.getVideoFileTypesAsArray()) {
-            if (format.equals(s)) {
-                return true;
-            }
+        if (path == null) {
+            throw new IllegalArgumentException("Illegal path specified.");
         }
-        return false;
+        Path fileName = path.getFileName();
+        if (fileName == null) {
+            throw new IllegalArgumentException("Illegal path specified: " + path);
+        }
+        String extension = FilenameUtils.getExtension(fileName.toString());
+        if (extension.isEmpty()) {
+            return false;
+        }
+        String format = extension.toLowerCase(Locale.ENGLISH);
+        return Stream.of(settingsService.getVideoFileTypesAsArray())
+                .anyMatch(type -> format.equals(type.toLowerCase(Locale.ENGLISH)));
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/FileUtil.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/FileUtil.java
@@ -24,6 +24,8 @@ package com.tesshu.jpsonic.util;
 import java.io.File;
 import java.nio.file.Path;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 /**
  * Miscellaneous file utility methods.
  *
@@ -41,14 +43,22 @@ public final class FileUtil {
      * Returns a short path for the given file. The path consists of the name of the parent directory and the given
      * file.
      */
-    public static String getShortPath(Path path) {
+    public static @Nullable String getShortPath(@Nullable Path path) {
         if (path == null) {
             return null;
         }
+        Path fileName = path.getFileName();
+        if (fileName == null) {
+            return "";
+        }
         Path parent = path.getParent();
         if (parent == null) {
-            return path.getFileName().toString();
+            return fileName.toString(); // Probably unreachable
         }
-        return parent.getFileName().toString() + File.separator + path.getFileName().toString();
+        Path parentFileName = parent.getFileName();
+        if (parentFileName == null) {
+            return File.separator + fileName.toString();
+        }
+        return parentFileName.toString() + File.separator + fileName.toString();
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/validator/UserSettingsValidator.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/validator/UserSettingsValidator.java
@@ -114,7 +114,7 @@ public class UserSettingsValidator implements Validator {
         }
     }
 
-    private void validateCurrentUser(UserSettingsCommand command, Errors errors) {
+    void validateCurrentUser(UserSettingsCommand command, Errors errors) {
         String username = command.getUsername();
         if (securityService.getCurrentUser(request).getUsername().equals(username)) {
             if (command.isDeleteUser()) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/validator/UserSettingsValidator.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/validator/UserSettingsValidator.java
@@ -116,7 +116,7 @@ public class UserSettingsValidator implements Validator {
 
     void validateCurrentUser(UserSettingsCommand command, Errors errors) {
         String username = command.getUsername();
-        if (securityService.getCurrentUser(request).getUsername().equals(username)) {
+        if (securityService.getCurrentUserStrict(request).getUsername().equals(username)) {
             if (command.isDeleteUser()) {
                 errors.rejectValue(REJECTED_FIELD_DELETEUSER, "usersettings.cantdeleteuser");
             }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/PersonalSettingsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/PersonalSettingsControllerTest.java
@@ -40,10 +40,12 @@ import com.tesshu.jpsonic.service.ServiceMockUtils;
 import com.tesshu.jpsonic.service.SettingsService;
 import com.tesshu.jpsonic.util.StringUtil;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestClassOrder;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -61,6 +63,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 @SpringBootTest
 @ExtendWith(NeedsHome.class)
 @SuppressWarnings("PMD.TooManyStaticImports")
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
 class PersonalSettingsControllerTest {
 
     private static final String VIEW_NAME = "personalSettings";
@@ -258,6 +261,7 @@ class PersonalSettingsControllerTest {
     @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
     @Nested
+    @Order(2)
     class DoSubmitAction {
 
         @DoSubmitDecision.Conditions.UserSettings.Locale.Null
@@ -646,6 +650,7 @@ class PersonalSettingsControllerTest {
     @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
     @Nested
+    @Order(1)
     class NowPlaying {
 
         @NowPlayingDecision.Conditions.UserSettings.NowPlayingAllowed.False

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MusicIndexServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MusicIndexServiceTest.java
@@ -200,6 +200,26 @@ class MusicIndexServiceTest {
     }
 
     @Test
+    void testGetSingleSongs() throws URISyntaxException {
+        Path path = Path.of(MusicIndexServiceTest.class.getResource("/MEDIAS").toURI());
+        MusicFolder musicFolder = new MusicFolder(path.toFile(), "musicFolder", false, null);
+        assertEquals(path, musicFolder.getPath().toPath());
+
+        final List<MusicFolder> musicFolders = Arrays.asList(musicFolder);
+        MediaFile mediaFile = new MediaFile();
+        mediaFile.setId(0);
+        mediaFile.setPathString(path.toString());
+
+        Mockito.when(mediaFileService.getMediaFile(path, true)).thenReturn(null);
+        musicIndexService.getSingleSongs(musicFolders, false);
+        Mockito.verify(mediaFileService, Mockito.never()).getChildrenOf(mediaFile, true, false, true, true);
+
+        Mockito.when(mediaFileService.getMediaFile(path, true)).thenReturn(mediaFile);
+        musicIndexService.getSingleSongs(musicFolders, false);
+        Mockito.verify(mediaFileService, Mockito.times(1)).getChildrenOf(mediaFile, true, false, true, true);
+    }
+
+    @Test
     void testGetShortcuts() throws URISyntaxException {
         Mockito.when(settingsService.getShortcutsAsArray())
                 .thenReturn(StringUtil.split(SettingsConstants.General.Extension.SHORTCUTS.defaultValue + " Metadata"));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/SecurityServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/SecurityServiceTest.java
@@ -210,8 +210,8 @@ class SecurityServiceTest {
 
     @Test
     void testIsWriteAllowed() {
-        assertThrows(NullPointerException.class, () -> service.isWriteAllowed(null));
-        assertThrows(NullPointerException.class, () -> service.isWriteAllowed(Path.of("/")));
+        assertThrows(IllegalArgumentException.class, () -> service.isWriteAllowed(null));
+        assertThrows(IllegalArgumentException.class, () -> service.isWriteAllowed(Path.of("/")));
         assertFalse(service.isWriteAllowed(Path.of("")));
         Mockito.when(musicFolderService.getAllMusicFolders(false, true)).thenReturn(Collections.emptyList());
         Mockito.when(settingsService.getPodcastFolder()).thenReturn("");

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/SecurityServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/SecurityServiceTest.java
@@ -24,8 +24,11 @@ package com.tesshu.jpsonic.service;
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.file.Path;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 
@@ -37,6 +40,7 @@ import com.tesshu.jpsonic.domain.SpeechToTextLangScheme;
 import com.tesshu.jpsonic.domain.UserSettings;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -45,96 +49,109 @@ import org.mockito.Mockito;
  *
  * @author Sindre Mehus
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals") // In the testing class, it may be less readable.
+@SuppressWarnings({ "PMD.AvoidDuplicateLiterals", "PMD.TooManyStaticImports" })
 class SecurityServiceTest {
 
     private SecurityService service;
     private SettingsService settingsService;
+    private MusicFolderService musicFolderService;
 
     @BeforeEach
     public void setup() {
         settingsService = mock(SettingsService.class);
-        service = new SecurityService(mock(UserDao.class), settingsService, mock(MusicFolderService.class), null);
+        musicFolderService = mock(MusicFolderService.class);
+        service = new SecurityService(mock(UserDao.class), settingsService, musicFolderService, null);
+    }
+
+    @Nested
+    class GetUserSettingsTest {
+
+        @Test
+        void testLanguageAndTheme() throws ExecutionException {
+            assertEquals("DEFAULT", service.getUserSettings("").getFontSchemeName());
+        }
+
+        @Test
+        void testSettings4DesktopPC() throws ExecutionException {
+            UserSettings userSettings = service.getUserSettings("");
+            assertTrue(userSettings.isKeyboardShortcutsEnabled());
+            assertEquals(AlbumListType.RANDOM, userSettings.getDefaultAlbumList());
+            assertFalse(userSettings.isPutMenuInDrawer());
+            assertTrue(userSettings.isShowIndex());
+            assertFalse(userSettings.isCloseDrawer());
+            assertTrue(userSettings.isClosePlayQueue());
+            assertTrue(userSettings.isAlternativeDrawer());
+            assertTrue(userSettings.isAutoHidePlayQueue());
+            assertTrue(userSettings.isBreadcrumbIndex());
+            assertTrue(userSettings.isAssignAccesskeyToNumber());
+            assertTrue(userSettings.isSimpleDisplay());
+            assertTrue(userSettings.isQueueFollowingSongs());
+            assertFalse(userSettings.isOpenDetailSetting());
+            assertFalse(userSettings.isOpenDetailStar());
+            assertFalse(userSettings.isOpenDetailIndex());
+            assertFalse(userSettings.isSongNotificationEnabled());
+            assertFalse(userSettings.isVoiceInputEnabled());
+            assertTrue(userSettings.isShowCurrentSongInfo());
+            assertEquals(SpeechToTextLangScheme.DEFAULT.name(), userSettings.getSpeechLangSchemeName());
+            Assertions.assertNull(userSettings.getIetf());
+            assertEquals(FontScheme.DEFAULT.name(), userSettings.getFontSchemeName());
+            assertEquals(WebFontUtils.DEFAULT_FONT_FAMILY, userSettings.getFontFamily());
+            assertEquals(WebFontUtils.DEFAULT_FONT_SIZE, userSettings.getFontSize());
+            assertEquals(Integer.valueOf(101), userSettings.getSystemAvatarId());
+        }
+
+        @Test
+        void testDisplay() throws Exception {
+            UserSettings userSettings = service.getUserSettings("");
+            assertTrue(userSettings.getMainVisibility().isTrackNumberVisible());
+            assertTrue(userSettings.getMainVisibility().isArtistVisible());
+            assertFalse(userSettings.getMainVisibility().isAlbumVisible());
+            assertTrue(userSettings.getMainVisibility().isComposerVisible());
+            assertTrue(userSettings.getMainVisibility().isGenreVisible());
+            assertFalse(userSettings.getMainVisibility().isYearVisible());
+            assertFalse(userSettings.getMainVisibility().isBitRateVisible());
+            assertTrue(userSettings.getMainVisibility().isDurationVisible());
+            assertFalse(userSettings.getMainVisibility().isFormatVisible());
+            assertFalse(userSettings.getMainVisibility().isFileSizeVisible());
+
+            assertFalse(userSettings.getPlaylistVisibility().isTrackNumberVisible());
+            assertTrue(userSettings.getPlaylistVisibility().isArtistVisible());
+            assertTrue(userSettings.getPlaylistVisibility().isAlbumVisible());
+            assertTrue(userSettings.getPlaylistVisibility().isComposerVisible());
+            assertTrue(userSettings.getPlaylistVisibility().isGenreVisible());
+            assertTrue(userSettings.getPlaylistVisibility().isYearVisible());
+            assertTrue(userSettings.getPlaylistVisibility().isBitRateVisible());
+            assertTrue(userSettings.getPlaylistVisibility().isDurationVisible());
+            assertTrue(userSettings.getPlaylistVisibility().isFormatVisible());
+            assertTrue(userSettings.getPlaylistVisibility().isFileSizeVisible());
+        }
+
+        @Test
+        void testAdditionalDisplay() throws ExecutionException {
+            UserSettings userSettings = service.getUserSettings("");
+            assertFalse(userSettings.isShowNowPlayingEnabled());
+            assertFalse(userSettings.isNowPlayingAllowed());
+            assertFalse(userSettings.isShowArtistInfoEnabled());
+            assertFalse(userSettings.isForceBio2Eng());
+            assertFalse(userSettings.isShowTopSongs());
+            assertFalse(userSettings.isShowSimilar());
+            assertFalse(userSettings.isShowSibling());
+            assertEquals(40, userSettings.getPaginationSize());
+            assertFalse(userSettings.isShowDownload());
+            assertFalse(userSettings.isShowTag());
+            assertFalse(userSettings.isShowChangeCoverArt());
+            assertFalse(userSettings.isShowComment());
+            assertFalse(userSettings.isShowShare());
+            assertFalse(userSettings.isShowRate());
+            assertFalse(userSettings.isShowAlbumSearch());
+            assertFalse(userSettings.isShowLastPlay());
+            assertFalse(userSettings.isShowAlbumActions());
+            assertFalse(userSettings.isPartyModeEnabled());
+        }
     }
 
     @Test
-    void testIsFileInFolder() {
-
-        assertTrue(service.isFileInFolder("/music/foo.mp3", "\\"));
-        assertTrue(service.isFileInFolder("/music/foo.mp3", "/"));
-
-        assertTrue(service.isFileInFolder("/music/foo.mp3", "/music"));
-        assertTrue(service.isFileInFolder("\\music\\foo.mp3", "/music"));
-        assertTrue(service.isFileInFolder("/music/foo.mp3", "\\music"));
-        assertTrue(service.isFileInFolder("/music/foo.mp3", "\\music\\"));
-
-        assertFalse(service.isFileInFolder("", "/tmp"));
-        assertFalse(service.isFileInFolder("foo.mp3", "/tmp"));
-        assertFalse(service.isFileInFolder("/music/foo.mp3", "/tmp"));
-        assertFalse(service.isFileInFolder("/music/foo.mp3", "/tmp/music"));
-
-        // Test that references to the parent directory (..) is not allowed.
-        assertTrue(service.isFileInFolder("/music/foo..mp3", "/music"));
-        assertTrue(service.isFileInFolder("/music/foo..", "/music"));
-        assertTrue(service.isFileInFolder("/music/foo.../", "/music"));
-        assertFalse(service.isFileInFolder("/music/foo/..", "/music"));
-        assertFalse(service.isFileInFolder("../music/foo", "/music"));
-        assertFalse(service.isFileInFolder("/music/../foo", "/music"));
-        assertFalse(service.isFileInFolder("/music/../bar/../foo", "/music"));
-        assertFalse(service.isFileInFolder("/music\\foo\\..", "/music"));
-        assertFalse(service.isFileInFolder("..\\music/foo", "/music"));
-        assertFalse(service.isFileInFolder("/music\\../foo", "/music"));
-        assertFalse(service.isFileInFolder("/music/..\\bar/../foo", "/music"));
-    }
-
-    /*
-     * #852. https://wiki.sei.cmu.edu/confluence/display/java/STR02-J.+Specify+an+appropriate+locale+when+
-     * comparing+locale-dependent+data
-     */
-    @Test
-    void testIsFileInFolderSTR02J() {
-        Mockito.when(settingsService.getLocale()).thenReturn(Locale.ENGLISH);
-        assertTrue(service.isFileInFolder("/music/foo.mp3", "/Music"));
-        assertTrue(service.isFileInFolder("/\u0130\u0049/foo.mp3", // İI
-                "/\u0069\u0131")); // iı
-    }
-
-    @Test
-    void testLanguageAndTheme() throws ExecutionException {
-        assertEquals("DEFAULT", service.getUserSettings("").getFontSchemeName());
-    }
-
-    @Test
-    void testSettings4DesktopPC() throws ExecutionException {
-        UserSettings userSettings = service.getUserSettings("");
-        assertTrue(userSettings.isKeyboardShortcutsEnabled());
-        assertEquals(AlbumListType.RANDOM, userSettings.getDefaultAlbumList());
-        assertFalse(userSettings.isPutMenuInDrawer());
-        assertTrue(userSettings.isShowIndex());
-        assertFalse(userSettings.isCloseDrawer());
-        assertTrue(userSettings.isClosePlayQueue());
-        assertTrue(userSettings.isAlternativeDrawer());
-        assertTrue(userSettings.isAutoHidePlayQueue());
-        assertTrue(userSettings.isBreadcrumbIndex());
-        assertTrue(userSettings.isAssignAccesskeyToNumber());
-        assertTrue(userSettings.isSimpleDisplay());
-        assertTrue(userSettings.isQueueFollowingSongs());
-        assertFalse(userSettings.isOpenDetailSetting());
-        assertFalse(userSettings.isOpenDetailStar());
-        assertFalse(userSettings.isOpenDetailIndex());
-        assertFalse(userSettings.isSongNotificationEnabled());
-        assertFalse(userSettings.isVoiceInputEnabled());
-        assertTrue(userSettings.isShowCurrentSongInfo());
-        assertEquals(SpeechToTextLangScheme.DEFAULT.name(), userSettings.getSpeechLangSchemeName());
-        Assertions.assertNull(userSettings.getIetf());
-        assertEquals(FontScheme.DEFAULT.name(), userSettings.getFontSchemeName());
-        assertEquals(WebFontUtils.DEFAULT_FONT_FAMILY, userSettings.getFontFamily());
-        assertEquals(WebFontUtils.DEFAULT_FONT_SIZE, userSettings.getFontSize());
-        assertEquals(Integer.valueOf(101), userSettings.getSystemAvatarId());
-    }
-
-    @Test
-    void testSettings4Tablet() {
+    void testCreateDefaultTabletUserSettings() {
         UserSettings tabletSettings = service.createDefaultTabletUserSettings("");
         assertFalse(tabletSettings.isKeyboardShortcutsEnabled());
         assertEquals(AlbumListType.RANDOM, tabletSettings.getDefaultAlbumList());
@@ -163,7 +180,7 @@ class SecurityServiceTest {
     }
 
     @Test
-    void testSettings4Smartphone() {
+    void testCreateDefaultSmartphoneUserSettings() {
         UserSettings smartphoneSettings = service.createDefaultSmartphoneUserSettings("");
         assertFalse(smartphoneSettings.isKeyboardShortcutsEnabled());
         assertEquals(AlbumListType.INDEX, smartphoneSettings.getDefaultAlbumList());
@@ -192,51 +209,58 @@ class SecurityServiceTest {
     }
 
     @Test
-    void testDisplay() throws Exception {
-        UserSettings userSettings = service.getUserSettings("");
-        assertTrue(userSettings.getMainVisibility().isTrackNumberVisible());
-        assertTrue(userSettings.getMainVisibility().isArtistVisible());
-        assertFalse(userSettings.getMainVisibility().isAlbumVisible());
-        assertTrue(userSettings.getMainVisibility().isComposerVisible());
-        assertTrue(userSettings.getMainVisibility().isGenreVisible());
-        assertFalse(userSettings.getMainVisibility().isYearVisible());
-        assertFalse(userSettings.getMainVisibility().isBitRateVisible());
-        assertTrue(userSettings.getMainVisibility().isDurationVisible());
-        assertFalse(userSettings.getMainVisibility().isFormatVisible());
-        assertFalse(userSettings.getMainVisibility().isFileSizeVisible());
-
-        assertFalse(userSettings.getPlaylistVisibility().isTrackNumberVisible());
-        assertTrue(userSettings.getPlaylistVisibility().isArtistVisible());
-        assertTrue(userSettings.getPlaylistVisibility().isAlbumVisible());
-        assertTrue(userSettings.getPlaylistVisibility().isComposerVisible());
-        assertTrue(userSettings.getPlaylistVisibility().isGenreVisible());
-        assertTrue(userSettings.getPlaylistVisibility().isYearVisible());
-        assertTrue(userSettings.getPlaylistVisibility().isBitRateVisible());
-        assertTrue(userSettings.getPlaylistVisibility().isDurationVisible());
-        assertTrue(userSettings.getPlaylistVisibility().isFormatVisible());
-        assertTrue(userSettings.getPlaylistVisibility().isFileSizeVisible());
+    void testIsWriteAllowed() {
+        assertThrows(NullPointerException.class, () -> service.isWriteAllowed(null));
+        assertThrows(NullPointerException.class, () -> service.isWriteAllowed(Path.of("/")));
+        assertFalse(service.isWriteAllowed(Path.of("")));
+        Mockito.when(musicFolderService.getAllMusicFolders(false, true)).thenReturn(Collections.emptyList());
+        Mockito.when(settingsService.getPodcastFolder()).thenReturn("");
+        assertTrue(service.isWriteAllowed(Path.of("cover.jpg")));
     }
 
-    @Test
-    void testAdditionalDisplay() throws ExecutionException {
-        UserSettings userSettings = service.getUserSettings("");
-        assertFalse(userSettings.isShowNowPlayingEnabled());
-        assertFalse(userSettings.isNowPlayingAllowed());
-        assertFalse(userSettings.isShowArtistInfoEnabled());
-        assertFalse(userSettings.isForceBio2Eng());
-        assertFalse(userSettings.isShowTopSongs());
-        assertFalse(userSettings.isShowSimilar());
-        assertFalse(userSettings.isShowSibling());
-        assertEquals(40, userSettings.getPaginationSize());
-        assertFalse(userSettings.isShowDownload());
-        assertFalse(userSettings.isShowTag());
-        assertFalse(userSettings.isShowChangeCoverArt());
-        assertFalse(userSettings.isShowComment());
-        assertFalse(userSettings.isShowShare());
-        assertFalse(userSettings.isShowRate());
-        assertFalse(userSettings.isShowAlbumSearch());
-        assertFalse(userSettings.isShowLastPlay());
-        assertFalse(userSettings.isShowAlbumActions());
-        assertFalse(userSettings.isPartyModeEnabled());
+    @Nested
+    class IsFileInFolderTest {
+
+        @Test
+        void testIsFileInFolder() {
+
+            assertTrue(service.isFileInFolder("/music/foo.mp3", "\\"));
+            assertTrue(service.isFileInFolder("/music/foo.mp3", "/"));
+
+            assertTrue(service.isFileInFolder("/music/foo.mp3", "/music"));
+            assertTrue(service.isFileInFolder("\\music\\foo.mp3", "/music"));
+            assertTrue(service.isFileInFolder("/music/foo.mp3", "\\music"));
+            assertTrue(service.isFileInFolder("/music/foo.mp3", "\\music\\"));
+
+            assertFalse(service.isFileInFolder("", "/tmp"));
+            assertFalse(service.isFileInFolder("foo.mp3", "/tmp"));
+            assertFalse(service.isFileInFolder("/music/foo.mp3", "/tmp"));
+            assertFalse(service.isFileInFolder("/music/foo.mp3", "/tmp/music"));
+
+            // Test that references to the parent directory (..) is not allowed.
+            assertTrue(service.isFileInFolder("/music/foo..mp3", "/music"));
+            assertTrue(service.isFileInFolder("/music/foo..", "/music"));
+            assertTrue(service.isFileInFolder("/music/foo.../", "/music"));
+            assertFalse(service.isFileInFolder("/music/foo/..", "/music"));
+            assertFalse(service.isFileInFolder("../music/foo", "/music"));
+            assertFalse(service.isFileInFolder("/music/../foo", "/music"));
+            assertFalse(service.isFileInFolder("/music/../bar/../foo", "/music"));
+            assertFalse(service.isFileInFolder("/music\\foo\\..", "/music"));
+            assertFalse(service.isFileInFolder("..\\music/foo", "/music"));
+            assertFalse(service.isFileInFolder("/music\\../foo", "/music"));
+            assertFalse(service.isFileInFolder("/music/..\\bar/../foo", "/music"));
+        }
+
+        /*
+         * #852. https://wiki.sei.cmu.edu/confluence/display/java/STR02-J.+Specify+an+appropriate+locale+when+
+         * comparing+locale-dependent+data
+         */
+        @Test
+        void testIsFileInFolderSTR02J() {
+            Mockito.when(settingsService.getLocale()).thenReturn(Locale.ENGLISH);
+            assertTrue(service.isFileInFolder("/music/foo.mp3", "/Music"));
+            assertTrue(service.isFileInFolder("/\u0130\u0049/foo.mp3", // İI
+                    "/\u0069\u0131")); // iı
+        }
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/MetaDataParserTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/MetaDataParserTest.java
@@ -129,8 +129,8 @@ class MetaDataParserTest {
 
     @Test
     void testGuessArtist() {
-        assertThrows(NullPointerException.class, () -> parser.guessArtist(Path.of("/")));
-        assertThrows(NullPointerException.class, () -> parser.guessArtist(Path.of("/song.mp3")));
+        assertThrows(IllegalArgumentException.class, () -> parser.guessArtist(Path.of("/")));
+        assertThrows(IllegalArgumentException.class, () -> parser.guessArtist(Path.of("/song.mp3")));
         assertEquals("", parser.guessArtist(Path.of("/MusicFolder/artist")));
         assertEquals("MusicFolder", parser.guessArtist(Path.of("/MusicFolder/artist/song.mp3")));
         assertEquals("MusicFolder", parser.guessArtist(Path.of("/MusicFolder/artist/album")));
@@ -139,8 +139,8 @@ class MetaDataParserTest {
         List<MusicFolder> musicFolders = Arrays
                 .asList(new MusicFolder(new File("/MusicFolder"), "MusicFolder", true, null));
         Mockito.when(musicFolderService.getAllMusicFolders(false, true)).thenReturn(musicFolders);
-        assertThrows(NullPointerException.class, () -> parser.guessArtist(Path.of("/")));
-        assertThrows(NullPointerException.class, () -> parser.guessArtist(Path.of("/song.mp3")));
+        assertThrows(IllegalArgumentException.class, () -> parser.guessArtist(Path.of("/")));
+        assertThrows(IllegalArgumentException.class, () -> parser.guessArtist(Path.of("/song.mp3")));
         assertNull(parser.guessArtist(Path.of("/MusicFolder/artist")));
         assertNull(parser.guessArtist(Path.of("/MusicFolder/artist/song.mp3")));
         assertNull(parser.guessArtist(Path.of("/MusicFolder/artist/album")));
@@ -149,7 +149,7 @@ class MetaDataParserTest {
 
     @Test
     void testGuessAlbum() {
-        assertThrows(NullPointerException.class, () -> parser.guessAlbum(Path.of("/"), "artist"));
+        assertThrows(IllegalArgumentException.class, () -> parser.guessAlbum(Path.of("/"), "artist"));
         assertEquals("", parser.guessAlbum(Path.of("/song.mp3"), "artist"));
         assertEquals("MusicFolder", parser.guessAlbum(Path.of("/MusicFolder/artist"), "artist"));
         assertEquals("artist", parser.guessAlbum(Path.of("/MusicFolder/artist/song.mp3"), "artist"));
@@ -159,7 +159,7 @@ class MetaDataParserTest {
         List<MusicFolder> musicFolders = Arrays
                 .asList(new MusicFolder(new File("/MusicFolder"), "MusicFolder", true, null));
         Mockito.when(musicFolderService.getAllMusicFolders(false, true)).thenReturn(musicFolders);
-        assertThrows(NullPointerException.class, () -> parser.guessAlbum(Path.of("/"), "artist"));
+        assertThrows(IllegalArgumentException.class, () -> parser.guessAlbum(Path.of("/"), "artist"));
         assertEquals("", parser.guessAlbum(Path.of("/song.mp3"), "artist"));
         assertNull(parser.guessAlbum(Path.of("/MusicFolder/artist"), "artist"));
         assertEquals("artist", parser.guessAlbum(Path.of("/MusicFolder/artist/song.mp3"), "artist"));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/VideoParserTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/VideoParserTest.java
@@ -46,8 +46,8 @@ class VideoParserTest {
 
     @Test
     void testisApplicable() {
-        assertThrows(NullPointerException.class, () -> parser.isApplicable(null));
-        assertThrows(NullPointerException.class, () -> parser.isApplicable(Path.of("/")));
+        assertThrows(IllegalArgumentException.class, () -> parser.isApplicable(null));
+        assertThrows(IllegalArgumentException.class, () -> parser.isApplicable(Path.of("/")));
         assertFalse(parser.isApplicable(Path.of("/album")));
         assertFalse(parser.isApplicable(Path.of("")));
         assertTrue(parser.isApplicable(Path.of("movie.mp4")));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/VideoParserTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/VideoParserTest.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2022 tesshucom
+ */
+
+package com.tesshu.jpsonic.service.metadata;
+
+import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import com.tesshu.jpsonic.service.MusicFolderService;
+import com.tesshu.jpsonic.service.SettingsService;
+import org.assertj.core.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class VideoParserTest {
+
+    private VideoParser parser;
+
+    @BeforeEach
+    void setUp() {
+        SettingsService settingsService = mock(SettingsService.class);
+        Mockito.when(settingsService.getVideoFileTypesAsArray()).thenReturn(Arrays.array("mp4"));
+        parser = new VideoParser(settingsService, mock(MusicFolderService.class), mock(FFprobe.class));
+    }
+
+    @Test
+    void testisApplicable() {
+        assertThrows(NullPointerException.class, () -> parser.isApplicable(null));
+        assertThrows(NullPointerException.class, () -> parser.isApplicable(Path.of("/")));
+        assertFalse(parser.isApplicable(Path.of("/album")));
+        assertFalse(parser.isApplicable(Path.of("")));
+        assertTrue(parser.isApplicable(Path.of("movie.mp4")));
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/FileUtilTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/FileUtilTest.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2022 tesshucom
+ */
+
+package com.tesshu.jpsonic.util;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class FileUtilTest {
+
+    @Test
+    void testGetShortPath() {
+
+        assertNull(FileUtil.getShortPath(null));
+
+        assertEquals("", FileUtil.getShortPath(Path.of("/")));
+
+        assertEquals(File.separator + "child.mp3", FileUtil.getShortPath(Path.of("/child.mp3")));
+
+        assertEquals("MusicFolder" + File.separator + "artist", FileUtil.getShortPath(Path.of("/MusicFolder/artist")));
+
+        assertEquals("artist" + File.separator + "child.mp3",
+                FileUtil.getShortPath(Path.of("/MusicFolder/artist/child.mp3")));
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/validator/UserSettingsValidatorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/validator/UserSettingsValidatorTest.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2022 tesshucom
+ */
+
+package com.tesshu.jpsonic.validator;
+
+import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+
+import com.tesshu.jpsonic.command.UserSettingsCommand;
+import com.tesshu.jpsonic.service.SecurityService;
+import com.tesshu.jpsonic.service.SettingsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.validation.MapBindingResult;
+
+class UserSettingsValidatorTest {
+
+    public static final String ADMIN_NAME = "admin";
+    UserSettingsValidator validator;
+
+    @BeforeEach
+    public void setup() throws ExecutionException {
+        validator = new UserSettingsValidator(mock(SecurityService.class), mock(SettingsService.class),
+                mock(MockHttpServletRequest.class));
+    }
+
+    @Test
+    void validateCurrentUser() {
+        UserSettingsCommand command = new UserSettingsCommand();
+        command.setUsername(ADMIN_NAME);
+        MapBindingResult errors = new MapBindingResult(new ConcurrentHashMap<>(), ADMIN_NAME);
+        command.setDeleteUser(false);
+        command.setAdminRole(false);
+        validator.validateCurrentUser(command, errors);
+        assertEquals(1, errors.getAllErrors().size());
+        assertEquals(1, errors.getErrorCount());
+        assertEquals("usersettings.cantremoverole", errors.getFieldError().getCode());
+    }
+}


### PR DESCRIPTION
 - The null dereference pointed out by Sonatype is resolved.
 - The null dereference pointed out by Sonatype is included in the spotbugs NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE check item. 
   - The purpose of this pull request is to eliminate alerts about this.
   - Therefore, a wider range of corrections will be made than Sonatype's advice.
____

In most cases, the cause of the correction is one of the following.

 - When null occurs in the process of creating a user object from HttpRequest. Access by an unauthorized user, or when the user account is deleted while browsing, etc.
 - Illegal path processing. In most cases, the path object handled by this system is NonNull. However, for directory roots, certain operations will result in null (Including the case where parent indirectly refers to the route by the path operation). In legacy code, it was NPE in such cases.

So it's a fix for null references caused by runtime. This fix changes to explicitly throw an IllegalArgumentException instead of an NPE in such cases.

eg.

> throw new IllegalArgumentException("User not found:" + username)
> throw new IllegalArgumentException("Illegal path specified: " + path)
____

As a result, **nothing changes in the behavioral specifications** from the user's perspective. However, unlike the NPE exception message, we can determine if it is a trivial unchecked exception.

