### PR TITLE
NIO.2 migration of domain (#1526)

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/MusicFolderSettingsCommand.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/MusicFolderSettingsCommand.java
@@ -22,6 +22,8 @@
 package com.tesshu.jpsonic.command;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
 
@@ -167,10 +169,11 @@ public class MusicFolderSettingsCommand extends SettingsPageCommons {
 
         public MusicFolderInfo(MusicFolder musicFolder) {
             id = musicFolder.getId();
-            path = musicFolder.getPath().getPath();
             name = musicFolder.getName();
             enabled = musicFolder.isEnabled();
-            existing = musicFolder.getPath().exists() && musicFolder.getPath().isDirectory();
+            Path folderPath = musicFolder.toPath();
+            path = folderPath.toString();
+            existing = Files.exists(folderPath) && Files.isDirectory(folderPath);
         }
 
         public MusicFolderInfo() {
@@ -227,7 +230,7 @@ public class MusicFolderSettingsCommand extends SettingsPageCommons {
             if (name == null) {
                 name = file.getName();
             }
-            return new MusicFolder(id, new File(path), name, enabled, new Date());
+            return new MusicFolder(id, path, name, enabled, new Date());
         }
 
         public boolean isExisting() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DownloadController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DownloadController.java
@@ -213,7 +213,7 @@ public class DownloadController {
     private void downloadFile(HttpServletResponse response, TransferStatus status, Path path, HttpRange range)
             throws IOException {
         writeLog("Starting to download", FileUtil.getShortPath(path), status.getPlayer());
-        status.setFile(path.toFile());
+        status.setPathString(path.toString());
 
         response.setContentType("application/x-download");
         Path fileName = path.getFileName();
@@ -421,7 +421,7 @@ public class DownloadController {
         String zipName = path.toRealPath().toString().substring(root.toRealPath().toString().length() + 1);
 
         if (Files.isRegularFile(path)) {
-            status.setFile(path.toFile());
+            status.setPathString(path.toString());
 
             ZipEntry zipEntry = new ZipEntry(zipName);
             zipEntry.setSize(Files.size(path));

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MoreController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MoreController.java
@@ -21,7 +21,7 @@
 
 package com.tesshu.jpsonic.controller;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.Calendar;
 import java.util.List;
 
@@ -75,7 +75,7 @@ public class MoreController {
         String uploadDirectory = null;
         List<MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(user.getUsername());
         if (!musicFolders.isEmpty()) {
-            uploadDirectory = new File(musicFolders.get(0).getPath(), "Incoming").getPath();
+            uploadDirectory = Path.of(musicFolders.get(0).getPathString(), "Incoming").toString();
         }
 
         Player player = playerService.getPlayer(request, response);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/NowPlayingController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/NowPlayingController.java
@@ -67,8 +67,7 @@ public class NowPlayingController {
         Player player = playerService.getPlayer(request, response);
         List<TransferStatus> statuses = statusService.getStreamStatusesForPlayer(player);
 
-        MediaFile current = statuses.isEmpty() ? null
-                : mediaFileService.getMediaFile(statuses.get(0).getFile().toPath());
+        MediaFile current = statuses.isEmpty() ? null : mediaFileService.getMediaFile(statuses.get(0).toPath());
         MediaFile dir = current == null ? null : mediaFileService.getParentOf(current);
 
         String url;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StatusController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StatusController.java
@@ -142,7 +142,7 @@ public class StatusController {
         }
 
         public String getPath() {
-            return FileUtil.getShortPath(transferStatus.getFile().toPath());
+            return FileUtil.getShortPath(transferStatus.toPath());
         }
 
         public String getBytes() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SubsonicRESTController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SubsonicRESTController.java
@@ -1450,8 +1450,7 @@ public class SubsonicRESTController {
         List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService.getAllMusicFolders(false, true);
         StringBuilder builder = new StringBuilder();
         for (com.tesshu.jpsonic.domain.MusicFolder musicFolder : musicFolders) {
-            String folderPath = musicFolder.getPath().getPath();
-            folderPath = folderPath.replace('\\', '/');
+            String folderPath = musicFolder.getPathString().replace('\\', '/');
             String folderPathLower = folderPath.toLowerCase(settingsService.getLocale());
             if (!folderPathLower.endsWith("/")) {
                 builder.setLength(0);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/TopController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/TopController.java
@@ -23,7 +23,6 @@ package com.tesshu.jpsonic.controller;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
@@ -207,17 +206,16 @@ public class TopController {
         MusicFolder selectedMusicFolder = securityService.getSelectedMusicFolder(username);
         if (selectedMusicFolder == null) {
             for (MusicFolder musicFolder : allMusicFolders) {
-                Path path = musicFolder.getPath().toPath();
                 try {
-                    lastModified = Math.max(lastModified, Files.getLastModifiedTime(path).toMillis());
+                    lastModified = Math.max(lastModified, Files.getLastModifiedTime(musicFolder.toPath()).toMillis());
                 } catch (IOException e) {
                     LOG.error("Unable to get last modified.", e);
                 }
             }
         } else {
-            Path path = selectedMusicFolder.getPath().toPath();
             try {
-                lastModified = Math.max(lastModified, Files.getLastModifiedTime(path).toMillis());
+                lastModified = Math.max(lastModified,
+                        Files.getLastModifiedTime(selectedMusicFolder.toPath()).toMillis());
             } catch (IOException e) {
                 LOG.error("Unable to get last modified.", e);
             }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/UploadController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/UploadController.java
@@ -325,8 +325,8 @@ public class UploadController {
         }
 
         @Override
-        public void start(String fileName) {
-            status.setFile(new File(fileName));
+        public void start(String path) {
+            status.setPathString(path);
         }
 
         @Override

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/UploadEntryController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/UploadEntryController.java
@@ -19,7 +19,7 @@
 
 package com.tesshu.jpsonic.controller;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
@@ -55,7 +55,7 @@ public class UploadEntryController {
         String uploadDirectory = null;
         List<MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(user.getUsername());
         if (!musicFolders.isEmpty()) {
-            uploadDirectory = new File(musicFolders.get(0).getPath(), "Incoming").getPath();
+            uploadDirectory = Path.of(musicFolders.get(0).getPathString(), "Incoming").toString();
         }
 
         ModelAndView result = new ModelAndView();

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MusicFolderDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MusicFolderDao.java
@@ -21,7 +21,6 @@
 
 package com.tesshu.jpsonic.dao;
 
-import java.io.File;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
@@ -81,14 +80,14 @@ public class MusicFolderDao extends AbstractDao {
      */
     public void createMusicFolder(MusicFolder musicFolder) {
         String sql = "insert into music_folder (" + INSERT_COLUMNS + ") values (?, ?, ?, ?)";
-        update(sql, musicFolder.getPath().getPath(), musicFolder.getName(), musicFolder.isEnabled(),
+        update(sql, musicFolder.getPathString(), musicFolder.getName(), musicFolder.isEnabled(),
                 musicFolder.getChanged());
 
         Integer id = queryForInt("select max(id) from music_folder", 0);
         update("insert into music_folder_user (music_folder_id, username) select ?, username from "
                 + userDao.getUserTable(), id);
         if (LOG.isInfoEnabled()) {
-            LOG.info("Created music folder " + musicFolder.getPath());
+            LOG.info("Created music folder " + musicFolder.getPathString());
         }
     }
 
@@ -114,7 +113,7 @@ public class MusicFolderDao extends AbstractDao {
      */
     public void updateMusicFolder(MusicFolder musicFolder) {
         String sql = "update music_folder set path=?, name=?, enabled=?, changed=? where id=?";
-        update(sql, musicFolder.getPath().getPath(), musicFolder.getName(), musicFolder.isEnabled(),
+        update(sql, musicFolder.getPathString(), musicFolder.getName(), musicFolder.isEnabled(),
                 musicFolder.getChanged(), musicFolder.getId());
     }
 
@@ -134,7 +133,7 @@ public class MusicFolderDao extends AbstractDao {
     private static class MusicFolderRowMapper implements RowMapper<MusicFolder> {
         @Override
         public MusicFolder mapRow(ResultSet rs, int rowNum) throws SQLException {
-            return new MusicFolder(rs.getInt(1), new File(rs.getString(2)), rs.getString(3), rs.getBoolean(4),
+            return new MusicFolder(rs.getInt(1), rs.getString(2), rs.getString(3), rs.getBoolean(4),
                     rs.getTimestamp(5));
         }
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicFolder.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicFolder.java
@@ -21,7 +21,6 @@
 
 package com.tesshu.jpsonic.domain;
 
-import java.io.File;
 import java.io.Serializable;
 import java.nio.file.Path;
 import java.util.Date;
@@ -39,26 +38,10 @@ import com.google.common.base.Objects;
 public class MusicFolder implements Serializable {
 
     private final Integer id;
-    @Deprecated
-    private File file;
     private String pathString;
     private String name;
     private boolean enabled;
     private Date changed;
-
-    @Deprecated
-    public MusicFolder(Integer id, File file, String name, boolean enabled, Date changed) {
-        this.id = id;
-        this.file = file;
-        this.name = name;
-        this.enabled = enabled;
-        this.changed = changed;
-    }
-
-    @Deprecated
-    public MusicFolder(File file, String name, boolean enabled, Date changed) {
-        this(null, file, name, enabled, changed);
-    }
 
     public MusicFolder(Integer id, String pathString, String name, boolean enabled, Date changed) {
         this.id = id;
@@ -74,16 +57,6 @@ public class MusicFolder implements Serializable {
 
     public Integer getId() {
         return id;
-    }
-
-    @Deprecated
-    public File getPath() {
-        return file;
-    }
-
-    @Deprecated
-    public void setFolderPath(File path) {
-        this.file = path;
     }
 
     public String getPathString() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicFolder.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicFolder.java
@@ -39,130 +39,60 @@ import com.google.common.base.Objects;
 public class MusicFolder implements Serializable {
 
     private final Integer id;
-    private File path;
+    @Deprecated
+    private File file;
     private String name;
     private boolean enabled;
     private Date changed;
 
-    /**
-     * Creates a new music folder.
-     *
-     * @param id
-     *            The system-generated ID.
-     * @param path
-     *            The path of the music folder.
-     * @param name
-     *            The user-defined name.
-     * @param enabled
-     *            Whether the folder is enabled.
-     * @param changed
-     *            When the corresponding database entry was last changed.
-     */
-    public MusicFolder(Integer id, File path, String name, boolean enabled, Date changed) {
+    @Deprecated
+    public MusicFolder(Integer id, File file, String name, boolean enabled, Date changed) {
         this.id = id;
-        this.path = path;
+        this.file = file;
         this.name = name;
         this.enabled = enabled;
         this.changed = changed;
     }
 
-    /**
-     * Creates a new music folder.
-     *
-     * @param path
-     *            The path of the music folder.
-     * @param name
-     *            The user-defined name.
-     * @param enabled
-     *            Whether the folder is enabled.
-     * @param changed
-     *            When the corresponding database entry was last changed.
-     */
-    public MusicFolder(File path, String name, boolean enabled, Date changed) {
-        this(null, path, name, enabled, changed);
+    @Deprecated
+    public MusicFolder(File file, String name, boolean enabled, Date changed) {
+        this(null, file, name, enabled, changed);
     }
 
-    /**
-     * Returns the system-generated ID.
-     *
-     * @return The system-generated ID.
-     */
     public Integer getId() {
         return id;
     }
 
-    /**
-     * Returns the path of the music folder.
-     *
-     * @return The path of the music folder.
-     */
+    @Deprecated
     public File getPath() {
-        return path;
+        return file;
     }
 
-    /**
-     * Sets the path of the music folder.
-     *
-     * @param path
-     *            The path of the music folder.
-     */
-    public void setPath(File path) {
-        this.path = path;
+    @Deprecated
+    public void setFolderPath(File path) {
+        this.file = path;
     }
 
-    /**
-     * Returns the user-defined name.
-     *
-     * @return The user-defined name.
-     */
     public String getName() {
         return name;
     }
 
-    /**
-     * Sets the user-defined name.
-     *
-     * @param name
-     *            The user-defined name.
-     */
     public void setName(String name) {
         this.name = name;
     }
 
-    /**
-     * Returns whether the folder is enabled.
-     *
-     * @return Whether the folder is enabled.
-     */
     public boolean isEnabled() {
         return enabled;
     }
 
-    /**
-     * Sets whether the folder is enabled.
-     *
-     * @param enabled
-     *            Whether the folder is enabled.
-     */
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
     }
 
-    /**
-     * Returns when the corresponding database entry was last changed.
-     *
-     * @return When the corresponding database entry was last changed.
-     */
     public Date getChanged() {
         return changed;
     }
 
-    /**
-     * Sets when the corresponding database entry was last changed.
-     *
-     * @param changed
-     *            When the corresponding database entry was last changed.
-     */
     public void setChanged(Date changed) {
         this.changed = changed;
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicFolder.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicFolder.java
@@ -23,9 +23,9 @@ package com.tesshu.jpsonic.domain;
 
 import java.io.File;
 import java.io.Serializable;
+import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Objects;
@@ -41,6 +41,7 @@ public class MusicFolder implements Serializable {
     private final Integer id;
     @Deprecated
     private File file;
+    private String pathString;
     private String name;
     private boolean enabled;
     private Date changed;
@@ -59,6 +60,18 @@ public class MusicFolder implements Serializable {
         this(null, file, name, enabled, changed);
     }
 
+    public MusicFolder(Integer id, String pathString, String name, boolean enabled, Date changed) {
+        this.id = id;
+        this.pathString = pathString;
+        this.name = name;
+        this.enabled = enabled;
+        this.changed = changed;
+    }
+
+    public MusicFolder(String pathString, String name, boolean enabled, Date changed) {
+        this(null, pathString, name, enabled, changed);
+    }
+
     public Integer getId() {
         return id;
     }
@@ -71,6 +84,18 @@ public class MusicFolder implements Serializable {
     @Deprecated
     public void setFolderPath(File path) {
         this.file = path;
+    }
+
+    public String getPathString() {
+        return pathString;
+    }
+
+    public void setPathString(String pathString) {
+        this.pathString = pathString;
+    }
+
+    public Path toPath() {
+        return Path.of(pathString);
     }
 
     public String getName() {
@@ -114,18 +139,10 @@ public class MusicFolder implements Serializable {
     }
 
     public static List<Integer> toIdList(List<MusicFolder> from) {
-        return from.stream().map(toId()).collect(Collectors.toList());
+        return from.stream().map(MusicFolder::getId).collect(Collectors.toList());
     }
 
     public static List<String> toPathList(List<MusicFolder> from) {
-        return from.stream().map(toPath()).collect(Collectors.toList());
-    }
-
-    public static Function<MusicFolder, Integer> toId() {
-        return MusicFolder::getId;
-    }
-
-    public static Function<MusicFolder, String> toPath() {
-        return from -> from.getPath().getPath();
+        return from.stream().map(MusicFolder::getPathString).collect(Collectors.toList());
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/TransferStatus.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/TransferStatus.java
@@ -21,7 +21,6 @@
 
 package com.tesshu.jpsonic.domain;
 
-import java.io.File;
 import java.io.Serializable;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicLong;
@@ -46,8 +45,6 @@ public class TransferStatus implements Serializable {
     private static final Object HISTORY_LOCK = new Object();
 
     private transient Player player;
-    @Deprecated
-    private File file;
     private String pathString;
     private final AtomicLong bytesTransfered;
     private final AtomicLong bytesSkipped;
@@ -119,16 +116,6 @@ public class TransferStatus implements Serializable {
 
     public void addBytesSkipped(long byteCount) {
         bytesSkipped.addAndGet(byteCount);
-    }
-
-    @Deprecated
-    public File getFile() {
-        return file;
-    }
-
-    @Deprecated
-    public void setFile(File file) {
-        this.file = file;
     }
 
     public String getPathString() {
@@ -208,8 +195,8 @@ public class TransferStatus implements Serializable {
 
     @Override
     public String toString() {
-        return "TransferStatus-" + hashCode() + " [player: " + player.getId() + ", file: " + file + ", terminated: "
-                + terminated + ", active: " + active + "]";
+        return "TransferStatus-" + hashCode() + " [player: " + player.getId() + ", path: " + pathString
+                + ", terminated: " + terminated + ", active: " + active + "]";
     }
 
     @SuppressWarnings("serial")

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/TransferStatus.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/TransferStatus.java
@@ -45,6 +45,7 @@ public class TransferStatus implements Serializable {
     private static final Object HISTORY_LOCK = new Object();
 
     private transient Player player;
+    @Deprecated
     private File file;
     private final AtomicLong bytesTransfered;
     private final AtomicLong bytesSkipped;
@@ -173,6 +174,7 @@ public class TransferStatus implements Serializable {
      *
      * @return The file that is currently being transferred.
      */
+    @Deprecated
     public File getFile() {
         return file;
     }
@@ -183,6 +185,7 @@ public class TransferStatus implements Serializable {
      * @param file
      *            The file that is currently being transferred.
      */
+    @Deprecated
     public void setFile(File file) {
         this.file = file;
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/io/PlayQueueInputStream.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/io/PlayQueueInputStream.java
@@ -166,7 +166,7 @@ public class PlayQueueInputStream extends InputStream {
                             pqis.transcodingService.getTranscodedInputStream(pqis.transParam));
                     if (!isEmpty(pqis.delegate) || pqis.player.getPlayQueue().getStatus() != PlayQueue.Status.STOPPED) {
                         pqis.currentFile = new AtomicReference<>(file);
-                        pqis.status.setFile(pqis.currentFile.get().toPath().toFile());
+                        pqis.status.setPathString(pqis.currentFile.get().toPath().toString());
                         return true;
                     }
                 } catch (IOException e) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/JMediaFileService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/JMediaFileService.java
@@ -19,7 +19,7 @@
 
 package com.tesshu.jpsonic.service;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 
 import com.tesshu.jpsonic.dao.JMediaFileDao;
@@ -69,12 +69,11 @@ public class JMediaFileService {
      * @return the number of child elements
      */
     public int getChildSizeOf(MusicFolder musicFolder) {
-        return mediaFileDao.getChildSizeOf(musicFolder.getPath().getPath());
+        return mediaFileDao.getChildSizeOf(musicFolder.getPathString());
     }
 
-    public MediaFile getMediaFile(File file) {
-        return deligate.getMediaFile(file.toPath());
-
+    public MediaFile getMediaFile(Path path) {
+        return deligate.getMediaFile(path);
     }
 
     public MediaFile getMediaFile(int id) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
@@ -253,7 +253,7 @@ public class MediaFileService {
 
     public boolean isRoot(MediaFile mediaFile) {
         for (MusicFolder musicFolder : musicFolderService.getAllMusicFolders(false, true)) {
-            if (mediaFile.toPath().equals(musicFolder.getPath().toPath())) {
+            if (mediaFile.toPath().equals(musicFolder.toPath())) {
                 return true;
             }
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaScannerService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaScannerService.java
@@ -192,16 +192,18 @@ public class MediaScannerService {
 
             // Recurse through all files on disk.
             for (MusicFolder musicFolder : musicFolderService.getAllMusicFolders()) {
-                MediaFile root = mediaFileService.getMediaFile(musicFolder.getPath().toPath(), false);
+                MediaFile root = mediaFileService.getMediaFile(musicFolder.toPath(), false);
                 scanFile(root, musicFolder, statistics, albumCount, genres, false);
             }
 
             // Scan podcast folder.
-            Path podcastFolder = Path.of(settingsService.getPodcastFolder());
-            if (Files.exists(podcastFolder)) {
-                scanFile(mediaFileService.getMediaFile(podcastFolder),
-                        new MusicFolder(podcastFolder.toFile(), null, true, null), statistics, albumCount, genres,
-                        true);
+            if (settingsService.getPodcastFolder() != null) {
+                Path podcastFolder = Path.of(settingsService.getPodcastFolder());
+                if (Files.exists(podcastFolder)) {
+                    scanFile(mediaFileService.getMediaFile(podcastFolder),
+                            new MusicFolder(podcastFolder.toString(), null, true, null), statistics, albumCount, genres,
+                            true);
+                }
             }
 
             writeInfo("Scanned media library with " + scanCount + " entries.");
@@ -277,8 +279,9 @@ public class MediaScannerService {
         writeScanLog(file);
 
         // Update the root folder if it has changed.
-        if (!musicFolder.getPath().getPath().equals(file.getFolder())) {
-            file.setFolder(musicFolder.getPath().getPath());
+        String musicFolderPath = musicFolder.getPathString();
+        if (!musicFolderPath.equals(file.getFolder())) {
+            file.setFolder(musicFolderPath);
             mediaFileDao.createOrUpdateMediaFile(file);
         }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicFolderService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicFolderService.java
@@ -72,8 +72,7 @@ public class MusicFolderService {
 
         List<MusicFolder> result = new ArrayList<>(cachedMusicFolders.size());
         for (MusicFolder folder : cachedMusicFolders) {
-            if ((includeDisabled || folder.isEnabled())
-                    && (includeNonExisting || Files.exists(folder.getPath().toPath()))) {
+            if ((includeDisabled || folder.isEnabled()) && (includeNonExisting || Files.exists(folder.toPath()))) {
                 result.add(folder);
             }
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicIndexService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicIndexService.java
@@ -92,7 +92,7 @@ public class MusicIndexService {
     List<MediaFile> getSingleSongs(List<MusicFolder> folders, boolean refresh) {
         List<MediaFile> result = new ArrayList<>();
         for (MusicFolder folder : folders) {
-            MediaFile parent = mediaFileService.getMediaFile(folder.getPath().toPath(), !refresh);
+            MediaFile parent = mediaFileService.getMediaFile(folder.toPath(), !refresh);
             if (parent != null) {
                 result.addAll(mediaFileService.getChildrenOf(parent, true, false, true, !refresh));
             }
@@ -104,7 +104,7 @@ public class MusicIndexService {
         List<MediaFile> result = new ArrayList<>();
         for (String shortcut : settingsService.getShortcutsAsArray()) {
             for (MusicFolder musicFolder : musicFoldersToUse) {
-                Path shortcutPath = Path.of(musicFolder.getPath().toString(), shortcut);
+                Path shortcutPath = Path.of(musicFolder.getPathString(), shortcut);
                 if (Files.exists(shortcutPath)) {
                     result.add(mediaFileService.getMediaFile(shortcutPath, true));
                 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicIndexServiceUtils.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicIndexServiceUtils.java
@@ -89,7 +89,7 @@ public class MusicIndexServiceUtils {
         Comparator<SortableArtist> c = comparators.sortableArtistOrder();
         for (MusicFolder folder : folders) {
 
-            MediaFile root = mediaFileService.getMediaFile(folder.getPath().toPath(), !refresh);
+            MediaFile root = mediaFileService.getMediaFile(folder.toPath(), !refresh);
             if (root == null) {
                 continue;
             }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
@@ -441,7 +441,7 @@ public class SecurityService implements UserDetailsService {
     private MusicFolder getMusicFolderForFile(String path) {
         List<MusicFolder> folders = musicFolderService.getAllMusicFolders(false, true);
         for (MusicFolder folder : folders) {
-            if (isFileInFolder(path, folder.getPath().getPath())) {
+            if (isFileInFolder(path, folder.getPathString())) {
                 return folder;
             }
         }
@@ -469,7 +469,7 @@ public class SecurityService implements UserDetailsService {
     public String getRootFolderForFile(String path) {
         MusicFolder folder = getMusicFolderForFile(path);
         if (folder != null) {
-            return folder.getPath().getPath();
+            return folder.getPathString();
         }
 
         if (isInPodcastFolder(path)) {
@@ -481,7 +481,7 @@ public class SecurityService implements UserDetailsService {
     public String getRootFolderForFile(Path path) {
         MusicFolder folder = getMusicFolderForFile(path.toString());
         if (folder != null) {
-            return folder.getPath().getPath();
+            return folder.getPathString();
         }
 
         if (isInPodcastFolder(path)) {
@@ -496,7 +496,7 @@ public class SecurityService implements UserDetailsService {
         }
 
         for (MusicFolder musicFolder : musicFolderService.getMusicFoldersForUser(username)) {
-            if (musicFolder.getPath().getPath().equals(file.getFolder())) {
+            if (musicFolder.getPathString().equals(file.getFolder())) {
                 return true;
             }
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/StatusService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/StatusService.java
@@ -23,7 +23,7 @@ package com.tesshu.jpsonic.service;
 
 import static java.util.Collections.unmodifiableList;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
@@ -203,11 +203,11 @@ public class StatusService {
 
                 for (TransferStatus streamStatus : statuses) {
                     Player player = streamStatus.getPlayer();
-                    File file = streamStatus.getFile();
-                    if (file == null) {
+                    Path path = streamStatus.toPath();
+                    if (path == null) {
                         continue;
                     }
-                    MediaFile mediaFile = mediaFileService.getMediaFile(file.toPath());
+                    MediaFile mediaFile = mediaFileService.getMediaFile(path);
                     if (player == null || mediaFile == null) {
                         continue;
                     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MetaDataParser.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MetaDataParser.java
@@ -166,7 +166,7 @@ public abstract class MetaDataParser {
     protected boolean isRoot(Path path) {
         List<MusicFolder> folders = getMusicFolderService().getAllMusicFolders(false, true);
         for (MusicFolder folder : folders) {
-            if (path.equals(folder.getPath().toPath())) {
+            if (path.equals(folder.toPath())) {
                 return true;
             }
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
@@ -205,7 +205,7 @@ public class IndexManager {
         }
     }
 
-    public final void startIndexing() {
+    public void startIndexing() {
         try {
             for (IndexType indexType : IndexType.values()) {
                 writers.put(indexType, createIndexWriter(indexType));

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/QueryFactory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/QueryFactory.java
@@ -74,7 +74,7 @@ public class QueryFactory {
 
     private final Function<MusicFolder, Query> toFolderPathQuery = (folder) -> {
         // Unanalyzed field
-        return new TermQuery(new Term(FieldNamesConstants.FOLDER, folder.getPath().getPath()));
+        return new TermQuery(new Term(FieldNamesConstants.FOLDER, folder.getPathString()));
     };
 
     public final BiFunction<@NonNull Boolean, @NonNull List<MusicFolder>, @NonNull Query> toFolderQuery = (isId3,
@@ -331,8 +331,8 @@ public class QueryFactory {
 
         // sub - folder
         BooleanQuery.Builder folderQuery = new BooleanQuery.Builder();
-        musicFolders.forEach(musicFolder -> folderQuery.add(
-                new TermQuery(new Term(FieldNamesConstants.FOLDER, musicFolder.getPath().getPath())), Occur.SHOULD));
+        musicFolders.forEach(musicFolder -> folderQuery
+                .add(new TermQuery(new Term(FieldNamesConstants.FOLDER, musicFolder.getPathString())), Occur.SHOULD));
         query.add(folderQuery.build(), Occur.MUST);
 
         return query.build();

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/MediaFileUpnpProcessor.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/MediaFileUpnpProcessor.java
@@ -148,10 +148,10 @@ public class MediaFileUpnpProcessor extends UpnpContentProcessor<MediaFile, Medi
         List<MusicFolder> allFolders = util.getGuestMusicFolders();
         List<MediaFile> returnValue = new ArrayList<>();
         if (allFolders.size() == SINGLE_MUSIC_FOLDER) {
-            returnValue = getChildren(mediaFileService.getMediaFile(allFolders.get(0).getPath()), offset, maxResults);
+            returnValue = getChildren(mediaFileService.getMediaFile(allFolders.get(0).toPath()), offset, maxResults);
         } else {
             for (int i = (int) offset; i < Math.min(allFolders.size(), offset + maxResults); i++) {
-                returnValue.add(mediaFileService.getMediaFile(allFolders.get(i).getPath()));
+                returnValue.add(mediaFileService.getMediaFile(allFolders.get(i).toPath()));
             }
         }
         return returnValue;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/MusicFolderTestDataUtils.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/MusicFolderTestDataUtils.java
@@ -22,10 +22,13 @@
 package com.tesshu.jpsonic;
 
 import java.io.File;
-import java.util.ArrayList;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.tesshu.jpsonic.domain.MusicFolder;
 
 public final class MusicFolderTestDataUtils {
@@ -36,7 +39,12 @@ public final class MusicFolderTestDataUtils {
     }
 
     public static String resolveBaseMediaPath() {
-        return MusicFolderTestDataUtils.class.getResource(BASE_RESOURCES).toString().replace("file:", "");
+        try {
+            return Path.of(MusicFolderTestDataUtils.class.getResource(BASE_RESOURCES).toURI()).toString()
+                    + File.separator;
+        } catch (URISyntaxException e) {
+            throw new UncheckedExecutionException(e);
+        }
     }
 
     public static String resolveMusicFolderPath() {
@@ -52,14 +60,8 @@ public final class MusicFolderTestDataUtils {
     }
 
     public static List<MusicFolder> getTestMusicFolders() {
-        List<MusicFolder> liste = new ArrayList<>();
-        File musicDir = new File(MusicFolderTestDataUtils.resolveMusicFolderPath());
-        MusicFolder musicFolder = new MusicFolder(1, musicDir, "Music", true, new Date());
-        liste.add(musicFolder);
-
-        File music2Dir = new File(MusicFolderTestDataUtils.resolveMusic2FolderPath());
-        MusicFolder musicFolder2 = new MusicFolder(2, music2Dir, "Music2", true, new Date());
-        liste.add(musicFolder2);
-        return liste;
+        return Arrays.asList(
+                new MusicFolder(1, MusicFolderTestDataUtils.resolveMusicFolderPath(), "Music", true, new Date()),
+                new MusicFolder(2, MusicFolderTestDataUtils.resolveMusic2FolderPath(), "Music2", true, new Date()));
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/CoverArtServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/CoverArtServiceTest.java
@@ -24,12 +24,11 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -62,9 +61,7 @@ class CoverArtServiceTest extends AbstractNeedsScan {
     @Override
     public List<MusicFolder> getMusicFolders() {
         if (isEmpty(musicFolders)) {
-            musicFolders = new ArrayList<>();
-            File musicDir = new File(resolveBaseMediaPath("Music"));
-            musicFolders.add(new MusicFolder(1, musicDir, "Music", true, new Date()));
+            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, new Date()));
         }
         return musicFolders;
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/MultiServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/MultiServiceTest.java
@@ -24,8 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
-import java.io.File;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -65,9 +64,7 @@ class MultiServiceTest extends AbstractNeedsScan {
     @Override
     public List<MusicFolder> getMusicFolders() {
         if (isEmpty(musicFolders)) {
-            musicFolders = new ArrayList<>();
-            File musicDir = new File(resolveBaseMediaPath("Music"));
-            musicFolders.add(new MusicFolder(1, musicDir, "Music", true, new Date()));
+            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, new Date()));
         }
         return musicFolders;
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/ChangeCoverArtControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/ChangeCoverArtControllerTest.java
@@ -21,8 +21,7 @@ package com.tesshu.jpsonic.controller;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.File;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -50,13 +49,8 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 @ComponentScan(basePackages = "com.tesshu.jpsonic")
 class ChangeCoverArtControllerTest extends AbstractNeedsScan {
 
-    private static final List<MusicFolder> MUSIC_FOLDERS;
-
-    static {
-        MUSIC_FOLDERS = new ArrayList<>();
-        File musicDir = new File(resolveBaseMediaPath("Music"));
-        MUSIC_FOLDERS.add(new MusicFolder(1, musicDir, "Music", true, new Date()));
-    }
+    private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, new Date()));
 
     @Autowired
     private MediaFileDao mediaFileDao;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DLNASettingsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DLNASettingsControllerTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.File;
 import java.lang.annotation.Documented;
 import java.util.Arrays;
 import java.util.List;
@@ -159,7 +160,7 @@ class DLNASettingsControllerTest {
          * Always false if all folders are not allowed. Because the genre count is a statistical result for all
          * directories.
          */
-        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, null, null, true, null));
+        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, new File(""), null, true, null));
         Mockito.when(musicFolderService.getAllMusicFolders()).thenReturn(musicFolders);
         Mockito.when(musicFolderService.getMusicFoldersForUser(User.USERNAME_GUEST)).thenReturn(musicFolders);
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DLNASettingsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DLNASettingsControllerTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.File;
 import java.lang.annotation.Documented;
 import java.util.Arrays;
 import java.util.List;
@@ -160,7 +159,7 @@ class DLNASettingsControllerTest {
          * Always false if all folders are not allowed. Because the genre count is a statistical result for all
          * directories.
          */
-        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, new File(""), null, true, null));
+        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, "", null, true, null));
         Mockito.when(musicFolderService.getAllMusicFolders()).thenReturn(musicFolders);
         Mockito.when(musicFolderService.getMusicFoldersForUser(User.USERNAME_GUEST)).thenReturn(musicFolders);
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DownloadControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DownloadControllerTest.java
@@ -22,10 +22,8 @@ package com.tesshu.jpsonic.controller;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -72,9 +70,7 @@ class DownloadControllerTest extends AbstractNeedsScan {
     @Override
     public List<MusicFolder> getMusicFolders() {
         if (isEmpty(musicFolders)) {
-            musicFolders = new ArrayList<>();
-            File musicDir = new File(resolveBaseMediaPath("Music"));
-            musicFolders.add(new MusicFolder(1, musicDir, "Music", true, new Date()));
+            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, new Date()));
         }
         return musicFolders;
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/EditTagsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/EditTagsControllerTest.java
@@ -21,8 +21,7 @@ package com.tesshu.jpsonic.controller;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.File;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -46,13 +45,8 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 @SpringBootTest
 class EditTagsControllerTest extends AbstractNeedsScan {
 
-    private static final List<MusicFolder> MUSIC_FOLDERS;
-
-    static {
-        MUSIC_FOLDERS = new ArrayList<>();
-        File musicDir = new File(resolveBaseMediaPath("Music"));
-        MUSIC_FOLDERS.add(new MusicFolder(1, musicDir, "Music", true, new Date()));
-    }
+    private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, new Date()));
 
     private MockMvc mockMvc;
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/ExternalPlayerControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/ExternalPlayerControllerTest.java
@@ -22,7 +22,6 @@ package com.tesshu.jpsonic.controller;
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.File;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -86,7 +85,7 @@ class ExternalPlayerControllerTest {
         mediaFile.setPathString(path.toString());
         List<MediaFile> mediaFiles = Arrays.asList(mediaFile);
 
-        MusicFolder folder = new MusicFolder(0, new File(""), "", true, expires);
+        MusicFolder folder = new MusicFolder(0, "", "", true, expires);
         List<MusicFolder> folders = Arrays.asList(folder);
         Mockito.when(musicFolderService.getMusicFoldersForUser(Mockito.anyString())).thenReturn(folders);
         Mockito.when(shareService.getSharedFiles(shareId, folders)).thenReturn(mediaFiles);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/HomeControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/HomeControllerTest.java
@@ -27,7 +27,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -212,7 +211,7 @@ class HomeControllerTest {
             MockHttpServletRequest req = mock(MockHttpServletRequest.class);
             Mockito.when(req.getParameter(Attributes.Request.LIST_TYPE.value()))
                     .thenReturn(AlbumListType.INDEX.getId());
-            List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, new File(""), "name", false, new Date()));
+            List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, "", "name", false, new Date()));
             Mockito.when(musicFolderService.getMusicFoldersForUser(anyString(), Mockito.nullable(Integer.class)))
                     .thenReturn(musicFolders);
             Mockito.when(musicIndexService.getMusicFolderContent(musicFolders, false))

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/HomeControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/HomeControllerTest.java
@@ -27,6 +27,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -211,7 +212,7 @@ class HomeControllerTest {
             MockHttpServletRequest req = mock(MockHttpServletRequest.class);
             Mockito.when(req.getParameter(Attributes.Request.LIST_TYPE.value()))
                     .thenReturn(AlbumListType.INDEX.getId());
-            List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, null, "name", false, new Date()));
+            List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, new File(""), "name", false, new Date()));
             Mockito.when(musicFolderService.getMusicFoldersForUser(anyString(), Mockito.nullable(Integer.class)))
                     .thenReturn(musicFolders);
             Mockito.when(musicIndexService.getMusicFolderContent(musicFolders, false))

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/InternalHelpControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/InternalHelpControllerTest.java
@@ -69,7 +69,7 @@ class InternalHelpControllerTest {
         void testSetFromPath() throws URISyntaxException {
             Path path = Path.of(InternalHelpControllerTest.class.getResource("/MEDIAS/Music").toURI());
             FileStatistics fileStatistics = new FileStatistics();
-            fileStatistics.setFromFile(path.toFile());
+            fileStatistics.setFromPath(path);
             assertEquals("Music", fileStatistics.getName());
             assertNotNull(fileStatistics.getFreeFilesystemSizeBytes());
             assertTrue(fileStatistics.isReadable());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/InternalHelpControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/InternalHelpControllerTest.java
@@ -21,10 +21,18 @@
 
 package com.tesshu.jpsonic.controller;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+
 import com.tesshu.jpsonic.NeedsHome;
+import com.tesshu.jpsonic.controller.InternalHelpController.FileStatistics;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,7 +45,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest
 @ExtendWith(NeedsHome.class)
 @AutoConfigureMockMvc
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert") // pmd/pmd/issues/1084
+@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert", "PMD.TooManyStaticImports" }) // pmd/pmd/issues/1084
 class InternalHelpControllerTest {
 
     @Autowired
@@ -53,5 +61,22 @@ class InternalHelpControllerTest {
     @WithMockUser(username = "user", roles = { "USER" })
     void testNotOkForUsers() throws Exception {
         mockMvc.perform(get("/internalhelp").contentType(MediaType.TEXT_HTML)).andExpect(status().isForbidden());
+    }
+
+    @Nested
+    class FileStatisticsTest {
+        @Test
+        void testSetFromPath() throws URISyntaxException {
+            Path path = Path.of(InternalHelpControllerTest.class.getResource("/MEDIAS/Music").toURI());
+            FileStatistics fileStatistics = new FileStatistics();
+            fileStatistics.setFromFile(path.toFile());
+            assertEquals("Music", fileStatistics.getName());
+            assertNotNull(fileStatistics.getFreeFilesystemSizeBytes());
+            assertTrue(fileStatistics.isReadable());
+            assertTrue(fileStatistics.isWritable());
+            assertTrue(fileStatistics.isExecutable());
+            assertNotNull(fileStatistics.getTotalFilesystemSizeBytes());
+            assertEquals(path.toString(), fileStatistics.getPath());
+        }
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MoreControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MoreControllerTest.java
@@ -63,8 +63,9 @@ class MoreControllerTest {
                 .build();
         Mockito.when(searchService.getGenres(false)).thenReturn(Collections.emptyList());
         Mockito.when(playerService.getPlayer(Mockito.any(), Mockito.any())).thenReturn(new Player());
-        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
-                Path.of(MoreControllerTest.class.getResource("/MEDIAS").toURI()).toFile(), "MEDIAS", true, new Date()));
+        List<MusicFolder> musicFolders = Arrays
+                .asList(new MusicFolder(1, Path.of(MoreControllerTest.class.getResource("/MEDIAS").toURI()).toString(),
+                        "MEDIAS", true, new Date()));
         Mockito.when(musicFolderService.getMusicFoldersForUser(ServiceMockUtils.ADMIN_NAME)).thenReturn(musicFolders);
     }
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MoreControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MoreControllerTest.java
@@ -23,9 +23,15 @@ import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.domain.Player;
 import com.tesshu.jpsonic.service.MusicFolderService;
 import com.tesshu.jpsonic.service.PlayerService;
@@ -48,13 +54,18 @@ class MoreControllerTest {
     private MockMvc mockMvc;
 
     @BeforeEach
-    public void setup() throws ExecutionException {
+    public void setup() throws ExecutionException, URISyntaxException {
+        MusicFolderService musicFolderService = mock(MusicFolderService.class);
         SearchService searchService = mock(SearchService.class);
         PlayerService playerService = mock(PlayerService.class);
-        mockMvc = MockMvcBuilders.standaloneSetup(new MoreController(mock(MusicFolderService.class),
-                mock(SecurityService.class), playerService, searchService)).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(
+                new MoreController(musicFolderService, mock(SecurityService.class), playerService, searchService))
+                .build();
         Mockito.when(searchService.getGenres(false)).thenReturn(Collections.emptyList());
         Mockito.when(playerService.getPlayer(Mockito.any(), Mockito.any())).thenReturn(new Player());
+        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
+                Path.of(MoreControllerTest.class.getResource("/MEDIAS").toURI()).toFile(), "MEDIAS", true, new Date()));
+        Mockito.when(musicFolderService.getMusicFoldersForUser(ServiceMockUtils.ADMIN_NAME)).thenReturn(musicFolders);
     }
 
     @Test

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MusicFolderSettingsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MusicFolderSettingsControllerTest.java
@@ -24,12 +24,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 
+import com.tesshu.jpsonic.MusicFolderTestDataUtils;
 import com.tesshu.jpsonic.command.MusicFolderSettingsCommand;
 import com.tesshu.jpsonic.command.MusicFolderSettingsCommand.MusicFolderInfo;
 import com.tesshu.jpsonic.domain.FileModifiedCheckScheme;
@@ -174,8 +174,8 @@ class MusicFolderSettingsControllerTest {
                 .get(Attributes.Model.Command.VALUE);
         assertNotNull(command);
 
-        File dir = new File(MusicFolderSettingsControllerTest.class.getResource("/MEDIAS/Music").toURI());
-        MusicFolder musicFolder = new MusicFolder(dir, "Music", true, new Date());
+        MusicFolder musicFolder = new MusicFolder(MusicFolderTestDataUtils.resolveMusicFolderPath(), "Music", true,
+                new Date());
         MusicFolderInfo musicFolderInfo = new MusicFolderInfo(musicFolder);
         command.setNewMusicFolder(musicFolderInfo);
 
@@ -201,23 +201,22 @@ class MusicFolderSettingsControllerTest {
                 .get(Attributes.Model.Command.VALUE);
         assertNotNull(command);
 
-        File dir = new File(MusicFolderSettingsControllerTest.class.getResource("/MEDIAS/Music").toURI());
-        MusicFolder musicFolder1 = new MusicFolder(99, dir, "Music", true, new Date());
+        MusicFolder musicFolder1 = new MusicFolder(99, MusicFolderTestDataUtils.resolveMusicFolderPath(), "Music", true,
+                new Date());
         MusicFolderInfo musicFolderInfo1 = new MusicFolderInfo(musicFolder1);
         musicFolderInfo1.setDelete(true);
-        File dir2 = new File(MusicFolderSettingsControllerTest.class.getResource("/MEDIAS/Music2").toURI());
-        MusicFolder musicFolder2 = new MusicFolder(dir2, null, true, new Date());
+        MusicFolder musicFolder2 = new MusicFolder(MusicFolderTestDataUtils.resolveMusic2FolderPath(), null, true,
+                new Date());
         MusicFolderInfo musicFolderInfo2 = new MusicFolderInfo(musicFolder2);
         command.setMusicFolders(Arrays.asList(musicFolderInfo1, musicFolderInfo2));
 
         // Case where the registered path is deleted on the web page
-        File dir3 = new File(MusicFolderSettingsControllerTest.class.getResource("/MEDIAS/Music3").toURI());
-        MusicFolder musicFolder3 = new MusicFolder(dir3, null, true, new Date());
+        MusicFolder musicFolder3 = new MusicFolder(MusicFolderTestDataUtils.resolveMusic3FolderPath(), null, true,
+                new Date());
         MusicFolderInfo musicFolderInfo3 = new MusicFolderInfo(musicFolder3);
         musicFolderInfo3.setPath(null);
         // Cases that do not (already) exist. Update will be executed but will be ignored in Dao.
-        File dir4 = new File("/Unknown");
-        MusicFolder musicFolder4 = new MusicFolder(dir4, null, true, new Date());
+        MusicFolder musicFolder4 = new MusicFolder("/Unknown", null, true, new Date());
         MusicFolderInfo musicFolderInfo4 = new MusicFolderInfo(musicFolder4);
 
         command.setMusicFolders(Arrays.asList(musicFolderInfo1, musicFolderInfo2, musicFolderInfo3, musicFolderInfo4));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/StatusControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/StatusControllerTest.java
@@ -71,7 +71,7 @@ class StatusControllerTest {
         Path path = Path.of(StatusControllerTest.class.getResource(
                 "/MEDIAS/Music/_DIR_ Céline Frisch- Café Zimmermann - Bach- Goldberg Variations, Canons [Disc 1]/01 - Bach- Goldberg Variations, BWV 988 - Aria.flac")
                 .toURI());
-        status.setFile(path.toFile());
+        status.setPathString(path.toString());
         TransferStatusHolder holder = new TransferStatusHolder(status, false, false, false, 0, null);
         assertEquals(FileUtil.getShortPath(path), holder.getPath());
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/SubsonicRESTControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/SubsonicRESTControllerTest.java
@@ -1235,8 +1235,9 @@ class SubsonicRESTControllerTest {
 
                 statusService.getAllStreamStatuses().stream().filter(t -> player.getId() == t.getPlayer().getId())
                         .findFirst().ifPresentOrElse((status) -> {
-                            assertNotNull(status.getFile());
-                            assertEquals(song.toPath(), status.getFile().toPath());
+                            assertNotNull(status.getPathString());
+                            assertNotNull(status.toPath());
+                            assertEquals(song.toPath(), status.toPath());
                         }, () -> Assertions.fail());
 
                 res = new MockHttpServletResponse();
@@ -1255,8 +1256,9 @@ class SubsonicRESTControllerTest {
 
                 statusService.getAllStreamStatuses().stream().filter(t -> player.getId() == t.getPlayer().getId())
                         .findFirst().ifPresentOrElse((status) -> {
-                            assertNotNull(status.getFile());
-                            assertEquals(song.toPath(), status.getFile().toPath());
+                            assertNotNull(status.getPathString());
+                            assertNotNull(status.toPath());
+                            assertEquals(song.toPath(), status.toPath());
                         }, () -> Assertions.fail());
 
                 res.getOutputStream().close();
@@ -1292,8 +1294,9 @@ class SubsonicRESTControllerTest {
 
                 statusService.getAllStreamStatuses().stream().filter(t -> player.getId() == t.getPlayer().getId())
                         .findFirst().ifPresentOrElse((status) -> {
-                            assertNotNull(status.getFile());
-                            assertEquals(song.toPath(), status.getFile().toPath());
+                            assertNotNull(status.getPathString());
+                            assertNotNull(status.toPath());
+                            assertEquals(song.toPath(), status.toPath());
                         }, () -> Assertions.fail());
 
                 res = new MockHttpServletResponse();
@@ -1314,8 +1317,9 @@ class SubsonicRESTControllerTest {
 
                 statusService.getAllStreamStatuses().stream().filter(t -> player.getId() == t.getPlayer().getId())
                         .findFirst().ifPresentOrElse((status) -> {
-                            assertNotNull(status.getFile());
-                            assertEquals(song.toPath(), status.getFile().toPath());
+                            assertNotNull(status.getPathString());
+                            assertNotNull(status.toPath());
+                            assertEquals(song.toPath(), status.toPath());
                         }, () -> Assertions.fail());
 
                 res.getOutputStream().close();

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/SubsonicRESTControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/SubsonicRESTControllerTest.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Arrays;
@@ -239,7 +238,7 @@ class SubsonicRESTControllerTest {
     class IntegreationTest extends AbstractNeedsScan {
 
         private final List<MusicFolder> musicFolders = Arrays
-                .asList(new MusicFolder(1, new File(resolveBaseMediaPath("Music")), "Music", true, new Date()));
+                .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, new Date()));
 
         @Autowired
         private MockMvc mvc;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/TopControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/TopControllerTest.java
@@ -235,7 +235,7 @@ class TopControllerTest {
         @Test
         void testWithoutSelectedMusicFolders() throws ServletRequestBindingException, URISyntaxException {
             List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
-                    Path.of(TopControllerTest.class.getResource("/MEDIAS/Sort/Pagination/Artists").toURI()).toFile(),
+                    Path.of(TopControllerTest.class.getResource("/MEDIAS/Sort/Pagination/Artists").toURI()).toString(),
                     "MEDIAS", true, new Date()));
             Mockito.when(musicFolderService.getMusicFoldersForUser(Mockito.anyString())).thenReturn(musicFolders);
 
@@ -247,7 +247,7 @@ class TopControllerTest {
         @Test
         void testWithSelectedMusicFolders() throws ServletRequestBindingException, URISyntaxException {
             List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
-                    Path.of(TopControllerTest.class.getResource("/MEDIAS/Sort/Pagination/Artists").toURI()).toFile(),
+                    Path.of(TopControllerTest.class.getResource("/MEDIAS/Sort/Pagination/Artists").toURI()).toString(),
                     "MEDIAS", true, new Date()));
             Mockito.when(musicFolderService.getMusicFoldersForUser(Mockito.anyString())).thenReturn(musicFolders);
             Mockito.when(securityService.getSelectedMusicFolder(Mockito.anyString())).thenReturn(musicFolders.get(0));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/UploadControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/UploadControllerTest.java
@@ -74,7 +74,7 @@ class UploadControllerTest {
     // @Test Currently it is not possible to run two tests in a row
     void testHandleRequestInternalWithFile(@TempDir Path tempDirPath) throws Exception {
 
-        MusicFolder musicFolder = new MusicFolder(Integer.valueOf(0), tempDirPath.toFile(), "Incoming1", true,
+        MusicFolder musicFolder = new MusicFolder(Integer.valueOf(0), tempDirPath.toString(), "Incoming1", true,
                 new Date());
         musicFolderDao.createMusicFolder(musicFolder);
 
@@ -103,7 +103,7 @@ class UploadControllerTest {
     @WithMockUser(username = "admin")
     void testHandleRequestInternalWithZip(@TempDir Path tempDirPath) throws Exception {
 
-        MusicFolder musicFolder = new MusicFolder(Integer.valueOf(1), tempDirPath.toFile(), "Incoming2", true,
+        MusicFolder musicFolder = new MusicFolder(Integer.valueOf(1), tempDirPath.toString(), "Incoming2", true,
                 new Date());
         musicFolderDao.createMusicFolder(musicFolder);
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/UploadEntryControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/UploadEntryControllerTest.java
@@ -23,14 +23,21 @@ import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
+import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.service.MusicFolderService;
 import com.tesshu.jpsonic.service.SecurityService;
 import com.tesshu.jpsonic.service.ServiceMockUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -44,10 +51,14 @@ class UploadEntryControllerTest {
     private MockMvc mockMvc;
 
     @BeforeEach
-    public void setup() throws ExecutionException {
+    public void setup() throws ExecutionException, URISyntaxException {
+        List<MusicFolder> musicFolders = Arrays.asList(
+                new MusicFolder(1, Path.of(UploadEntryControllerTest.class.getResource("/MEDIAS").toURI()).toFile(),
+                        "MEDIAS", true, new Date()));
+        MusicFolderService musicFolderService = mock(MusicFolderService.class);
+        Mockito.when(musicFolderService.getMusicFoldersForUser(ServiceMockUtils.ADMIN_NAME)).thenReturn(musicFolders);
         mockMvc = MockMvcBuilders
-                .standaloneSetup(new UploadEntryController(mock(MusicFolderService.class), mock(SecurityService.class)))
-                .build();
+                .standaloneSetup(new UploadEntryController(musicFolderService, mock(SecurityService.class))).build();
     }
 
     @Test

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/UploadEntryControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/UploadEntryControllerTest.java
@@ -53,7 +53,7 @@ class UploadEntryControllerTest {
     @BeforeEach
     public void setup() throws ExecutionException, URISyntaxException {
         List<MusicFolder> musicFolders = Arrays.asList(
-                new MusicFolder(1, Path.of(UploadEntryControllerTest.class.getResource("/MEDIAS").toURI()).toFile(),
+                new MusicFolder(1, Path.of(UploadEntryControllerTest.class.getResource("/MEDIAS").toURI()).toString(),
                         "MEDIAS", true, new Date()));
         MusicFolderService musicFolderService = mock(MusicFolderService.class);
         Mockito.when(musicFolderService.getMusicFoldersForUser(ServiceMockUtils.ADMIN_NAME)).thenReturn(musicFolders);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/JAlbumDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/JAlbumDaoTest.java
@@ -21,8 +21,7 @@ package com.tesshu.jpsonic.dao;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -37,13 +36,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 class JAlbumDaoTest extends AbstractNeedsScan {
 
-    private static final List<MusicFolder> MUSIC_FOLDERS;
-
-    static {
-        MUSIC_FOLDERS = new ArrayList<>();
-        File musicDir = new File(resolveBaseMediaPath("Sort/Compare"));
-        MUSIC_FOLDERS.add(new MusicFolder(1, musicDir, "Albums", true, new Date()));
-    }
+    private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Compare"), "Albums", true, new Date()));
 
     @Autowired
     private AlbumDao albumDao;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/JArtistDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/JArtistDaoTest.java
@@ -21,8 +21,6 @@ package com.tesshu.jpsonic.dao;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -38,13 +36,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 class JArtistDaoTest extends AbstractNeedsScan {
 
-    private static final List<MusicFolder> MUSIC_FOLDERS;
-
-    static {
-        MUSIC_FOLDERS = new ArrayList<>();
-        File musicDir = new File(resolveBaseMediaPath("Sort/Compare"));
-        MUSIC_FOLDERS.add(new MusicFolder(1, musicDir, "Artists", true, new Date()));
-    }
+    private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Compare"), "Artists", true, new Date()));
 
     @Autowired
     private JArtistDao artistDao;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/JMediaFileDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/JMediaFileDaoTest.java
@@ -23,9 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import java.io.File;
 import java.lang.annotation.Documented;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -47,13 +46,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 class JMediaFileDaoTest extends AbstractNeedsScan {
 
-    private static final List<MusicFolder> MUSIC_FOLDERS;
-
-    static {
-        MUSIC_FOLDERS = new ArrayList<>();
-        File musicDir = new File(resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Merge"));
-        MUSIC_FOLDERS.add(new MusicFolder(1, musicDir, "Duplicate", true, new Date()));
-    }
+    private static final List<MusicFolder> MUSIC_FOLDERS = Arrays.asList(
+            new MusicFolder(1, resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Merge"), "Duplicate", true, new Date()));
 
     @Autowired
     private JMediaFileDao mediaFileDao;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MediaFileDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MediaFileDaoTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -142,7 +143,7 @@ class MediaFileDaoTest {
             assertFalse(op.isPresent());
 
             List<com.tesshu.jpsonic.domain.MusicFolder> folders = new ArrayList<>();
-            folders.add(new com.tesshu.jpsonic.domain.MusicFolder(null, "", false, null));
+            folders.add(new com.tesshu.jpsonic.domain.MusicFolder(new File(""), "", false, null));
             criteria = new RandomSearchCriteria(0, null, null, null, folders, null, null, null, null, null, null, false,
                     false, null);
             builder = new RandomSongsQueryBuilder(criteria);
@@ -471,7 +472,7 @@ class MediaFileDaoTest {
 
             // folder
             List<com.tesshu.jpsonic.domain.MusicFolder> folders = new ArrayList<>();
-            folders.add(new com.tesshu.jpsonic.domain.MusicFolder(null, "", false, null));
+            folders.add(new com.tesshu.jpsonic.domain.MusicFolder(new File(""), "", false, null));
             criteria = new RandomSearchCriteria(0, null, null, null, folders, null, null, null, null, null, null, false,
                     false, null);
             builder = new RandomSongsQueryBuilder(criteria);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MediaFileDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MediaFileDaoTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -143,7 +142,7 @@ class MediaFileDaoTest {
             assertFalse(op.isPresent());
 
             List<com.tesshu.jpsonic.domain.MusicFolder> folders = new ArrayList<>();
-            folders.add(new com.tesshu.jpsonic.domain.MusicFolder(new File(""), "", false, null));
+            folders.add(new com.tesshu.jpsonic.domain.MusicFolder("/", "", false, null));
             criteria = new RandomSearchCriteria(0, null, null, null, folders, null, null, null, null, null, null, false,
                     false, null);
             builder = new RandomSongsQueryBuilder(criteria);
@@ -472,7 +471,7 @@ class MediaFileDaoTest {
 
             // folder
             List<com.tesshu.jpsonic.domain.MusicFolder> folders = new ArrayList<>();
-            folders.add(new com.tesshu.jpsonic.domain.MusicFolder(new File(""), "", false, null));
+            folders.add(new com.tesshu.jpsonic.domain.MusicFolder("/", "", false, null));
             criteria = new RandomSearchCriteria(0, null, null, null, folders, null, null, null, null, null, null, false,
                     false, null);
             builder = new RandomSongsQueryBuilder(criteria);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MusicFolderDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MusicFolderDaoTest.java
@@ -23,7 +23,6 @@ package com.tesshu.jpsonic.dao;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
 import java.util.Date;
 
 import com.tesshu.jpsonic.NeedsHome;
@@ -57,7 +56,7 @@ class MusicFolderDaoTest {
 
     @Test
     void testCreateMusicFolder() {
-        MusicFolder musicFolder = new MusicFolder(new File("path"), "name", true, new Date());
+        MusicFolder musicFolder = new MusicFolder("path", "name", true, new Date());
         musicFolderDao.createMusicFolder(musicFolder);
 
         MusicFolder newMusicFolder = musicFolderDao.getAllMusicFolders().get(0);
@@ -66,11 +65,10 @@ class MusicFolderDaoTest {
 
     @Test
     void testUpdateMusicFolder() {
-        MusicFolder musicFolder = new MusicFolder(new File("path"), "name", true, new Date());
+        MusicFolder musicFolder = new MusicFolder("path", "name", true, new Date());
         musicFolderDao.createMusicFolder(musicFolder);
         musicFolder = musicFolderDao.getAllMusicFolders().get(0);
 
-        musicFolder.setFolderPath(new File("newPath"));
         musicFolder.setName("newName");
         musicFolder.setEnabled(false);
         musicFolder.setChanged(new Date(234_234L));
@@ -84,10 +82,10 @@ class MusicFolderDaoTest {
     void testDeleteMusicFolder() {
         assertEquals(0, musicFolderDao.getAllMusicFolders().size(), "Wrong number of music folders.");
 
-        musicFolderDao.createMusicFolder(new MusicFolder(new File("path"), "name", true, new Date()));
+        musicFolderDao.createMusicFolder(new MusicFolder("path", "name", true, new Date()));
         assertEquals(1, musicFolderDao.getAllMusicFolders().size(), "Wrong number of music folders.");
 
-        musicFolderDao.createMusicFolder(new MusicFolder(new File("path"), "name", true, new Date()));
+        musicFolderDao.createMusicFolder(new MusicFolder("path", "name", true, new Date()));
         assertEquals(2, musicFolderDao.getAllMusicFolders().size(), "Wrong number of music folders.");
 
         musicFolderDao.deleteMusicFolder(musicFolderDao.getAllMusicFolders().get(0).getId());
@@ -99,7 +97,7 @@ class MusicFolderDaoTest {
 
     private void assertMusicFolderEquals(MusicFolder expected, MusicFolder actual) {
         assertEquals(expected.getName(), actual.getName(), "Wrong name.");
-        assertEquals(expected.getPath(), actual.getPath(), "Wrong path.");
+        assertEquals(expected.toPath(), actual.toPath(), "Wrong path.");
         assertEquals(expected.isEnabled(), actual.isEnabled(), "Wrong enabled state.");
         assertEquals(expected.getChanged(), actual.getChanged(), "Wrong changed date.");
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MusicFolderDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MusicFolderDaoTest.java
@@ -70,7 +70,7 @@ class MusicFolderDaoTest {
         musicFolderDao.createMusicFolder(musicFolder);
         musicFolder = musicFolderDao.getAllMusicFolders().get(0);
 
-        musicFolder.setPath(new File("newPath"));
+        musicFolder.setFolderPath(new File("newPath"));
         musicFolder.setName("newName");
         musicFolder.setEnabled(false);
         musicFolder.setChanged(new Date(234_234L));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MusicFolderTestDataUtils.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MusicFolderTestDataUtils.java
@@ -21,6 +21,11 @@
 
 package com.tesshu.jpsonic.dao;
 
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+
+import com.google.common.util.concurrent.UncheckedExecutionException;
+
 public final class MusicFolderTestDataUtils {
 
     private static final String BASE_RESOURCES = "/MEDIAS/";
@@ -29,7 +34,11 @@ public final class MusicFolderTestDataUtils {
     }
 
     private static String resolveBaseMediaPath() {
-        return MusicFolderTestDataUtils.class.getResource(BASE_RESOURCES).toString().replace("file:", "");
+        try {
+            return Path.of(MusicFolderTestDataUtils.class.getResource(BASE_RESOURCES).toURI()).toString();
+        } catch (URISyntaxException e) {
+            throw new UncheckedExecutionException(e);
+        }
     }
 
     public static String resolveMusicFolderPath() {

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JpsonicComparatorsTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JpsonicComparatorsTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Documented;
 import java.util.ArrayList;
@@ -71,13 +70,8 @@ class JpsonicComparatorsTest extends AbstractNeedsScan {
 
     protected static final Logger LOG = LoggerFactory.getLogger(JpsonicComparatorsTest.class);
 
-    protected static final List<MusicFolder> MUSIC_FOLDERS;
-
-    static {
-        MUSIC_FOLDERS = new ArrayList<>();
-        File musicDir = new File(resolveBaseMediaPath("Sort/Compare"));
-        MUSIC_FOLDERS.add(new MusicFolder(1, musicDir, "test date for sorting", true, new Date()));
-    }
+    protected static final List<MusicFolder> MUSIC_FOLDERS = Arrays.asList(
+            new MusicFolder(1, resolveBaseMediaPath("Sort/Compare"), "test date for sorting", true, new Date()));
 
     protected static final List<String> INDEX_LIST = Collections.unmodifiableList(Arrays.asList("abcde", "abcいうえおあ", // Turn
                                                                                                                      // over

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceTest.java
@@ -156,10 +156,6 @@ class MediaScannerServiceTest {
         @Nested
         class ScanFileTest {
 
-            private File createFile(String path) throws URISyntaxException {
-                return new File(MediaFileServiceTest.class.getResource(path).toURI());
-            }
-
             private Path createPath(String path) throws URISyntaxException {
                 return Path.of(MediaFileServiceTest.class.getResource(path).toURI());
             }
@@ -192,7 +188,8 @@ class MediaScannerServiceTest {
                 MediaFile child = mediaFileService.createMediaFile(file);
                 child.setLastScanned(MediaFileDao.ZERO_DATE);
 
-                MusicFolder musicFolder = new MusicFolder(createFile("/MEDIAS/Music2"), "name", false, new Date());
+                MusicFolder musicFolder = new MusicFolder(
+                        MusicFolderTestDataUtils.resolveBaseMediaPath().concat("Music2"), "name", false, new Date());
                 Date scanStart = DateUtils.truncate(new Date(), Calendar.SECOND);
                 MediaLibraryStatistics statistics = new MediaLibraryStatistics(scanStart);
                 Map<String, Integer> albumCount = new ConcurrentHashMap<>();
@@ -226,7 +223,7 @@ class MediaScannerServiceTest {
             }
 
             private MusicFolder createMusicFolder() {
-                return new MusicFolder(Integer.valueOf(1), new File(""), "", true, new Date());
+                return new MusicFolder(Integer.valueOf(1), "", "", true, new Date());
             }
 
             @Test
@@ -468,7 +465,7 @@ class MediaScannerServiceTest {
             }
 
             private MusicFolder createMusicFolder() {
-                return new MusicFolder(Integer.valueOf(1), new File(""), "", true, new Date());
+                return new MusicFolder(Integer.valueOf(1), "", "", true, new Date());
             }
 
             @Test
@@ -548,13 +545,11 @@ class MediaScannerServiceTest {
         @Override
         public List<MusicFolder> getMusicFolders() {
             if (ObjectUtils.isEmpty(musicFolders)) {
-                musicFolders = new ArrayList<>();
-                File musicDir1 = new File(resolveBaseMediaPath("Scan/Id3LIFO"));
-                musicFolders.add(new MusicFolder(1, musicDir1, "alphaBeticalProps", true, new Date()));
-                File musicDir2 = new File(resolveBaseMediaPath("Scan/Null"));
-                musicFolders.add(new MusicFolder(2, musicDir2, "noTagFirstChild", true, new Date()));
-                File musicDir3 = new File(resolveBaseMediaPath("Scan/Reverse"));
-                musicFolders.add(new MusicFolder(3, musicDir3, "fileAndPropsNameInReverse", true, new Date()));
+                musicFolders = Arrays.asList(
+                        new MusicFolder(1, resolveBaseMediaPath("Scan/Id3LIFO"), "alphaBeticalProps", true, new Date()),
+                        new MusicFolder(2, resolveBaseMediaPath("Scan/Null"), "noTagFirstChild", true, new Date()),
+                        new MusicFolder(3, resolveBaseMediaPath("Scan/Reverse"), "fileAndPropsNameInReverse", true,
+                                new Date()));
             }
             return musicFolders;
         }
@@ -781,9 +776,9 @@ class MediaScannerServiceTest {
     class GetChildrenOfTest extends AbstractNeedsScan {
 
         private List<MusicFolder> musicFolders;
-        private File artist;
-        private File album;
-        private File song;
+        private Path artist;
+        private Path album;
+        private Path song;
 
         @Autowired
         private MediaFileDao mediaFileDao;
@@ -801,22 +796,21 @@ class MediaScannerServiceTest {
         }
 
         @BeforeEach
-        public void setup(@TempDir File tempDir) throws IOException, URISyntaxException {
+        public void setup(@TempDir Path tempDir) throws IOException, URISyntaxException {
 
             // Create a musicfolder for verification
-            File musicFolder = new File(tempDir.getPath());
-            artist = new File(musicFolder, "ARTIST");
-            assertTrue(artist.mkdirs());
-            this.album = new File(artist, "ALBUM");
-            assertTrue(album.mkdirs());
-            this.musicFolders = Arrays.asList(new MusicFolder(1, musicFolder, "musicFolder", true, new Date()));
+            artist = Path.of(tempDir.toString(), "ARTIST");
+            assertNotNull(Files.createDirectory(artist));
+            this.album = Path.of(artist.toString(), "ALBUM");
+            assertNotNull(Files.createDirectory(album));
+            this.musicFolders = Arrays.asList(new MusicFolder(1, tempDir.toString(), "musicFolder", true, new Date()));
 
             // Copy the song file from the test resource. No tags are registered in this file.
-            File sample = new File(MediaScannerServiceTest.class
+            Path sample = Path.of(MediaScannerServiceTest.class
                     .getResource("/MEDIAS/Scan/Timestamp/ARTIST/ALBUM/sample.mp3").toURI());
-            this.song = new File(this.album, "sample.mp3");
-            Files.copy(sample.toPath(), song.toPath());
-            assertTrue(song.exists());
+            this.song = Path.of(this.album.toString(), "sample.mp3");
+            assertNotNull(Files.copy(sample, song));
+            assertTrue(Files.exists(song));
 
             // Exec scan
             populateDatabase();
@@ -825,34 +819,34 @@ class MediaScannerServiceTest {
         @Test
         void testSpecialCharactersInDirName() throws URISyntaxException, IOException, InterruptedException {
 
-            MediaFile artist = mediaFileDao.getMediaFile(this.artist.getPath());
-            assertEquals(this.artist.toPath(), artist.toPath());
+            MediaFile artist = mediaFileDao.getMediaFile(this.artist.toString());
+            assertEquals(this.artist, artist.toPath());
             assertEquals("ARTIST", artist.getName());
-            MediaFile album = mediaFileDao.getMediaFile(this.album.getPath());
-            assertEquals(this.album.toPath(), album.toPath());
+            MediaFile album = mediaFileDao.getMediaFile(this.album.toString());
+            assertEquals(this.album, album.toPath());
             assertEquals("ALBUM", album.getName());
-            MediaFile song = mediaFileDao.getMediaFile(this.song.getPath());
-            assertEquals(this.song.getPath(), song.getPathString());
+            MediaFile song = mediaFileDao.getMediaFile(this.song.toString());
+            assertEquals(this.song, song.toPath());
             assertEquals("ARTIST", song.getArtist());
             assertEquals("ALBUM", song.getAlbumName());
 
             // Copy the song file from the test resource. Tags are registered in this file.
-            assertTrue(this.song.delete());
-            File sampleEdited = new File(MediaScannerServiceTest.class
+            Files.delete(this.song);
+            Path sampleEdited = Path.of(MediaScannerServiceTest.class
                     .getResource("/MEDIAS/Scan/Timestamp/ARTIST/ALBUM/sampleEdited.mp3").toURI());
-            this.song = new File(this.album, "sample.mp3");
-            Files.copy(sampleEdited.toPath(), this.song.toPath());
+            this.song = Path.of(this.album.toString(), "sample.mp3");
+            Files.copy(sampleEdited, this.song);
             assertTrue(song.exists());
 
             /*
              * If you get it via Dao, you can get the record before had been copied. (It's a expected behavior)
              */
-            List<MediaFile> albums = mediaFileDao.getChildrenOf(this.artist.getPath());
+            List<MediaFile> albums = mediaFileDao.getChildrenOf(this.artist.toString());
             assertEquals(1, albums.size());
-            List<MediaFile> songs = mediaFileDao.getChildrenOf(this.album.getPath());
+            List<MediaFile> songs = mediaFileDao.getChildrenOf(this.album.toString());
             assertEquals(1, songs.size());
             song = songs.get(0);
-            assertEquals(this.song.getPath(), song.getPathString());
+            assertEquals(this.song, song.toPath());
             assertEquals("ARTIST", song.getArtist());
             assertEquals("ALBUM", song.getAlbumName());
 
@@ -871,16 +865,16 @@ class MediaScannerServiceTest {
              */
 
             // Artist and Album are not subject to the update process
-            artist = mediaFileDao.getMediaFile(this.artist.getPath());
-            assertEquals(this.artist.getPath(), artist.getPathString());
+            artist = mediaFileDao.getMediaFile(this.artist.toString());
+            assertEquals(this.artist, artist.toPath());
             assertEquals("ARTIST", artist.getName());
-            album = mediaFileDao.getMediaFile(this.album.getPath());
-            assertEquals(this.album.getPath(), album.getPathString());
+            album = mediaFileDao.getMediaFile(this.album.toString());
+            assertEquals(this.album, album.toPath());
             assertEquals("ALBUM", album.getName());
 
             // Only songs are updated
-            song = mediaFileDao.getMediaFile(this.song.getPath());
-            assertEquals(this.song.getPath(), song.getPathString());
+            song = mediaFileDao.getMediaFile(this.song.toString());
+            assertEquals(this.song, song.toPath());
             assertEquals("Edited artist!", song.getArtist());
             assertEquals("Edited album!", song.getAlbumName());
 
@@ -908,19 +902,19 @@ class MediaScannerServiceTest {
                 Thread.sleep(1000);
             }
 
-            artist = mediaFileDao.getMediaFile(this.artist.getPath());
-            assertEquals(this.artist.getPath(), artist.getPathString());
+            artist = mediaFileDao.getMediaFile(this.artist.toString());
+            assertEquals(this.artist, artist.toPath());
             assertNull(artist.getTitle());
             assertEquals("ARTIST", artist.getName());
             assertEquals("ARTIST", artist.getArtist());
-            album = mediaFileDao.getMediaFile(this.album.getPath());
-            assertEquals(this.album.getPath(), album.getPathString());
+            album = mediaFileDao.getMediaFile(this.album.toString());
+            assertEquals(this.album, album.toPath());
             assertNull(album.getTitle());
             assertEquals("ALBUM", album.getName());
             assertEquals("Edited album!", album.getAlbumName());
 
-            song = mediaFileDao.getMediaFile(this.song.getPath());
-            assertEquals(this.song.getPath(), song.getPathString());
+            song = mediaFileDao.getMediaFile(this.song.toString());
+            assertEquals(this.song, song.toPath());
             assertEquals("Edited song!", song.getTitle());
             assertEquals("Edited song!", song.getName());
             assertEquals("Edited artist!", song.getArtist());
@@ -1096,7 +1090,7 @@ class MediaScannerServiceTest {
                 IOUtils.copy(resource, Files.newOutputStream(musicPath));
             }
 
-            MusicFolder musicFolder = new MusicFolder(1, tempDirPath.toFile(), "Music", true, new Date());
+            MusicFolder musicFolder = new MusicFolder(1, tempDirPath.toString(), "Music", true, new Date());
             musicFolderDao.createMusicFolder(musicFolder);
             musicFolderService.clearMusicFolderCache();
             TestCaseUtils.execScan(mediaScannerService);
@@ -1114,8 +1108,8 @@ class MediaScannerServiceTest {
         void testMusicBrainzReleaseIdTag() {
 
             // Add the "Music3" folder to the database
-            File musicFolderFile = new File(MusicFolderTestDataUtils.resolveMusic3FolderPath());
-            MusicFolder musicFolder = new MusicFolder(1, musicFolderFile, "Music3", true, new Date());
+            Path musicFolderPath = Path.of(MusicFolderTestDataUtils.resolveMusic3FolderPath());
+            MusicFolder musicFolder = new MusicFolder(1, musicFolderPath.toString(), "Music3", true, new Date());
             musicFolderDao.createMusicFolder(musicFolder);
             musicFolderService.clearMusicFolderCache();
             TestCaseUtils.execScan(mediaScannerService);
@@ -1123,7 +1117,7 @@ class MediaScannerServiceTest {
             // Retrieve the "Music3" folder from the database to make
             // sure that we don't accidentally operate on other folders
             // from previous tests.
-            musicFolder = musicFolderDao.getMusicFolderForPath(musicFolder.getPath().getPath());
+            musicFolder = musicFolderDao.getMusicFolderForPath(musicFolder.getPathString());
             List<MusicFolder> folders = new ArrayList<>();
             folders.add(musicFolder);
 
@@ -1142,7 +1136,7 @@ class MediaScannerServiceTest {
             assertEquals("TestArtist", album.getArtist());
             assertEquals(1, album.getSongCount());
             assertEquals("0820752d-1043-4572-ab36-2df3b5cc15fa", album.getMusicBrainzReleaseId());
-            assertEquals(musicFolderFile.toPath().resolve("TestAlbum").toString(), album.getPath());
+            assertEquals(musicFolderPath.resolve("TestAlbum").toString(), album.getPath());
 
             // Test that the music file is correctly imported, along with its MusicBrainz release ID and recording ID
             List<MediaFile> albumFiles = mediaFileDao.getChildrenOf(allAlbums.get(0).getPath());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceUtilsTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceUtilsTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -63,9 +62,8 @@ class MediaScannerServiceUtilsTest {
     @Order(1)
     class CompensateSortOfArtistTest extends AbstractNeedsScan {
 
-        private final List<MusicFolder> musicFolders = Arrays
-                .asList(new MusicFolder(1, new File(resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Compensation")),
-                        "Duplicate", true, new Date()));
+        private final List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
+                resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Compensation"), "Duplicate", true, new Date()));
 
         @Autowired
         private JMediaFileDao mediaFileDao;
@@ -348,7 +346,7 @@ class MediaScannerServiceUtilsTest {
     class CopySortOfArtistTest extends AbstractNeedsScan {
 
         private final List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
-                new File(resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Copy")), "Duplicate", true, new Date()));
+                resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Copy"), "Duplicate", true, new Date()));
 
         @Autowired
         private JMediaFileDao mediaFileDao;
@@ -487,7 +485,7 @@ class MediaScannerServiceUtilsTest {
     class MergeSortOfArtistTest extends AbstractNeedsScan {
 
         private final List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
-                new File(resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Merge")), "Duplicate", true, new Date()));
+                resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Merge"), "Duplicate", true, new Date()));
 
         @Autowired
         private JMediaFileDao mediaFileDao;
@@ -1300,8 +1298,8 @@ class MediaScannerServiceUtilsTest {
     // Windows 10 Home and Ubuntu results are same
     class UpdateSortOfAlbumTest extends AbstractNeedsScan {
 
-        private final List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
-                new File(resolveBaseMediaPath("Sort/Cleansing/AlbumSort")), "Duplicate", true, new Date()));
+        private final List<MusicFolder> musicFolders = Arrays.asList(
+                new MusicFolder(1, resolveBaseMediaPath("Sort/Cleansing/AlbumSort"), "Duplicate", true, new Date()));
 
         @Autowired
         private JMediaFileDao mediaFileDao;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MusicIndexServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MusicIndexServiceTest.java
@@ -24,7 +24,6 @@ package com.tesshu.jpsonic.service;
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -95,7 +94,7 @@ class MusicIndexServiceTest {
         List<MediaFile> children = Arrays.asList(child1, child2);
         Mockito.when(mediaFileService.getChildrenOf(Mockito.any(MediaFile.class), Mockito.anyBoolean(),
                 Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean())).thenReturn(children);
-        MusicFolder folder = new MusicFolder(0, new File("path"), "name", true, new Date());
+        MusicFolder folder = new MusicFolder(0, "path", "name", true, new Date());
 
         SortedMap<MusicIndex, List<MusicIndex.SortableArtistWithMediaFiles>> indexedArtists = musicIndexService
                 .getIndexedArtists(Arrays.asList(folder), false);
@@ -183,7 +182,7 @@ class MusicIndexServiceTest {
                 .thenReturn(songs).thenThrow(new RuntimeException("Fail"));
         Mockito.when(mediaFileService.getMediaFile(Mockito.any(Path.class), Mockito.anyBoolean()))
                 .thenReturn(new MediaFile());
-        MusicFolder folder = new MusicFolder(0, new File("path"), "name", true, new Date());
+        MusicFolder folder = new MusicFolder(0, "path", "name", true, new Date());
 
         MusicFolderContent content = musicIndexService.getMusicFolderContent(Arrays.asList(folder), false);
         assertEquals(2, content.getIndexedArtists().size());
@@ -202,8 +201,8 @@ class MusicIndexServiceTest {
     @Test
     void testGetSingleSongs() throws URISyntaxException {
         Path path = Path.of(MusicIndexServiceTest.class.getResource("/MEDIAS").toURI());
-        MusicFolder musicFolder = new MusicFolder(path.toFile(), "musicFolder", false, null);
-        assertEquals(path, musicFolder.getPath().toPath());
+        MusicFolder musicFolder = new MusicFolder(path.toString(), "musicFolder", false, null);
+        assertEquals(path, musicFolder.toPath());
 
         final List<MusicFolder> musicFolders = Arrays.asList(musicFolder);
         MediaFile mediaFile = new MediaFile();
@@ -227,8 +226,9 @@ class MusicIndexServiceTest {
         song.setTitle("Files directly under the shortcut directory");
         song.setPathString("path");
         Mockito.when(mediaFileService.getMediaFile(Mockito.any(Path.class), Mockito.anyBoolean())).thenReturn(song);
-        File dummy = new File(MusicIndexServiceTest.class.getResource("/MEDIAS").toURI());
-        MusicFolder folder = new MusicFolder(dummy, "Music", true, new Date());
+        MusicFolder folder = new MusicFolder(
+                Path.of(MusicIndexServiceTest.class.getResource("/MEDIAS").toURI()).toString(), "Music", true,
+                new Date());
 
         List<MediaFile> shortcuts = musicIndexService.getShortcuts(Arrays.asList(folder));
         assertEquals(1, shortcuts.size());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MusicIndexServiceUtilsTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MusicIndexServiceUtilsTest.java
@@ -85,8 +85,8 @@ class MusicIndexServiceUtilsTest {
     @Test
     void testCreateSortableArtists() throws URISyntaxException {
         Path path = Path.of(MusicIndexServiceTest.class.getResource("/MEDIAS").toURI());
-        MusicFolder musicFolder = new MusicFolder(path.toFile(), "musicFolder", false, null);
-        assertEquals(path, musicFolder.getPath().toPath());
+        MusicFolder musicFolder = new MusicFolder(path.toString(), "musicFolder", false, null);
+        assertEquals(path, musicFolder.toPath());
 
         final List<MusicFolder> musicFolders = Arrays.asList(musicFolder);
         MediaFile mediaFile = new MediaFile();

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/RatingServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/RatingServiceTest.java
@@ -61,7 +61,7 @@ class RatingServiceTest {
         album.setPathString(albumPath.toString());
         Mockito.when(mediaFileService.getMediaFile(albumPath)).thenReturn(album);
 
-        MusicFolder musicFolder = new MusicFolder(0, Path.of("path").toFile(), "Music", true, new Date());
+        MusicFolder musicFolder = new MusicFolder(0, "path", "Music", true, new Date());
         List<MusicFolder> musicFolders = Arrays.asList(musicFolder);
         List<MediaFile> highestRatedAlbums = ratingService.getHighestRatedAlbums(0, 0, musicFolders);
         assertEquals(1, highestRatedAlbums.size());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/StreamServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/StreamServiceTest.java
@@ -368,7 +368,7 @@ class StreamServiceTest {
         song.setPathString("song");
 
         Mockito.when(mediaFileService.getMediaFile(song.getId())).thenReturn(song);
-        Mockito.when(mediaFileService.getMediaFile(song.toPath().toString())).thenReturn(song);
+        Mockito.when(mediaFileService.getMediaFile(song.getPathString())).thenReturn(song);
 
         MockHttpServletRequest request = new MockHttpServletRequest();
         assertNull(streamService.getSingleFile(request));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/MetaDataParserTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/MetaDataParserTest.java
@@ -28,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -136,8 +135,7 @@ class MetaDataParserTest {
         assertEquals("MusicFolder", parser.guessArtist(Path.of("/MusicFolder/artist/album")));
         assertEquals("artist", parser.guessArtist(Path.of("/MusicFolder/artist/album/song.mp3")));
 
-        List<MusicFolder> musicFolders = Arrays
-                .asList(new MusicFolder(new File("/MusicFolder"), "MusicFolder", true, null));
+        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder("/MusicFolder", "MusicFolder", true, null));
         Mockito.when(musicFolderService.getAllMusicFolders(false, true)).thenReturn(musicFolders);
         assertThrows(IllegalArgumentException.class, () -> parser.guessArtist(Path.of("/")));
         assertThrows(IllegalArgumentException.class, () -> parser.guessArtist(Path.of("/song.mp3")));
@@ -156,8 +154,7 @@ class MetaDataParserTest {
         assertEquals("artist", parser.guessAlbum(Path.of("/MusicFolder/artist/album"), "artist"));
         assertEquals("album", parser.guessAlbum(Path.of("/MusicFolder/artist/album/song.mp3"), "artist"));
 
-        List<MusicFolder> musicFolders = Arrays
-                .asList(new MusicFolder(new File("/MusicFolder"), "MusicFolder", true, null));
+        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder("/MusicFolder", "MusicFolder", true, null));
         Mockito.when(musicFolderService.getAllMusicFolders(false, true)).thenReturn(musicFolders);
         assertThrows(IllegalArgumentException.class, () -> parser.guessAlbum(Path.of("/"), "artist"));
         assertEquals("", parser.guessAlbum(Path.of("/song.mp3"), "artist"));
@@ -182,8 +179,7 @@ class MetaDataParserTest {
         assertFalse(parser.isRoot(Path.of("/MusicFolder/artist")));
         assertFalse(parser.isRoot(Path.of("/MusicFolder")));
         assertFalse(parser.isRoot(Path.of("/")));
-        List<MusicFolder> musicFolders = Arrays
-                .asList(new MusicFolder(new File("/MusicFolder"), "MusicFolder", true, null));
+        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder("/MusicFolder", "MusicFolder", true, null));
         Mockito.when(musicFolderService.getAllMusicFolders(false, true)).thenReturn(musicFolders);
         assertFalse(parser.isRoot(Path.of("/MusicFolder/artist")));
         assertTrue(parser.isRoot(Path.of("/MusicFolder")));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/DocumentFactoryTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/DocumentFactoryTest.java
@@ -26,7 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.io.File;
 import java.lang.annotation.Documented;
 import java.util.Date;
 
@@ -155,8 +154,8 @@ class DocumentFactoryTest {
         artist.setName("name");
         artist.setSort("sort");
         artist.setFolderId(10);
-        File musicDir = new File(MusicFolderTestDataUtils.resolveMusicFolderPath());
-        MusicFolder musicFolder = new MusicFolder(100, musicDir, "Music", true, new Date());
+        MusicFolder musicFolder = new MusicFolder(100, MusicFolderTestDataUtils.resolveMusicFolderPath(), "Music", true,
+                new Date());
         Document document = documentFactory.createArtistId3Document(artist, musicFolder);
         assertEquals(6, document.getFields().size(), "fields.size");
         assertEquals("1", document.get(FieldNamesConstants.ID));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -76,9 +76,7 @@ class IndexManagerTest extends AbstractNeedsScan {
     @Override
     public List<MusicFolder> getMusicFolders() {
         if (ObjectUtils.isEmpty(musicFolders)) {
-            musicFolders = new ArrayList<>();
-            File musicDir = new File(resolveBaseMediaPath("Music"));
-            musicFolders.add(new MusicFolder(1, musicDir, "Music", true, new Date()));
+            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, new Date()));
         }
         return musicFolders;
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/QueryFactoryTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/QueryFactoryTest.java
@@ -25,7 +25,6 @@ import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -62,10 +61,8 @@ class QueryFactoryTest {
     private static final int FID1 = 10;
     private static final int FID2 = 20;
 
-    private static final MusicFolder MUSIC_FOLDER1 = new MusicFolder(FID1, new File(PATH1), "music1", true,
-            new java.util.Date());
-    private static final MusicFolder MUSIC_FOLDER2 = new MusicFolder(FID2, new File(PATH2), "music2", true,
-            new java.util.Date());
+    private static final MusicFolder MUSIC_FOLDER1 = new MusicFolder(FID1, PATH1, "music1", true, new java.util.Date());
+    private static final MusicFolder MUSIC_FOLDER2 = new MusicFolder(FID2, PATH2, "music2", true, new java.util.Date());
 
     private static final List<MusicFolder> SINGLE_FOLDERS = Arrays.asList(MUSIC_FOLDER1);
     private static final List<MusicFolder> MULTI_FOLDERS = Arrays.asList(MUSIC_FOLDER1, MUSIC_FOLDER2);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/SearchServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/SearchServiceTest.java
@@ -24,9 +24,7 @@ package com.tesshu.jpsonic.service.search;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
-import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -593,9 +591,8 @@ class SearchServiceTest {
         @Override
         public List<MusicFolder> getMusicFolders() {
             if (isEmpty(musicFolders)) {
-                musicFolders = new ArrayList<>();
-                File musicDir = new File(resolveBaseMediaPath("Search/SpecialGenre"));
-                musicFolders.add(new MusicFolder(1, musicDir, "accessible", true, new Date()));
+                musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Search/SpecialGenre"),
+                        "accessible", true, new Date()));
             }
             return musicFolders;
         }
@@ -869,16 +866,13 @@ class SearchServiceTest {
         @Override
         public List<MusicFolder> getMusicFolders() {
             if (isEmpty(musicFolders)) {
-                musicFolders = new ArrayList<>();
-
-                File musicDir = new File(resolveBaseMediaPath("Search/SpecialPath/accessible"));
-                musicFolders.add(new MusicFolder(1, musicDir, "accessible", true, new Date()));
-
-                File music2Dir = new File(resolveBaseMediaPath("Search/SpecialPath/accessible's"));
-                musicFolders.add(new MusicFolder(2, music2Dir, "accessible's", true, new Date()));
-
-                File music3Dir = new File(resolveBaseMediaPath("Search/SpecialPath/accessible+s"));
-                musicFolders.add(new MusicFolder(3, music3Dir, "accessible+s", true, new Date()));
+                musicFolders = Arrays.asList(
+                        new MusicFolder(1, resolveBaseMediaPath("Search/SpecialPath/accessible"), "accessible", true,
+                                new Date()),
+                        new MusicFolder(2, resolveBaseMediaPath("Search/SpecialPath/accessible's"), "accessible's",
+                                true, new Date()),
+                        new MusicFolder(3, resolveBaseMediaPath("Search/SpecialPath/accessible+s"), "accessible+s",
+                                true, new Date()));
             }
             return musicFolders;
         }
@@ -937,9 +931,8 @@ class SearchServiceTest {
         @Override
         public List<MusicFolder> getMusicFolders() {
             if (isEmpty(musicFolders)) {
-                musicFolders = new ArrayList<>();
-                File musicDir = new File(resolveBaseMediaPath("Search/StartWithStopwards"));
-                musicFolders.add(new MusicFolder(1, musicDir, "accessible", true, new Date()));
+                musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Search/StartWithStopwards"),
+                        "accessible", true, new Date()));
             }
             return musicFolders;
         }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/UPnPSearchCriteriaDirectorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/UPnPSearchCriteriaDirectorTest.java
@@ -25,7 +25,6 @@ import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.io.File;
 import java.lang.annotation.Documented;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -245,13 +244,12 @@ public class UPnPSearchCriteriaDirectorTest {
         Mockito.when(settingsService.isSearchComposer()).thenReturn(true);
 
         List<MusicFolder> musicFolders = new ArrayList<>();
-        File musicDir = new File("dummy");
-        musicFolders.add(new MusicFolder(1, musicDir, "accessible", true, new Date()));
+        musicFolders.add(new MusicFolder(1, "dummy", "accessible", true, new Date()));
         musicFolderService = mock(MusicFolderService.class);
         Mockito.when(musicFolderService.getMusicFoldersForUser(User.USERNAME_GUEST)).thenReturn(musicFolders);
 
         for (MusicFolder m : musicFolders) {
-            path = path.concat("f:").concat(m.getPath().getPath()).concat(" ");
+            path = path.concat("f:").concat(m.getPathString()).concat(" ");
             fid = fid.concat("fId:").concat(Integer.toString(m.getId())).concat(" ");
         }
         path = path.trim();

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/AlbumUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/AlbumUpnpProcessorTest.java
@@ -23,8 +23,7 @@ package com.tesshu.jpsonic.service.upnp.processor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -44,13 +43,8 @@ import org.springframework.context.annotation.ComponentScan;
 @SpringBootTest
 class AlbumUpnpProcessorTest extends AbstractNeedsScan {
 
-    private static final List<MusicFolder> MUSIC_FOLDERS;
-
-    static {
-        MUSIC_FOLDERS = new ArrayList<>();
-        File musicDir = new File(resolveBaseMediaPath("Sort/Pagination/Albums"));
-        MUSIC_FOLDERS.add(new MusicFolder(1, musicDir, "Albums", true, new Date()));
-    }
+    private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Albums"), "Albums", true, new Date()));
 
     @Autowired
     private AlbumUpnpProcessor albumUpnpProcessor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/ArtistUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/ArtistUpnpProcessorTest.java
@@ -23,8 +23,8 @@ package com.tesshu.jpsonic.service.upnp.processor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -45,13 +45,8 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 class ArtistUpnpProcessorTest extends AbstractNeedsScan {
 
-    private static final List<MusicFolder> MUSIC_FOLDERS;
-
-    static {
-        MUSIC_FOLDERS = new ArrayList<>();
-        File musicDir = new File(resolveBaseMediaPath("Sort/Pagination/Artists"));
-        MUSIC_FOLDERS.add(new MusicFolder(1, musicDir, "Artists", true, new Date()));
-    }
+    private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, new Date()));
 
     @Autowired
     private ArtistUpnpProcessor artistUpnpProcessor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/IndexUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/IndexUpnpProcessorTest.java
@@ -27,7 +27,6 @@ import static com.tesshu.jpsonic.service.upnp.processor.UpnpProcessorTestUtils.J
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -80,7 +79,7 @@ class IndexUpnpProcessorTest {
         @Test
         void testRefreshIndex() {
             // not scanning
-            List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, new File(""), "name", true, new Date()));
+            List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, "", "name", true, new Date()));
             Mockito.when(util.getGuestMusicFolders()).thenReturn(musicFolders);
             Mockito.when(musicIndexService.getMusicFolderContent(musicFolders, true))
                     .thenReturn(new MusicFolderContent(new TreeMap<>(), Collections.emptyList()));
@@ -103,8 +102,8 @@ class IndexUpnpProcessorTest {
     @Nested
     class IntegrationTest extends AbstractNeedsScan {
 
-        private final List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
-                new File(resolveBaseMediaPath("Sort/Pagination/Artists")), "Artists", true, new Date()));
+        private final List<MusicFolder> musicFolders = Arrays.asList(
+                new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, new Date()));
 
         @Autowired
         private IndexUpnpProcessor indexUpnpProcessor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/IndexUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/IndexUpnpProcessorTest.java
@@ -80,7 +80,7 @@ class IndexUpnpProcessorTest {
         @Test
         void testRefreshIndex() {
             // not scanning
-            List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, null, "name", true, new Date()));
+            List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, new File(""), "name", true, new Date()));
             Mockito.when(util.getGuestMusicFolders()).thenReturn(musicFolders);
             Mockito.when(musicIndexService.getMusicFolderContent(musicFolders, true))
                     .thenReturn(new MusicFolderContent(new TreeMap<>(), Collections.emptyList()));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/MediaFileUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/MediaFileUpnpProcessorTest.java
@@ -25,7 +25,6 @@ import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -74,12 +73,12 @@ class MediaFileUpnpProcessorTest {
             Path musicFolderPath1 = Path.of(MediaFileUpnpProcessorTest.class.getResource("/MEDIAS/Music").toURI());
             MediaFile folder1 = new MediaFile();
             folder1.setMediaType(MediaType.DIRECTORY);
-            Mockito.when(mediaFileService.getMediaFile(musicFolderPath1.toFile())).thenReturn(folder1);
+            Mockito.when(mediaFileService.getMediaFile(musicFolderPath1)).thenReturn(folder1);
 
             Mockito.when(upnpProcessorUtil.getGuestMusicFolders()).thenReturn(
-                    Arrays.asList(new MusicFolder(0, musicFolderPath1.toFile(), "Music", true, new Date())));
+                    Arrays.asList(new MusicFolder(0, musicFolderPath1.toString(), "Music", true, new Date())));
             List<MediaFile> result = mediaFileUpnpProcessor.getItems(0, Integer.MAX_VALUE);
-            Mockito.verify(mediaFileService, Mockito.times(1)).getMediaFile(Mockito.any(File.class));
+            Mockito.verify(mediaFileService, Mockito.times(1)).getMediaFile(Mockito.any(Path.class));
             assertEquals(0, result.size());
             Mockito.clearInvocations(mediaFileService);
 
@@ -87,13 +86,13 @@ class MediaFileUpnpProcessorTest {
             Path musicFolderPath2 = Path.of(MediaFileUpnpProcessorTest.class.getResource("/MEDIAS/Music2").toURI());
             MediaFile folder2 = new MediaFile();
             folder2.setMediaType(MediaType.DIRECTORY);
-            Mockito.when(mediaFileService.getMediaFile(musicFolderPath2.toFile())).thenReturn(folder2);
+            Mockito.when(mediaFileService.getMediaFile(musicFolderPath2)).thenReturn(folder2);
 
-            Mockito.when(upnpProcessorUtil.getGuestMusicFolders())
-                    .thenReturn(Arrays.asList(new MusicFolder(0, musicFolderPath1.toFile(), "Music1", true, new Date()),
-                            new MusicFolder(1, musicFolderPath2.toFile(), "Music2", true, new Date())));
+            Mockito.when(upnpProcessorUtil.getGuestMusicFolders()).thenReturn(
+                    Arrays.asList(new MusicFolder(0, musicFolderPath1.toString(), "Music1", true, new Date()),
+                            new MusicFolder(1, musicFolderPath2.toString(), "Music2", true, new Date())));
             result = mediaFileUpnpProcessor.getItems(0, Integer.MAX_VALUE);
-            Mockito.verify(mediaFileService, Mockito.times(2)).getMediaFile(Mockito.any(File.class));
+            Mockito.verify(mediaFileService, Mockito.times(2)).getMediaFile(Mockito.any(Path.class));
             assertEquals(2, result.size());
         }
     }
@@ -117,7 +116,7 @@ class MediaFileUpnpProcessorTest {
 
             musicFolders = Arrays.asList(new MusicFolder(1,
                     Path.of(MediaFileUpnpProcessorTest.class.getResource("/MEDIAS/Sort/Pagination/Artists").toURI())
-                            .toFile(),
+                            .toString(),
                     "Artists", true, new Date()));
 
             setSortStrict(true);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/PlaylistUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/PlaylistUpnpProcessorTest.java
@@ -23,8 +23,8 @@ package com.tesshu.jpsonic.service.upnp.processor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -49,13 +49,8 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 class PlaylistUpnpProcessorTest extends AbstractNeedsScan {
 
-    private static final List<MusicFolder> MUSIC_FOLDERS;
-
-    static {
-        MUSIC_FOLDERS = new ArrayList<>();
-        File musicDir = new File(resolveBaseMediaPath("Sort/Pagination/Artists"));
-        MUSIC_FOLDERS.add(new MusicFolder(1, musicDir, "Artists", true, new Date()));
-    }
+    private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, new Date()));
 
     @Autowired
     private PlaylistUpnpProcessor playlistUpnpProcessor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RandomSongByArtistUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RandomSongByArtistUpnpProcessorTest.java
@@ -23,8 +23,7 @@ package com.tesshu.jpsonic.service.upnp.processor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -43,13 +42,8 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 class RandomSongByArtistUpnpProcessorTest extends AbstractNeedsScan {
 
-    private static final List<MusicFolder> MUSIC_FOLDERS;
-
-    static {
-        MUSIC_FOLDERS = new ArrayList<>();
-        File musicDir = new File(resolveBaseMediaPath("Sort/Pagination/Artists"));
-        MUSIC_FOLDERS.add(new MusicFolder(1, musicDir, "Artists", true, new Date()));
-    }
+    private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, new Date()));
 
     @Autowired
     private RandomSongByArtistUpnpProcessor randomSongByArtistUpnpProcessor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RandomSongByFolderArtistUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RandomSongByFolderArtistUpnpProcessorTest.java
@@ -23,8 +23,7 @@ package com.tesshu.jpsonic.service.upnp.processor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -36,13 +35,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 class RandomSongByFolderArtistUpnpProcessorTest extends AbstractNeedsScan {
 
-    private static final List<MusicFolder> MUSIC_FOLDERS;
-
-    static {
-        MUSIC_FOLDERS = new ArrayList<>();
-        File musicDir = new File(resolveBaseMediaPath("Sort/Pagination/Artists"));
-        MUSIC_FOLDERS.add(new MusicFolder(1, musicDir, "Artists", true, new Date()));
-    }
+    private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, new Date()));
 
     @Autowired
     private RandomSongByFolderArtistUpnpProcessor processor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumId3UpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumId3UpnpProcessorTest.java
@@ -23,8 +23,7 @@ package com.tesshu.jpsonic.service.upnp.processor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -41,13 +40,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 class RecentAlbumId3UpnpProcessorTest extends AbstractNeedsScan {
 
-    private static final List<MusicFolder> MUSIC_FOLDERS;
-
-    static {
-        MUSIC_FOLDERS = new ArrayList<>();
-        File musicDir = new File(resolveBaseMediaPath("Sort/Pagination/Albums"));
-        MUSIC_FOLDERS.add(new MusicFolder(1, musicDir, "Albums", true, new Date()));
-    }
+    private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Albums"), "Albums", true, new Date()));
 
     @Autowired
     private RecentAlbumId3UpnpProcessor processor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumUpnpProcessorTest.java
@@ -23,8 +23,7 @@ package com.tesshu.jpsonic.service.upnp.processor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -43,13 +42,8 @@ class RecentAlbumUpnpProcessorTest extends AbstractNeedsScan {
 
     private static final Logger LOG = LoggerFactory.getLogger(RecentAlbumUpnpProcessorTest.class);
 
-    private static final List<MusicFolder> MUSIC_FOLDERS;
-
-    static {
-        MUSIC_FOLDERS = new ArrayList<>();
-        File musicDir = new File(resolveBaseMediaPath("Sort/Pagination/Albums"));
-        MUSIC_FOLDERS.add(new MusicFolder(1, musicDir, "Albums", true, new Date()));
-    }
+    private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Albums"), "Albums", true, new Date()));
 
     @Autowired
     private RecentAlbumUpnpProcessor processor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/SongByGenreUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/SongByGenreUpnpProcessorTest.java
@@ -23,8 +23,7 @@ package com.tesshu.jpsonic.service.upnp.processor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -43,13 +42,8 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 class SongByGenreUpnpProcessorTest extends AbstractNeedsScan {
 
-    private static final List<MusicFolder> MUSIC_FOLDERS;
-
-    static {
-        MUSIC_FOLDERS = new ArrayList<>();
-        File musicDir = new File(resolveBaseMediaPath("Sort/Pagination/Artists"));
-        MUSIC_FOLDERS.add(new MusicFolder(1, musicDir, "Artists", true, new Date()));
-    }
+    private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, new Date()));
 
     @Autowired
     private SongByGenreUpnpProcessor songByGenreUpnpProcessor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/UpnpProcessorUtilTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/UpnpProcessorUtilTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -98,7 +99,7 @@ class UpnpProcessorUtilTest {
         assertFalse(util.isGenreCountAvailable());
 
         Mockito.when(settingsService.isDlnaGenreCountVisible()).thenReturn(true);
-        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, null, null, true, null));
+        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, new File(""), null, true, null));
         Mockito.when(musicFolderService.getAllMusicFolders()).thenReturn(musicFolders);
         Mockito.when(musicFolderService.getMusicFoldersForUser(User.USERNAME_GUEST)).thenReturn(musicFolders);
         assertTrue(util.isGenreCountAvailable());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/UpnpProcessorUtilTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/UpnpProcessorUtilTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -99,7 +98,7 @@ class UpnpProcessorUtilTest {
         assertFalse(util.isGenreCountAvailable());
 
         Mockito.when(settingsService.isDlnaGenreCountVisible()).thenReturn(true);
-        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, new File(""), null, true, null));
+        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, "", null, true, null));
         Mockito.when(musicFolderService.getAllMusicFolders()).thenReturn(musicFolders);
         Mockito.when(musicFolderService.getMusicFoldersForUser(User.USERNAME_GUEST)).thenReturn(musicFolders);
         assertTrue(util.isGenreCountAvailable());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/WMPProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/WMPProcessorTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -143,7 +142,7 @@ class WMPProcessorTest {
             m.setPathString("path2");
             m.setTitle("dummy title");
             List<MediaFile> songs = Arrays.asList(m);
-            MusicFolder mf = new MusicFolder(0, new File("path3"), "dummy", true, null);
+            MusicFolder mf = new MusicFolder(0, "path3", "dummy", true, null);
             List<MusicFolder> folders = Arrays.asList(mf);
             Mockito.when(util.getGuestMusicFolders()).thenReturn(folders);
             Mockito.when(mediaFileService.getSongs(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyList()))
@@ -188,7 +187,7 @@ class WMPProcessorTest {
             m.setPathString("path5");
             m.setTitle("dummy title");
             List<MediaFile> songs = Arrays.asList(m);
-            MusicFolder mf = new MusicFolder(0, new File("path6"), "dummy", true, null);
+            MusicFolder mf = new MusicFolder(0, "path6", "dummy", true, null);
             List<MusicFolder> folders = Arrays.asList(mf);
             Mockito.when(util.getGuestMusicFolders()).thenReturn(folders);
             Mockito.when(mediaFileService.getVideos(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyList()))


### PR DESCRIPTION
> In v111.2.0, features that have a deep impact on scanning have been migrated to NIO.2. In v111.3.0 all features will be migrated.

In the domain package, the below three classes use java.io.File. Mediafile, which has a large impact on speed, has been modified in advance. Other than that, it was not fixed because the range of influence is large.

 - com.tesshu.jpsonic.domain.MediaFile (v111.2.0)
 - com.tesshu.jpsonic.domain.**MusicFolder** (v111.3.0)
 - com.tesshu.jpsonic.domain.**TransferStatus** (v111.3.0)

In this pull request, the domain object will be modified so that Java.io.File is not used. Code that doesn't cover the path will be covered by adding tests.
