### PR TITLE
Organize warnings of 'google/error-prone'

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/ArtistInfo.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/ArtistInfo.java
@@ -25,9 +25,6 @@ import java.util.List;
 
 import com.tesshu.jpsonic.domain.ArtistBio;
 
-/**
- * @author Sindre Mehus
- */
 public class ArtistInfo {
 
     private final List<SimilarArtist> similarArtists;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/LyricsService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/LyricsService.java
@@ -26,7 +26,6 @@ import static com.tesshu.jpsonic.util.XMLUtil.createSAXBuilder;
 import java.io.IOException;
 import java.io.StringReader;
 import java.net.SocketException;
-import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
 import com.tesshu.jpsonic.util.StringUtil;
@@ -87,7 +86,7 @@ public class LyricsService {
             if (LOG.isWarnEnabled()) {
                 LOG.warn("Failed to get lyrics for song '{}'. Request failed: {}", song, e.toString());
             }
-            if (Objects.equals(HttpStatus.SC_SERVICE_UNAVAILABLE, e.getStatusCode())) {
+            if (HttpStatus.SC_SERVICE_UNAVAILABLE == e.getStatusCode()) {
                 lyrics.setTryLater(true);
             }
         } catch (SocketException | ConnectTimeoutException e) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/NowPlayingService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/NowPlayingService.java
@@ -40,6 +40,7 @@ import com.tesshu.jpsonic.service.StatusService;
 import com.tesshu.jpsonic.util.StringUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.ServletRequestBindingException;
 
@@ -72,14 +73,7 @@ public class NowPlayingService {
         this.ajaxHelper = ajaxHelper;
     }
 
-    /**
-     * Returns details about what the current player is playing.
-     *
-     * @return Details about what the current player is playing, or <code>null</code> if not playing anything.
-     *
-     * @throws ServletRequestBindingException
-     */
-    public NowPlayingInfo getNowPlayingForCurrentPlayer() throws ServletRequestBindingException {
+    public @Nullable NowPlayingInfo getNowPlayingForCurrentPlayer() throws ServletRequestBindingException {
         Player player = playerService.getPlayer(ajaxHelper.getHttpServletRequest(),
                 ajaxHelper.getHttpServletResponse());
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/PlayQueueService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/PlayQueueService.java
@@ -269,10 +269,8 @@ public class PlayQueueService {
         return doPlay(request, player, songs).startPlayerAtAndGetInfo(0);
     }
 
-    /**
-     * @param startIndex
-     *            Start playing at this index in the list of radio streams, or play whole radio playlist if
-     *            {@code null}.
+    /*
+     * Start playing at this index in the list of radio streams, or play whole radio playlist if {@code null}.
      */
     public PlayQueueInfo playInternetRadio(int id, Integer startIndex)
             throws ServletRequestBindingException, ExecutionException {
@@ -300,9 +298,8 @@ public class PlayQueueService {
         return doAdd(request, response, ids, null);
     }
 
-    /**
-     * @param startIndex
-     *            Start playing at this index, or play whole playlist if {@code null}.
+    /*
+     * Start playing at this index, or play whole playlist if {@code null}.
      */
     public PlayQueueInfo playPlaylist(int id, Integer startIndex) throws ServletRequestBindingException {
         HttpServletRequest request = ajaxHelper.getHttpServletRequest();
@@ -328,9 +325,8 @@ public class PlayQueueService {
         return doPlay(request, player, files).startPlayerAtAndGetInfo(0);
     }
 
-    /**
-     * @param startIndex
-     *            Start playing at this index, or play all top songs if {@code null}.
+    /*
+     * Start playing at this index, or play all top songs if {@code null}.
      */
     public PlayQueueInfo playTopSong(int id, Integer startIndex) throws ServletRequestBindingException {
         HttpServletRequest request = ajaxHelper.getHttpServletRequest();
@@ -558,10 +554,9 @@ public class PlayQueueService {
         return playQueue;
     }
 
-    /**
-     * @param addAtIndex
-     *            if not null, insert the media files at the specified index otherwise, append the media files at the
-     *            end of the play queue
+    /*
+     * if not null, insert the media files at the specified index otherwise, append the media files at the end of the
+     * play queue
      */
     public PlayQueueInfo doAdd(HttpServletRequest request, HttpServletResponse response, int[] ids, Integer addAtIndex)
             throws ServletRequestBindingException {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/GeneralSettingsCommand.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/GeneralSettingsCommand.java
@@ -298,8 +298,8 @@ public class GeneralSettingsCommand extends SettingsPageCommons {
         return othersPlayingEnabled;
     }
 
-    public void setOthersPlayingEnabled(boolean othersplayingenabled) {
-        this.othersPlayingEnabled = othersplayingenabled;
+    public void setOthersPlayingEnabled(boolean othersPlayingEnabled) {
+        this.othersPlayingEnabled = othersPlayingEnabled;
     }
 
     public boolean isShowRememberMe() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/PersonalSettingsCommand.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/PersonalSettingsCommand.java
@@ -307,8 +307,8 @@ public class PersonalSettingsCommand extends SettingsPageCommons {
         return closePlayQueue;
     }
 
-    public void setClosePlayQueue(boolean closePlayqueue) {
-        this.closePlayQueue = closePlayqueue;
+    public void setClosePlayQueue(boolean closePlayQueue) {
+        this.closePlayQueue = closePlayQueue;
     }
 
     public boolean isAutoHidePlayQueue() {
@@ -483,8 +483,8 @@ public class PersonalSettingsCommand extends SettingsPageCommons {
         return showTopSongs;
     }
 
-    public void setShowTopSongs(boolean showtopSongs) {
-        this.showTopSongs = showtopSongs;
+    public void setShowTopSongs(boolean showTopSongs) {
+        this.showTopSongs = showTopSongs;
     }
 
     public boolean isShowSimilar() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/HelpController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/HelpController.java
@@ -127,7 +127,7 @@ public class HelpController {
                 }
                 lines.add(0, line);
             }
-            return lines;
+            return Collections.unmodifiableList(lines);
         } catch (IOException e) {
             if (LOG.isWarnEnabled()) {
                 LOG.warn("Could not open log file " + logFile, e);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/ImportPlaylistController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/ImportPlaylistController.java
@@ -46,9 +46,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-/**
- * @author Sindre Mehus
- */
 @Controller
 @RequestMapping({ "/importPlaylist", "/importPlaylist.view" })
 public class ImportPlaylistController {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/InternalHelpController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/InternalHelpController.java
@@ -380,7 +380,7 @@ public class InternalHelpController {
 
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops") // (File) Not reusable
     private Path lookForExecutable(String executableName) {
-        for (String path : System.getenv("PATH").split(java.io.File.pathSeparator)) {
+        for (String path : System.getenv("PATH").split(java.io.File.pathSeparator, -1)) {
             Path file = Path.of(path, executableName);
             if (Files.exists(file)) {
                 if (LOG.isDebugEnabled()) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/InternalHelpController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/InternalHelpController.java
@@ -32,7 +32,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -361,20 +360,20 @@ public class InternalHelpController {
     }
 
     private static List<String> getLatestLogEntries(Path logFile) {
-        List<String> lines = new ArrayList<>(LOG_LINES_TO_SHOW);
+        List<String> result = new ArrayList<>(LOG_LINES_TO_SHOW);
         try (ReversedLinesFileReader reader = new ReversedLinesFileReader(logFile, Charset.defaultCharset())) {
             for (String current = reader.readLine(); current != null; current = reader.readLine()) {
-                if (lines.size() >= LOG_LINES_TO_SHOW) {
+                if (result.size() >= LOG_LINES_TO_SHOW) {
                     break;
                 }
-                lines.add(0, current);
+                result.add(0, current);
             }
-            return lines;
+            return result;
         } catch (IOException e) {
             if (LOG.isWarnEnabled()) {
                 LOG.warn("Could not open log file " + logFile, e);
             }
-            return Collections.emptyList();
+            return result;
         }
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/JAXBWriter.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/JAXBWriter.java
@@ -54,9 +54,6 @@ import org.subsonic.restapi.ObjectFactory;
 import org.subsonic.restapi.Response;
 import org.subsonic.restapi.ResponseStatus;
 
-/**
- * @author Sindre Mehus
- */
 public class JAXBWriter {
 
     private static final Logger LOG = LoggerFactory.getLogger(JAXBWriter.class);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/ReloadFrame.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/ReloadFrame.java
@@ -21,10 +21,6 @@
 
 package com.tesshu.jpsonic.controller;
 
-/**
- *
- * @author Sindre Mehus
- */
 public class ReloadFrame {
 
     private String frame;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StreamController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StreamController.java
@@ -372,14 +372,6 @@ public class StreamController {
         }
     }
 
-    /**
-     * @param req
-     * @param res
-     * @param isRest
-     *            True if the call is from SubsonicRESTController
-     *
-     * @throws ServletRequestBindingException
-     */
     @GetMapping
     public void handleRequest(HttpServletRequest req, HttpServletResponse res, Boolean isRest)
             throws ServletRequestBindingException {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/WebFontUtils.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/WebFontUtils.java
@@ -46,7 +46,7 @@ public final class WebFontUtils {
         String escaped = raw;
         escaped = escaped.replace("\\", "").replace("\b", "").replace("\f", "").replace("\n", "").replace("\r", "")
                 .replace("\t", "");
-        String[] fonts = escaped.split(",");
+        String[] fonts = escaped.split(",", -1);
         escaped = "";
         for (String font : fonts) {
             String fontEscaped = font.trim().replaceAll("\"", "");

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Album.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Album.java
@@ -23,9 +23,6 @@ package com.tesshu.jpsonic.domain;
 
 import java.util.Date;
 
-/**
- * @author Sindre Mehus
- */
 public class Album {
 
     private int id;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/AlbumListType.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/AlbumListType.java
@@ -21,9 +21,6 @@
 
 package com.tesshu.jpsonic.domain;
 
-/**
- * @author Sindre Mehus
- */
 public enum AlbumListType {
 
     RANDOM("random", "Random"), NEWEST("newest", "Recently Added"), STARRED("starred", "Starred"),

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/AlbumNotes.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/AlbumNotes.java
@@ -21,9 +21,6 @@
 
 package com.tesshu.jpsonic.domain;
 
-/**
- * @author Sindre Mehus
- */
 public class AlbumNotes {
 
     private final String notes;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Artist.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Artist.java
@@ -23,9 +23,6 @@ package com.tesshu.jpsonic.domain;
 
 import java.util.Date;
 
-/**
- * @author Sindre Mehus
- */
 public class Artist {
 
     private int id;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/ArtistBio.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/ArtistBio.java
@@ -21,9 +21,6 @@
 
 package com.tesshu.jpsonic.domain;
 
-/**
- * @author Sindre Mehus
- */
 public class ArtistBio {
 
     private final String biography;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/CacheElement.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/CacheElement.java
@@ -21,9 +21,6 @@
 
 package com.tesshu.jpsonic.domain;
 
-/**
- * @author Sindre Mehus
- */
 public class CacheElement {
 
     private final long id;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/JapaneseReadingUtils.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/JapaneseReadingUtils.java
@@ -57,7 +57,7 @@ public class JapaneseReadingUtils {
     private static final String ASTER = "*";
     private static final String HYPHEN = "-";
     private static final String TILDE = "\uff5e"; // Special usage for Japanese
-    private static final char WAVY_LINE = '\u007e'; // ~
+    private static final char WAVY_LINE = '~';
 
     private final SettingsService settingsService;
     private final Tokenizer tokenizer;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/JapaneseReadingUtils.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/JapaneseReadingUtils.java
@@ -109,6 +109,7 @@ public class JapaneseReadingUtils {
      * @param japaneseReading
      *            string after analysis
      */
+    @SuppressWarnings("LoopOverCharArray")
     public String removePunctuationFromJapaneseReading(@Nullable String japaneseReading) {
         if (isJapaneseReading(japaneseReading)) {
             if (truncatedReadingMap.containsKey(japaneseReading)) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/LastFmCoverArt.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/LastFmCoverArt.java
@@ -21,9 +21,6 @@
 
 package com.tesshu.jpsonic.domain;
 
-/**
- * @author Sindre Mehus
- */
 public class LastFmCoverArt {
 
     private final String imageUrl;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaLibraryStatistics.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaLibraryStatistics.java
@@ -115,7 +115,7 @@ public class MediaLibraryStatistics {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof MediaLibraryStatistics)) {
             return false;
         }
         MediaLibraryStatistics that = (MediaLibraryStatistics) o;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicFolder.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicFolder.java
@@ -100,7 +100,7 @@ public class MusicFolder implements Serializable {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof MusicFolder)) {
             return false;
         }
         return Objects.equal(id, ((MusicFolder) o).id);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicFolderContent.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicFolderContent.java
@@ -24,9 +24,6 @@ package com.tesshu.jpsonic.domain;
 import java.util.List;
 import java.util.SortedMap;
 
-/**
- * @author Sindre Mehus
- */
 public class MusicFolderContent {
 
     private final SortedMap<MusicIndex, List<MusicIndex.SortableArtistWithMediaFiles>> indexedArtists;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Playlist.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Playlist.java
@@ -25,9 +25,6 @@ import java.util.Date;
 
 import com.tesshu.jpsonic.util.StringUtil;
 
-/**
- * @author Sindre Mehus
- */
 public class Playlist {
 
     private int id;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Transcoding.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Transcoding.java
@@ -226,7 +226,7 @@ public class Transcoding {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof Transcoding)) {
             return false;
         }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/UserSettings.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/UserSettings.java
@@ -290,8 +290,8 @@ public class UserSettings {
         return closePlayQueue;
     }
 
-    public void setClosePlayQueue(boolean closePlayqueue) {
-        this.closePlayQueue = closePlayqueue;
+    public void setClosePlayQueue(boolean closePlayQueue) {
+        this.closePlayQueue = closePlayQueue;
     }
 
     public boolean isAlternativeDrawer() {
@@ -493,8 +493,8 @@ public class UserSettings {
         return showTopSongs;
     }
 
-    public void setShowTopSongs(boolean showtopSongs) {
-        this.showTopSongs = showtopSongs;
+    public void setShowTopSongs(boolean showTopSongs) {
+        this.showTopSongs = showTopSongs;
     }
 
     public boolean isShowSimilar() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/security/LoginFailureListener.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/security/LoginFailureListener.java
@@ -29,9 +29,6 @@ import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.event.AbstractAuthenticationFailureEvent;
 import org.springframework.security.web.authentication.WebAuthenticationDetails;
 
-/**
- * @author Sindre Mehus
- */
 public class LoginFailureListener implements ApplicationListener<ApplicationEvent> {
 
     private static final Logger LOG = LoggerFactory.getLogger(LoginFailureListener.class);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/BookmarkService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/BookmarkService.java
@@ -22,7 +22,6 @@
 package com.tesshu.jpsonic.service;
 
 import java.util.List;
-import java.util.Objects;
 
 import com.tesshu.jpsonic.dao.BookmarkDao;
 import com.tesshu.jpsonic.domain.Bookmark;
@@ -39,9 +38,8 @@ public class BookmarkService {
     }
 
     public Bookmark getBookmarkForUserAndMediaFile(String username, MediaFile mediaFile) {
-        return dao.getBookmarks(username).stream()
-                .filter(bookmark -> Objects.equals(mediaFile.getId(), bookmark.getMediaFileId())).findFirst()
-                .orElse(null);
+        return dao.getBookmarks(username).stream().filter(bookmark -> mediaFile.getId() == bookmark.getMediaFileId())
+                .findFirst().orElse(null);
     }
 
     public void createOrUpdateBookmark(Bookmark bookmark) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
@@ -224,8 +224,9 @@ public class MediaFileService {
     public List<MediaFile> getChildrenOf(MediaFile parent, boolean includeFiles, boolean includeDirectories,
             boolean sort, boolean useFastCache, MediaLibraryStatistics... statistics) {
 
+        List<MediaFile> result = new ArrayList<>();
         if (!parent.isDirectory()) {
-            return Collections.emptyList();
+            return result;
         }
 
         // Make sure children are stored and up-to-date in the database.
@@ -233,7 +234,6 @@ public class MediaFileService {
             updateChildren(parent, statistics);
         }
 
-        List<MediaFile> result = new ArrayList<>();
         for (MediaFile child : mediaFileDao.getChildrenOf(parent.getPathString())) {
             MediaFile checked = checkLastModified(child, useFastCache, statistics);
             if (checked.isDirectory() && includeDirectories && includeMediaFile(checked)) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/NetworkUtils.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/NetworkUtils.java
@@ -73,7 +73,7 @@ public final class NetworkUtils {
         // If the request has been through multiple reverse proxies,
         // We need to return the original Host that the client used
         if (xForardedHost != null) {
-            xForardedHost = xForardedHost.split(",")[0];
+            xForardedHost = xForardedHost.split(",", -1)[0];
         }
 
         if (!isValidXForwardedHost(xForardedHost)) {
@@ -82,7 +82,7 @@ public final class NetworkUtils {
             // If the request has been through multiple reverse proxies,
             // We need to return the original Host that the client used
             if (xForardedHost != null) {
-                xForardedHost = xForardedHost.split(",")[0];
+                xForardedHost = xForardedHost.split(",", -1)[0];
             }
 
             if (!isValidXForwardedHost(xForardedHost)) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SettingsService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SettingsService.java
@@ -835,30 +835,28 @@ public class SettingsService {
     }
 
     /**
-     * @return The limit in Kbit/s. Zero if unlimited.
+     * Get the limit in Kbit/s. Zero if unlimited.
      */
     public long getDownloadBitrateLimit() {
         return getLong(SettingsConstants.Advanced.Bandwidth.DOWNLOAD_BITRATE_LIMIT);
     }
 
     /**
-     * @param l
-     *            The limit in Kbit/s. Zero if unlimited.
+     * Set the limit in Kbit/s. Zero if unlimited.
      */
     public void setDownloadBitrateLimit(long l) {
         setProperty(SettingsConstants.Advanced.Bandwidth.DOWNLOAD_BITRATE_LIMIT, l);
     }
 
     /**
-     * @return The limit in Kbit/s. Zero if unlimited.
+     * Get the limit in Kbit/s. Zero if unlimited.
      */
     public long getUploadBitrateLimit() {
         return getLong(SettingsConstants.Advanced.Bandwidth.UPLOAD_BITRATE_LIMIT);
     }
 
     /**
-     * @param l
-     *            The limit in Kbit/s. Zero if unlimited.
+     * Set the limit in Kbit/s. Zero if unlimited.
      */
     public void setUploadBitrateLimit(long l) {
         setProperty(SettingsConstants.Advanced.Bandwidth.UPLOAD_BITRATE_LIMIT, l);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/UPnPService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/UPnPService.java
@@ -261,15 +261,14 @@ public class UPnPService {
         String serverName = settingsService.getDlnaServerName();
         String serialNumber = versionService.getLocalBuildNumber();
         DLNADoc[] dlnaDocs = { new DLNADoc("DMS", DLNADoc.Version.V1_5) };
-        DeviceDetails details = null;
         URI modelURI = URI.create("https://tesshu.com");
         URI manufacturerURI = URI.create("https://github.com/jpsonic/jpsonic");
         URI presentationURI = URI.create(settingsService.getDlnaBaseLANURL());
         ManufacturerDetails manufacturerDetails = new ManufacturerDetails(serverName, modelURI);
         ModelDetails modelDetails = new ModelDetails(serverName, null, versionService.getLocalVersion().toString(),
                 manufacturerURI);
-        details = new DeviceDetails(serverName, manufacturerDetails, modelDetails, serialNumber, null, presentationURI,
-                dlnaDocs, null);
+        DeviceDetails details = new DeviceDetails(serverName, manufacturerDetails, modelDetails, serialNumber, null,
+                presentationURI, dlnaDocs, null);
         DeviceIdentity identity = new DeviceIdentity(UDN.uniqueSystemIdentifier(serverName),
                 MIN_ADVERTISEMENT_AGE_SECONDS);
         DeviceType type = new UDADeviceType("MediaServer", 1);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/UPnPService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/UPnPService.java
@@ -68,9 +68,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Service;
 
-/**
- * @author Sindre Mehus
- */
 @Service
 @DependsOn("shutdownHook")
 public class UPnPService {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/VersionService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/VersionService.java
@@ -65,7 +65,8 @@ import org.springframework.stereotype.Service;
 public class VersionService {
 
     private static final Logger LOG = LoggerFactory.getLogger(VersionService.class);
-    private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyyMMdd", Locale.US);
+    private static final ThreadLocal<DateFormat> DATE_FORMAT = ThreadLocal
+            .withInitial(() -> new SimpleDateFormat("yyyyMMdd", Locale.US));
     private static final Object LATEST_LOCK = new Object();
     private static final Object LOCAL_VERSION_LOCK = new Object();
     private static final Object LOCAL_BUILD_DATE = new Object();
@@ -147,7 +148,7 @@ public class VersionService {
                 try {
                     String date = readLineFromResource("/build_date.txt");
                     synchronized (DATE_FORMAT) {
-                        localBuildDate = DATE_FORMAT.parse(date);
+                        localBuildDate = DATE_FORMAT.get().parse(date);
                     }
                 } catch (ParseException e) {
                     if (LOG.isWarnEnabled()) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/AnalyzerFactory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/AnalyzerFactory.java
@@ -53,7 +53,6 @@ import org.apache.lucene.analysis.core.KeywordTokenizerFactory;
 import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
 import org.apache.lucene.analysis.core.StopFilterFactory;
 import org.apache.lucene.analysis.custom.CustomAnalyzer;
-import org.apache.lucene.analysis.custom.CustomAnalyzer.Builder;
 import org.apache.lucene.analysis.ja.JapanesePartOfSpeechStopFilter;
 import org.apache.lucene.analysis.ja.JapanesePartOfSpeechStopFilterFactory;
 import org.apache.lucene.analysis.ja.JapaneseTokenizerFactory;
@@ -116,7 +115,7 @@ public final class AnalyzerFactory {
      */
     private Analyzer createDefaultAnalyzer(boolean isArtist) throws IOException {
         IndexScheme scheme = IndexScheme.of(settingsService.getIndexSchemeName());
-        CustomAnalyzer.Builder builder = CustomAnalyzer.builder()
+        return CustomAnalyzer.builder()
                 .withTokenizer(scheme == IndexScheme.WITHOUT_JP_LANG_PROCESSING ? StandardTokenizerFactory.class
                         : JapaneseTokenizerFactory.class)
                 .addTokenFilter(CJKWidthFilterFactory.class)
@@ -133,8 +132,8 @@ public final class AnalyzerFactory {
                 .addTokenFilter(PatternReplaceFilterFactory.class, //
                         FILTER_ATTR_PATTERN, "\\_$", //
                         FILTER_ATTR_REPLACEMENT, "", //
-                        FILTER_ATTR_REPLACE, FILTER_ATTR_ALL);
-        return builder.build();
+                        FILTER_ATTR_REPLACE, FILTER_ATTR_ALL)
+                .build();
     }
 
     /**
@@ -229,7 +228,7 @@ public final class AnalyzerFactory {
      * @see org.jaudiotagger.tag.id3.framebody.FrameBodyTCON#convertID3v23GenreToGeneric
      */
     private Analyzer createGenreAnalyzer() throws IOException {
-        Builder builder = CustomAnalyzer.builder().withTokenizer(GenreTokenizerFactory.class) //
+        return CustomAnalyzer.builder().withTokenizer(GenreTokenizerFactory.class) //
                 .addTokenFilter(PatternReplaceFilterFactory.class, //
                         FILTER_ATTR_PATTERN, "\\(", FILTER_ATTR_REPLACEMENT, "", //
                         FILTER_ATTR_REPLACE, FILTER_ATTR_ALL)
@@ -246,8 +245,7 @@ public final class AnalyzerFactory {
                         FILTER_ATTR_PATTERN, "\\[\\]", FILTER_ATTR_REPLACEMENT, "\\[ \\]", //
                         FILTER_ATTR_REPLACE, FILTER_ATTR_ALL)
                 .addTokenFilter(CJKWidthFilterFactory.class) //
-                .addTokenFilter(ASCIIFoldingFilterFactory.class, "preserveOriginal", "false");
-        return builder.build();
+                .addTokenFilter(ASCIIFoldingFilterFactory.class, "preserveOriginal", "false").build();
     }
 
     /**

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
@@ -510,16 +510,16 @@ public class IndexManager {
      */
     public List<String> toPreAnalyzedGenres(@NonNull List<String> genres) {
 
+        List<String> result = new ArrayList<>();
         if (genres.isEmpty()) {
-            return Collections.emptyList();
+            return result;
         }
 
         IndexSearcher searcher = getSearcher(IndexType.GENRE);
         if (isEmpty(searcher)) {
-            return Collections.emptyList();
+            return result;
         }
 
-        List<String> result = new ArrayList<>();
         try {
             final Query query = queryFactory.toPreAnalyzedGenres(genres);
             TopDocs topDocs = searcher.search(query, Integer.MAX_VALUE);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexType.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexType.java
@@ -92,8 +92,10 @@ public enum IndexType {
 
     ;
 
+    @SuppressWarnings("ImmutableEnumChecker")
     private final Map<String, Float> boosts;
 
+    @SuppressWarnings("ImmutableEnumChecker")
     private final String[] fields;
 
     /**

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/SearchServiceImpl.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/SearchServiceImpl.java
@@ -442,11 +442,11 @@ public class SearchServiceImpl implements SearchService {
 
     @Override
     public List<MediaFile> getAlbumsByGenres(String genres, int offset, int count, List<MusicFolder> musicFolders) {
+        final List<MediaFile> result = new ArrayList<>();
         if (isEmpty(genres)) {
-            return Collections.emptyList();
+            return result;
         }
 
-        final List<MediaFile> result = new ArrayList<>();
         Consumer<List<MediaFile>> addSubToResult = (mediaFiles) -> result
                 .addAll(mediaFiles.subList(offset, Math.min(mediaFiles.size(), offset + count)));
         util.getCache(genres, musicFolders, IndexType.ALBUM).ifPresent(addSubToResult);
@@ -465,16 +465,16 @@ public class SearchServiceImpl implements SearchService {
     @Override
     public List<Album> getAlbumId3sByGenres(String genres, int offset, int count, List<MusicFolder> musicFolders) {
 
+        List<Album> result = new ArrayList<>();
         if (isEmpty(genres)) {
-            return Collections.emptyList();
+            return result;
         }
 
         IndexSearcher searcher = indexManager.getSearcher(IndexType.ALBUM_ID3);
         if (isEmpty(searcher)) {
-            return Collections.emptyList();
+            return result;
         }
 
-        List<Album> result = new ArrayList<>();
         try {
             SortField[] sortFields = Arrays.stream(IndexType.ALBUM_ID3.getFields())
                     .map(n -> new SortField(n, SortField.Type.STRING)).toArray(SortField[]::new);
@@ -501,11 +501,11 @@ public class SearchServiceImpl implements SearchService {
 
     @Override
     public List<MediaFile> getSongsByGenres(String genres, int offset, int count, List<MusicFolder> musicFolders) {
+        final List<MediaFile> result = new ArrayList<>();
         if (isEmpty(genres)) {
-            return Collections.emptyList();
+            return result;
         }
 
-        final List<MediaFile> result = new ArrayList<>();
         Consumer<List<MediaFile>> addSubToResult = (mediaFiles) -> result
                 .addAll(mediaFiles.subList(offset, Math.min(mediaFiles.size(), offset + count)));
         util.getCache(genres, musicFolders, IndexType.SONG).ifPresent(addSubToResult);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/UPnPSearchCriteriaDirector.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/UPnPSearchCriteriaDirector.java
@@ -246,6 +246,7 @@ public class UPnPSearchCriteriaDirector implements UPnPSearchCriteriaListener {
         assignableClass = MediaFile.class;
     }
 
+    @SuppressWarnings("ArgumentSelectionDefectChecker")
     private Class<?> purseDerivedfrom(String subject, String verb, String complement) {
 
         Class<?> clazz = null;
@@ -295,6 +296,7 @@ public class UPnPSearchCriteriaDirector implements UPnPSearchCriteriaListener {
         return clazz;
     }
 
+    @SuppressWarnings("ArgumentSelectionDefectChecker")
     private Class<?> purseClass(String subject, String verb, String complement) {
 
         Class<?> clazz = null;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/UPnPSearchCriteriaDirector.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/UPnPSearchCriteriaDirector.java
@@ -650,7 +650,7 @@ public class UPnPSearchCriteriaDirector implements UPnPSearchCriteriaListener {
         // folder
         IndexType t = getIndexType();
         boolean isId3 = t == IndexType.ALBUM_ID3 || t == IndexType.ARTIST_ID3;
-        Query folderQuery = queryFactory.toFolderQuery.apply(isId3, upnpUtil.getGuestMusicFolders());
+        Query folderQuery = queryFactory.createFolderQuery(isId3, upnpUtil.getGuestMusicFolders());
         mainQuery.add(folderQuery, Occur.MUST);
 
         result = new UPnPSearchCriteria(upnpSearchQuery, offset, count);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/CustomContentDirectory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/CustomContentDirectory.java
@@ -31,9 +31,6 @@ import org.fourthline.cling.support.model.BrowseResult;
 import org.fourthline.cling.support.model.DIDLContent;
 import org.fourthline.cling.support.model.SortCriterion;
 
-/**
- * @author Sindre Mehus
- */
 public abstract class CustomContentDirectory extends AbstractContentDirectoryService {
 
     public CustomContentDirectory() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/DispatchingContentDirectory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/DispatchingContentDirectory.java
@@ -143,7 +143,7 @@ public class DispatchingContentDirectory extends CustomContentDirectory implemen
         // maxResult == 0 means all.
         long max = maxResults == 0 ? Long.MAX_VALUE : maxResults;
 
-        String[] splitId = objectId.split(OBJECT_ID_SEPARATOR);
+        String[] splitId = objectId.split(OBJECT_ID_SEPARATOR, -1);
         String browseRoot = splitId[0];
         String itemId = splitId.length == 1 ? null : splitId[1];
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/MSMediaReceiverRegistrarService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/MSMediaReceiverRegistrarService.java
@@ -23,8 +23,5 @@ package com.tesshu.jpsonic.service.upnp;
 
 import org.fourthline.cling.support.xmicrosoft.AbstractMediaReceiverRegistrarService;
 
-/**
- * @author Sindre Mehus
- */
 public class MSMediaReceiverRegistrarService extends AbstractMediaReceiverRegistrarService {
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/NATPMPRouter.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/NATPMPRouter.java
@@ -25,9 +25,6 @@ import com.hoodcomputing.natpmp.MapRequestMessage;
 import com.hoodcomputing.natpmp.NatPmpDevice;
 import com.hoodcomputing.natpmp.NatPmpException;
 
-/**
- * @author Sindre Mehus
- */
 public final class NATPMPRouter implements Router {
 
     private final NatPmpDevice device;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/Router.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/Router.java
@@ -21,9 +21,6 @@
 
 package com.tesshu.jpsonic.service.upnp;
 
-/**
- * @author Sindre Mehus
- */
 public interface Router {
 
     /**

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/AlbumByGenreUpnpProcessor.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/AlbumByGenreUpnpProcessor.java
@@ -25,7 +25,6 @@ import static org.springframework.util.ObjectUtils.isEmpty;
 import java.net.URI;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
@@ -51,7 +50,7 @@ public class AlbumByGenreUpnpProcessor extends UpnpContentProcessor<MediaFile, M
     private final SearchService searchService;
     private final JMediaFileService mediaFileService;
 
-    private final Function<Genre, MediaFile> toMediaFile = (g) -> {
+    private MediaFile toMediaFile(Genre g) {
         MediaFile m = new MediaFile();
         m.setId(-1);
         m.setTitle(g.getName());
@@ -60,7 +59,7 @@ public class AlbumByGenreUpnpProcessor extends UpnpContentProcessor<MediaFile, M
         }
         m.setGenre(g.getName());
         return m;
-    };
+    }
 
     public AlbumByGenreUpnpProcessor(@Lazy UpnpProcessDispatcher d, UpnpProcessorUtil u, JMediaFileService m,
             SearchService s) {
@@ -130,7 +129,8 @@ public class AlbumByGenreUpnpProcessor extends UpnpContentProcessor<MediaFile, M
 
     @Override
     public List<MediaFile> getItems(long offset, long maxResults) {
-        return searchService.getGenres(true, offset, maxResults).stream().map(toMediaFile).collect(Collectors.toList());
+        return searchService.getGenres(true, offset, maxResults).stream().map(this::toMediaFile)
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -138,7 +138,7 @@ public class AlbumByGenreUpnpProcessor extends UpnpContentProcessor<MediaFile, M
         int index = Integer.parseInt(id);
         List<Genre> genres = searchService.getGenres(true);
         if (genres.size() > index) {
-            return toMediaFile.apply(genres.get(index));
+            return toMediaFile(genres.get(index));
         }
         return null;
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/PodcastUpnpProcessor.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/PodcastUpnpProcessor.java
@@ -22,6 +22,7 @@ package com.tesshu.jpsonic.service.upnp.processor;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
 import java.net.URI;
+import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -57,8 +58,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Service
 public class PodcastUpnpProcessor extends UpnpContentProcessor<PodcastChannel, PodcastEpisode> {
 
-    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
-
+    private static final ThreadLocal<DateFormat> DATE_FORMAT = ThreadLocal
+            .withInitial(() -> new SimpleDateFormat("yyyy-MM-dd", Locale.US));
     private final UpnpProcessorUtil util;
     private final MediaFileService mediaFileService;
     private final PodcastService podcastService;
@@ -122,7 +123,7 @@ public class PodcastUpnpProcessor extends UpnpContentProcessor<PodcastChannel, P
             Calendar c = Calendar.getInstance();
             c.setTime(publishDate);
             synchronized (DATE_FORMAT) {
-                item.setDate(DATE_FORMAT.format(c.getTime()));
+                item.setDate(DATE_FORMAT.get().format(c.getTime()));
             }
         }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/SongByGenreUpnpProcessor.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/SongByGenreUpnpProcessor.java
@@ -73,7 +73,6 @@ public class SongByGenreUpnpProcessor extends UpnpContentProcessor<Genre, MediaF
         return createBrowseResult(didl, (int) didl.getCount(), getItemCount());
     }
 
-    @Deprecated
     @Override
     public Container createContainer(Genre item) {
         return null;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/spring/EhcacheConfiguration.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/spring/EhcacheConfiguration.java
@@ -50,7 +50,7 @@ public class EhcacheConfiguration {
         return new CacheDisposer(settingsService);
     }
 
-    /*
+    /**
      * Shutdown priority is equal to database.
      *
      * @see net.sf.ehcache.constructs.web.ShutdownListener

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/HttpRange.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/HttpRange.java
@@ -26,9 +26,6 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 
-/**
- * @author Sindre Mehus
- */
 public class HttpRange {
 
     private static final Pattern PATTERN = Pattern.compile("bytes=(\\d+)-(\\d*)");
@@ -75,35 +72,35 @@ public class HttpRange {
     }
 
     /**
-     * @return The first byte position (inclusive) in the range. Never {@code null}.
+     * The first byte position (inclusive) in the range. Never {@code null}.
      */
     public Long getFirstBytePos() {
         return firstBytePos;
     }
 
     /**
-     * @return The last byte position (inclusive) in the range. Can be {@code null}.
+     * The last byte position (inclusive) in the range. Can be {@code null}.
      */
     public Long getLastBytePos() {
         return lastBytePos;
     }
 
     /**
-     * @return Whether this is a closed range (both first and last byte position specified).
+     * Whether this is a closed range (both first and last byte position specified).
      */
     public boolean isClosed() {
         return firstBytePos != null && lastBytePos != null;
     }
 
     /**
-     * @return The size in bytes if the range is closed, -1 otherwise.
+     * The size in bytes if the range is closed, -1 otherwise.
      */
     public long size() {
         return isClosed() ? lastBytePos - firstBytePos + 1 : -1;
     }
 
     /**
-     * @return Returns whether the given byte position is within this range.
+     * Returns whether the given byte position is within this range.
      */
     public boolean contains(long pos) {
         if (pos < firstBytePos) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/LegacyHsqlUtil.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/LegacyHsqlUtil.java
@@ -30,6 +30,7 @@ import java.util.Properties;
 
 import com.tesshu.jpsonic.service.SettingsService;
 import com.tesshu.jpsonic.spring.AirsonicHsqlDatabase;
+import org.hsqldb.jdbc.JDBCDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.FileSystemResource;
@@ -88,7 +89,7 @@ public final class LegacyHsqlUtil {
         try {
             Driver driver = (Driver) Class
                     .forName("org.hsqldb.jdbc.JDBCDriver", true, Thread.currentThread().getContextClassLoader())
-                    .getDeclaredConstructor().newInstance();
+                    .asSubclass(JDBCDriver.class).getDeclaredConstructor().newInstance();
             driverVersion = String.format("%d.%d", driver.getMajorVersion(), driver.getMinorVersion());
             if (driver.getMajorVersion() != AirsonicHsqlDatabase.CURRENT_SUPPORTED_MAJOR_VERSION) {
                 LOG.warn(

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/PlayerUtils.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/PlayerUtils.java
@@ -22,7 +22,6 @@
 package com.tesshu.jpsonic.util;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -109,10 +108,10 @@ public final class PlayerUtils {
     }
 
     public static List<Integer> toIntegerList(int... values) {
+        List<Integer> result = new ArrayList<>();
         if (values == null) {
-            return Collections.emptyList();
+            return result;
         }
-        List<Integer> result = new ArrayList<>(values.length);
         for (int value : values) {
             result.add(value);
         }

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -30,6 +30,20 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <extension>true</extension>
+                    <args>
+                        <arg>-Xannotate</arg>
+                    </args>
+                    <generatePackage>org.subsonic.restapi</generatePackage>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.jvnet.jaxb2_commons</groupId>
+                            <artifactId>jaxb2-basics-annotate</artifactId>
+                            <version>1.0.2</version>
+                        </plugin>
+                    </plugins>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
+++ b/subsonic-rest-api/src/main/resources/subsonic-rest-api.xsd
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+		   jaxb:version="2.1"
+		   jaxb:extensionBindingPrefixes="annox"
+           xmlns:annox="http://annox.dev.java.net"
            xmlns:sub="http://subsonic.org/restapi"
            targetNamespace="http://subsonic.org/restapi"
            attributeFormDefault="unqualified"
@@ -631,6 +635,11 @@
     </xs:complexType>
 
     <xs:complexType name="Error">
+        <xs:annotation>
+            <xs:appinfo>
+                <annox:annotate>@java.lang.SuppressWarnings({"JavaLangClash"})</annox:annotate>
+            </xs:appinfo>
+        </xs:annotation>
         <xs:attribute name="code" type="xs:int" use="required"/>
         <xs:attribute name="message" type="xs:string" use="optional"/>
     </xs:complexType>


### PR DESCRIPTION
The Sonatype warning that occurs while merging Github pull requests will be fixed. They are almost a pointless warning. In rare cases, important issues are included. So reduce noise. 

> Reduce noise -> For important issues, sub issues will be issued -> Track and resolve sub issues

In this pull request, noise and sub-issues on google/error-prone will be isolated.

https://lift.sonatype.com/results/github.com/tesshucom/jpsonic/

___

<details>
<summary>google/error-prone</summary>

#### Note



 - Suppressing google/error-prone isn't as convenient as other static tools, yet.
 - It includes false positives for uncorrectable ~~xjc and~~ ANTLR auto-generated code. (It is hard to completely reduce noise for ANTLR, now.)
 - Issues that require additional verification are not covered here. Marked pending and another issue will be issued.

#### Fixes

 - [x] AlmostJavadoc
 - [x] ArgumentSelectionDefectChecker
 - [x] BadImport
 - [x] DateFormatConstant
 - [x] EmptyBlockTag
 - [x] EqualsGetClass
 - [x] ImmutableEnumChecker
 - [x] InconsistentCapitalization
 - [x] InlineMeSuggester
 - [x] JavaLangClash
 - [x] LoopOverCharArray
 - [x] MissingSummary
 - [x] MixedMutabilityReturnType
 - [x] ObjectEqualsForPrimitives
 - [x] StringSplitter
 - [x] UnicodeEscape
 - [x] UnnecessaryLambda
 - [x] UnsafeReflectiveConstructionCast
 - [x] UnusedVariable

</details>

#### Fixed

![image](https://user-images.githubusercontent.com/27724847/174842420-237d8182-9445-4ffb-b9df-6d6b75564865.png)


#### Pending (Sub issues)

 - Date comparison(Collectively later) #1566 
   - UndefinedEquals
   - JavaUtilDate
   - JavaTimeDefaultTimeZone
 - Use ArrayList over LinkedList(Needs test) #1567
   - JdkObsolete

#### Impossible (False possitive)

Ignored for a while because there is no good way.

There is no very sophisticated method of suppression. The idea that the problem should be fixed is predominant, but it may be an ideal theory because there are always tool conflicts...

 - UnnecessaryParentheses : Warning for auto-generated code with ANTLR
   - The annotation interpretation of google/error-prone is unique and partial. "all" is ignored.
     - ``https://github.com/google/error-prone/issues/329``
     - ``https://github.com/google/error-prone/issues/463``
   - Suppressions can be added to ANTLR (Will be more complicated than necessary). Should not do it.
 - OperatorPrecedence
   - Compete with PMD. If anything, PMD is Cool.
   - There are many (19). I don't even want to add suppression annotations


