### PR TITLE
Remove guava

### DIFF
--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -229,10 +229,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.checkerframework</groupId>
             <artifactId>checker-qual</artifactId>
         </dependency>

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicFolder.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicFolder.java
@@ -25,9 +25,8 @@ import java.io.Serializable;
 import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
-
-import com.google.common.base.Objects;
 
 /**
  * Represents a top level directory in which music or other media is stored.
@@ -103,7 +102,7 @@ public class MusicFolder implements Serializable {
         if (!(o instanceof MusicFolder)) {
             return false;
         }
-        return Objects.equal(id, ((MusicFolder) o).id);
+        return Objects.equals(id, ((MusicFolder) o).id);
     }
 
     @Override

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/security/JWTAuthenticationProvider.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/security/JWTAuthenticationProvider.java
@@ -23,6 +23,7 @@ package com.tesshu.jpsonic.security;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import com.auth0.jwt.interfaces.Claim;
@@ -88,15 +89,14 @@ public class JWTAuthenticationProvider implements AuthenticationProvider {
         if (!Objects.equals(expected.getPath(), requested.getPath())) {
             return false;
         }
+        return expectedJWTParam(expected.getQueryParams(), requested.getQueryParams());
+    }
 
-        MapDifference<String, List<String>> difference = Maps.difference(expected.getQueryParams(),
-                requested.getQueryParams());
-        if (!difference.entriesDiffering().isEmpty() || !difference.entriesOnlyOnLeft().isEmpty()
+    static boolean expectedJWTParam(@NonNull Map<String, List<String>> left, @NonNull Map<String, List<String>> right) {
+        MapDifference<String, List<String>> difference = Maps.difference(left, right);
+        return !(!difference.entriesDiffering().isEmpty() || !difference.entriesOnlyOnLeft().isEmpty()
                 || difference.entriesOnlyOnRight().size() != 1
-                || difference.entriesOnlyOnRight().get(JWTSecurityService.JWT_PARAM_NAME) == null) {
-            return false;
-        }
-        return true;
+                || difference.entriesOnlyOnRight().get(JWTSecurityService.JWT_PARAM_NAME) == null);
     }
 
     @Override

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/security/JWTAuthenticationProvider.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/security/JWTAuthenticationProvider.java
@@ -31,8 +31,10 @@ import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import com.tesshu.jpsonic.service.JWTSecurityService;
 import org.apache.commons.lang3.StringUtils;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.Authentication;
@@ -77,23 +79,13 @@ public class JWTAuthenticationProvider implements AuthenticationProvider {
         return new JWTAuthenticationToken(authorities, rawToken, authentication.getRequestedPath());
     }
 
-    private static boolean roughlyEqual(String expectedRaw, String requestedPathRaw) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Comparing expected [{}] vs requested [{}]", expectedRaw, requestedPathRaw);
-        }
+    static boolean roughlyEqual(@Nullable String expectedRaw, @NonNull String requestedPathRaw) {
         if (StringUtils.isEmpty(expectedRaw)) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("False: empty expected");
-            }
             return false;
         }
         UriComponents expected = UriComponentsBuilder.fromUriString(expectedRaw).build();
         UriComponents requested = UriComponentsBuilder.fromUriString(requestedPathRaw).build();
         if (!Objects.equals(expected.getPath(), requested.getPath())) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("False: expected path [{}] does not match requested path [{}]", expected.getPath(),
-                        requested.getPath());
-            }
             return false;
         }
 
@@ -102,10 +94,6 @@ public class JWTAuthenticationProvider implements AuthenticationProvider {
         if (!difference.entriesDiffering().isEmpty() || !difference.entriesOnlyOnLeft().isEmpty()
                 || difference.entriesOnlyOnRight().size() != 1
                 || difference.entriesOnlyOnRight().get(JWTSecurityService.JWT_PARAM_NAME) == null) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("False: expected query params [{}] do not match requested query params [{}]",
-                        expected.getQueryParams(), requested.getQueryParams());
-            }
             return false;
         }
         return true;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/LastFmService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/LastFmService.java
@@ -36,7 +36,6 @@ import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
 
-import com.google.common.collect.Lists;
 import com.tesshu.jpsonic.dao.ArtistDao;
 import com.tesshu.jpsonic.dao.MediaFileDao;
 import com.tesshu.jpsonic.domain.AlbumNotes;
@@ -438,7 +437,9 @@ public class LastFmService {
 
     private LastFmCoverArt convert(Album album) {
         String imageUrl = null;
-        for (ImageSize imageSize : Lists.reverse(Arrays.asList(ImageSize.values()))) {
+        List<ImageSize> imageSizes = Arrays.asList(ImageSize.values());
+        Collections.reverse(imageSizes);
+        for (ImageSize imageSize : imageSizes) {
             imageUrl = StringUtils.trimToNull(album.getImageURL(imageSize));
             if (imageUrl != null) {
                 break;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/CustomContentDirectory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/CustomContentDirectory.java
@@ -21,9 +21,10 @@
 
 package com.tesshu.jpsonic.service.upnp;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 
-import com.google.common.collect.Lists;
 import org.fourthline.cling.support.contentdirectory.AbstractContentDirectoryService;
 import org.fourthline.cling.support.contentdirectory.ContentDirectoryException;
 import org.fourthline.cling.support.contentdirectory.DIDLParser;
@@ -34,7 +35,7 @@ import org.fourthline.cling.support.model.SortCriterion;
 public abstract class CustomContentDirectory extends AbstractContentDirectoryService {
 
     public CustomContentDirectory() {
-        super(Lists.newArrayList("*"), Lists.newArrayList());
+        super(Arrays.asList("*"), Collections.emptyList());
     }
 
     @SuppressWarnings("PMD.AvoidCatchingGenericException") // fourthline/DIDLParser#generate

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/spring/AirsonicSpringLiquibase.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/spring/AirsonicSpringLiquibase.java
@@ -27,7 +27,6 @@ import java.sql.Connection;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import liquibase.Scope;
 import liquibase.database.Database;
 import liquibase.database.DatabaseConnection;
@@ -53,7 +52,7 @@ public class AirsonicSpringLiquibase extends liquibase.integration.spring.Spring
             // Suppress console log. May be fixed in the future. #1476
             Scope.enter(Map.of(Scope.Attr.ui.name(), new LoggerUIService()));
         } catch (Exception e) {
-            throw new UncheckedExecutionException(e);
+            throw new LiquibaseException(e);
         }
 
         LOG.trace("Starting Liquibase Update");

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/spring/CustomPropertySourceConfigurer.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/spring/CustomPropertySourceConfigurer.java
@@ -22,8 +22,9 @@
 package com.tesshu.jpsonic.spring;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import com.google.common.collect.Lists;
 import com.tesshu.jpsonic.service.ApacheCommonsConfigurationService;
 import org.apache.commons.configuration2.ImmutableConfiguration;
 import org.apache.commons.lang3.StringUtils;
@@ -59,7 +60,8 @@ public class CustomPropertySourceConfigurer
             dataSourceConfigType = DataSourceConfigType.LEGACY;
         }
         String dataSourceTypeProfile = StringUtils.lowerCase(dataSourceConfigType.name());
-        List<String> existingProfiles = Lists.newArrayList(ctx.getEnvironment().getActiveProfiles());
+        List<String> existingProfiles = Stream.of(ctx.getEnvironment().getActiveProfiles())
+                .collect(Collectors.toList());
         existingProfiles.add(dataSourceTypeProfile);
         ctx.getEnvironment().setActiveProfiles(existingProfiles.toArray(new String[0]));
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/MusicFolderTestDataUtils.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/MusicFolderTestDataUtils.java
@@ -27,7 +27,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.tesshu.jpsonic.domain.MusicFolder;
 
 public final class MusicFolderTestDataUtils {
@@ -42,7 +41,7 @@ public final class MusicFolderTestDataUtils {
             return Path.of(MusicFolderTestDataUtils.class.getResource(BASE_RESOURCES).toURI()).toString()
                     + java.io.File.separator;
         } catch (URISyntaxException e) {
-            throw new UncheckedExecutionException(e);
+            throw new IllegalArgumentException(BASE_RESOURCES + "is not found", e);
         }
     }
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MusicFolderTestDataUtils.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MusicFolderTestDataUtils.java
@@ -24,8 +24,6 @@ package com.tesshu.jpsonic.dao;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 
-import com.google.common.util.concurrent.UncheckedExecutionException;
-
 public final class MusicFolderTestDataUtils {
 
     private static final String BASE_RESOURCES = "/MEDIAS/";
@@ -37,7 +35,7 @@ public final class MusicFolderTestDataUtils {
         try {
             return Path.of(MusicFolderTestDataUtils.class.getResource(BASE_RESOURCES).toURI()).toString();
         } catch (URISyntaxException e) {
-            throw new UncheckedExecutionException(e);
+            throw new IllegalArgumentException(BASE_RESOURCES + "is not found", e);
         }
     }
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/security/JWTAuthenticationProviderTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/security/JWTAuthenticationProviderTest.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2022 tesshucom
+ */
+
+package com.tesshu.jpsonic.security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+
+import com.tesshu.jpsonic.service.JWTSecurityService;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class JWTAuthenticationProviderTest {
+
+    @Test
+    void testRoughlyEqual() {
+        assertFalse(JWTAuthenticationProvider.roughlyEqual(null, null));
+        assertThrows(IllegalArgumentException.class, () -> JWTAuthenticationProvider.roughlyEqual("A", null));
+        assertFalse(JWTAuthenticationProvider.roughlyEqual(URI.create("http://dummy1.com/test1").toString(),
+                URI.create("http://dummy2.com/test2").toString()));
+        assertFalse(JWTAuthenticationProvider.roughlyEqual(URI.create("http://dummy.com/test").toString(),
+                URI.create("http://dummy.com/test").toString()));
+        assertFalse(JWTAuthenticationProvider.roughlyEqual(URI.create("http://dummy.com/test?A=dummy1").toString(),
+                URI.create("http://dummy.com/test?A=dummy2").toString()));
+        assertFalse(JWTAuthenticationProvider.roughlyEqual(URI.create("http://dummy.com/test").toString(),
+                URI.create("http://dummy.com/test?A=dummy").toString()));
+        assertFalse(JWTAuthenticationProvider.roughlyEqual(URI.create("http://dummy.com/test?A=dummy").toString(),
+                URI.create("http://dummy.com/test").toString()));
+        assertTrue(JWTAuthenticationProvider.roughlyEqual(URI.create("http://dummy.com/test").toString(),
+                URI.create("http://dummy.com/test?" + JWTSecurityService.JWT_PARAM_NAME + "=value").toString()));
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/security/JWTAuthenticationProviderTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/security/JWTAuthenticationProviderTest.java
@@ -24,11 +24,19 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.tesshu.jpsonic.service.JWTSecurityService;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({ "PMD.AvoidDuplicateLiterals", "PMD.UseConcurrentHashMap" })
 class JWTAuthenticationProviderTest {
 
     @Test
@@ -47,5 +55,163 @@ class JWTAuthenticationProviderTest {
                 URI.create("http://dummy.com/test").toString()));
         assertTrue(JWTAuthenticationProvider.roughlyEqual(URI.create("http://dummy.com/test").toString(),
                 URI.create("http://dummy.com/test?" + JWTSecurityService.JWT_PARAM_NAME + "=value").toString()));
+    }
+
+    @Nested
+    class ExistsDifferenceTest {
+
+        @Test
+        void testCheckNotNull() {
+            Map<String, List<String>> m = new HashMap<>();
+            assertThrows(NullPointerException.class, () -> JWTAuthenticationProvider.expectedJWTParam(null, m));
+            assertThrows(NullPointerException.class, () -> JWTAuthenticationProvider.expectedJWTParam(m, null));
+            assertThrows(NullPointerException.class, () -> JWTAuthenticationProvider.expectedJWTParam(null, null));
+            assertFalse(JWTAuthenticationProvider.expectedJWTParam(m, m));
+        }
+
+        @Test
+        void testNullValue() {
+            Map<String, List<String>> m1 = new HashMap<>();
+            Map<String, List<String>> m2 = new HashMap<>();
+            assertFalse(JWTAuthenticationProvider.expectedJWTParam(m1, m2));
+
+            m1.clear();
+            m2.clear();
+            m1.put("m1A", null);
+            assertFalse(JWTAuthenticationProvider.expectedJWTParam(m1, m2));
+
+            m1.clear();
+            m2.clear();
+            m2.put("m2A", null);
+            assertFalse(JWTAuthenticationProvider.expectedJWTParam(m1, m2));
+
+            m1.clear();
+            m2.clear();
+            m1.put("m1A", null);
+            m2.put("m2A", null);
+            assertFalse(JWTAuthenticationProvider.expectedJWTParam(m1, m2));
+
+            m1.clear();
+            m2.clear();
+            m1.put("m1A", null);
+            m1.put("m1B", Arrays.asList("1", null));
+            m2.put("m2A", null);
+            m2.put("m2B", Arrays.asList("1", null));
+            m2.put(JWTSecurityService.JWT_PARAM_NAME, Arrays.asList("param"));
+            assertFalse(JWTAuthenticationProvider.expectedJWTParam(m1, m2));
+        }
+
+        /*
+         * true if present in right
+         */
+        @Test
+        void testExistJWT() {
+            Map<String, List<String>> m1 = new ConcurrentHashMap<>();
+            Map<String, List<String>> m2 = new ConcurrentHashMap<>();
+
+            m1.clear();
+            m2.clear();
+            m1.put(JWTSecurityService.JWT_PARAM_NAME, Arrays.asList("param"));
+            assertFalse(JWTAuthenticationProvider.expectedJWTParam(m1, m2));
+
+            m1.clear();
+            m2.clear();
+            m2.put(JWTSecurityService.JWT_PARAM_NAME, Arrays.asList("param"));
+            assertTrue(JWTAuthenticationProvider.expectedJWTParam(m1, m2));
+
+            m1.clear();
+            m2.clear();
+            m1.put(JWTSecurityService.JWT_PARAM_NAME, Arrays.asList("param"));
+            m2.put(JWTSecurityService.JWT_PARAM_NAME, Arrays.asList("param"));
+            assertFalse(JWTAuthenticationProvider.expectedJWTParam(m1, m2));
+        }
+
+        /*
+         * List size is equivalent except for JWT_PARAM
+         */
+        @Test
+        void testKeySizeWithJWT() {
+            Map<String, List<String>> m1 = new ConcurrentHashMap<>();
+            Map<String, List<String>> m2 = new ConcurrentHashMap<>();
+
+            m1.clear();
+            m2.clear();
+            m2.put(JWTSecurityService.JWT_PARAM_NAME, Arrays.asList("param"));
+            assertTrue(JWTAuthenticationProvider.expectedJWTParam(m1, m2));
+
+            m1.clear();
+            m2.clear();
+            m1.put("A", Arrays.asList("A"));
+            m2.put(JWTSecurityService.JWT_PARAM_NAME, Arrays.asList("param"));
+            assertFalse(JWTAuthenticationProvider.expectedJWTParam(m1, m2));
+
+            m1.clear();
+            m2.clear();
+            m2.put(JWTSecurityService.JWT_PARAM_NAME, Arrays.asList("param"));
+            m2.put("A", Arrays.asList("A"));
+            assertFalse(JWTAuthenticationProvider.expectedJWTParam(m1, m2));
+        }
+
+        /*
+         * Lists excluding JWT_PARAM are equivalent
+         */
+        @Test
+        void testListEquivalence() {
+            Map<String, List<String>> m1 = new HashMap<>();
+            Map<String, List<String>> m2 = new HashMap<>();
+
+            m1.put("A", Arrays.asList("123"));
+            m2.put("A", Arrays.asList("123"));
+            m2.put(JWTSecurityService.JWT_PARAM_NAME, Arrays.asList("param"));
+            assertTrue(JWTAuthenticationProvider.expectedJWTParam(m1, m2));
+
+            m1.clear();
+            m2.clear();
+            m1.put("A", Arrays.asList("123"));
+            m2.put("A", Arrays.asList("456"));
+            m2.put(JWTSecurityService.JWT_PARAM_NAME, Arrays.asList("param"));
+            assertFalse(JWTAuthenticationProvider.expectedJWTParam(m1, m2));
+
+            m1.clear();
+            m2.clear();
+            m1.put("A", Arrays.asList("123"));
+            m2.put("B", Arrays.asList("123"));
+            m2.put(JWTSecurityService.JWT_PARAM_NAME, Arrays.asList("param"));
+            assertFalse(JWTAuthenticationProvider.expectedJWTParam(m1, m2));
+        }
+
+        /*
+         * List equivalence will be determined ignoring the element order
+         */
+        @Test
+        void testSorted() {
+            SortedMap<String, List<String>> m1 = new TreeMap<>();
+            SortedMap<String, List<String>> m2 = new TreeMap<>();
+
+            m1.put("A", Arrays.asList("123"));
+            m1.put("B", Arrays.asList("456"));
+            m2.put("A", Arrays.asList("123"));
+            m2.put("B", Arrays.asList("456"));
+            m2.put(JWTSecurityService.JWT_PARAM_NAME, Arrays.asList("param"));
+            assertTrue(JWTAuthenticationProvider.expectedJWTParam(m1, m2));
+
+            m1.clear();
+            m2.clear();
+            m1.put("A", Arrays.asList("123"));
+            m1.put("B", Arrays.asList("456"));
+            m2.put("B", Arrays.asList("456"));
+            m2.put("A", Arrays.asList("123"));
+            m2.put(JWTSecurityService.JWT_PARAM_NAME, Arrays.asList("param"));
+            assertTrue(JWTAuthenticationProvider.expectedJWTParam(m1, m2));
+
+            m1.clear();
+            m2.clear();
+            m1.put("B", Arrays.asList("456"));
+            m1.put("A", Arrays.asList("123"));
+            m2.put("A", Arrays.asList("123"));
+            m2.put("B", Arrays.asList("456"));
+            m2.put(JWTSecurityService.JWT_PARAM_NAME, Arrays.asList("param"));
+            assertTrue(JWTAuthenticationProvider.expectedJWTParam(m1, m2));
+        }
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PlaylistServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PlaylistServiceTest.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import com.google.common.collect.Lists;
 import com.tesshu.jpsonic.dao.DaoHelper;
 import com.tesshu.jpsonic.dao.JMediaFileDao;
 import com.tesshu.jpsonic.dao.JPlaylistDao;
@@ -59,7 +58,7 @@ class PlaylistServiceTest {
             JMediaFileDao jMediaFileDao = new JMediaFileDao(daoHelper, mediaFileDao);
             JPlaylistDao jPlaylistDao = new JPlaylistDao(daoHelper, mock(PlaylistDao.class));
             playlistService = new PlaylistService(jMediaFileDao, jPlaylistDao, mock(SecurityService.class),
-                    mock(SettingsService.class), Lists.newArrayList(new DefaultPlaylistExportHandler(mediaFileDao)),
+                    mock(SettingsService.class), Arrays.asList(new DefaultPlaylistExportHandler(mediaFileDao)),
                     Collections.emptyList(), null);
         }
 
@@ -131,7 +130,7 @@ class PlaylistServiceTest {
             JPlaylistDao jPlaylistDao = new JPlaylistDao(daoHelper, playlistDao);
             DefaultPlaylistImportHandler importHandler = new DefaultPlaylistImportHandler(mediaFileService);
             playlistService = new PlaylistService(jMediaFileDao, jPlaylistDao, mock(SecurityService.class),
-                    mock(SettingsService.class), Collections.emptyList(), Lists.newArrayList(importHandler), null);
+                    mock(SettingsService.class), Collections.emptyList(), Arrays.asList(importHandler), null);
             actual = ArgumentCaptor.forClass(Playlist.class);
             medias = ArgumentCaptor.forClass(List.class);
         }
@@ -300,7 +299,7 @@ class PlaylistServiceTest {
             JPlaylistDao jPlaylistDao = new JPlaylistDao(daoHelper, playlistDao);
             DefaultPlaylistImportHandler importHandler = new DefaultPlaylistImportHandler(mediaFileService);
             playlistService = new PlaylistService(jMediaFileDao, jPlaylistDao, mock(SecurityService.class),
-                    settingsService, Collections.emptyList(), Lists.newArrayList(importHandler), null);
+                    settingsService, Collections.emptyList(), Arrays.asList(importHandler), null);
         }
 
         @Test

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/ServiceMockUtils.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/ServiceMockUtils.java
@@ -19,12 +19,12 @@
 
 package com.tesshu.jpsonic.service;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
 import javax.servlet.http.HttpServletRequest;
 
-import com.google.common.collect.ImmutableList;
 import com.tesshu.jpsonic.dao.TranscodingDao;
 import com.tesshu.jpsonic.domain.FileModifiedCheckScheme;
 import com.tesshu.jpsonic.domain.IndexScheme;
@@ -41,7 +41,7 @@ public final class ServiceMockUtils {
 
     public static final String ADMIN_NAME = "admin";
 
-    private static final List<Transcoding> DEFAULT_TRANSCODINGS = ImmutableList.of(
+    private static final List<Transcoding> DEFAULT_TRANSCODINGS = Arrays.asList(
             new Transcoding(0, "mp3 audio", "mp3 ogg oga aac m4a flac wav wma aif aiff ape mpc shn", "mp3",
                     "ffmpeg -i %s -map 0:0 -b:a %bk -v 0 -f mp3 -", null, null, true),
             new Transcoding(1, "flv/h264 video", "avi mpg mpeg mp4 m4v mkv mov wmv ogv divx m2ts", "flv",

--- a/pom.xml
+++ b/pom.xml
@@ -182,17 +182,6 @@
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>31.1-jre</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>org.checkerframework</artifactId>
-                        <groupId>checker-qual</groupId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
                 <groupId>org.checkerframework</groupId>
                 <artifactId>checker-qual</artifactId>
                 <scope>compile</scope>


### PR DESCRIPTION
Fix to remove guava. And the library will be removed.

 - A long time ago, in the transitional period of Java syntax, guava had some usefulness. It makes little sense now. (Although it may still be used in Java on Android....)
 - Guava does have some useful features. Subsonic used the function in only one place to get the difference in the map. If anything, it should be rewritten to clarify the case.

In other words, if you rewrite it to the current Java syntax, guava is almost unnecessary.

Also it has some security bugs. (Not relevant to this project)

 - [sonatype-2020-0926] CWE-379
   > guava - Creation of Temporary File in Directory with Insecure Permissions [CVE-2020-8908] The software creates a temporary file in a directory whose permissions allow unintended actors to determine the file's existence or otherwise access that file.
 - ``https://github.com/google/guava/issues/4011``

It's better to remove less-needed library dependencies.

#### Fixes

 - [x] Add test for JWTAuthenticationProvider
 - [x] Fix JWTAuthenticationProvider not to use guava
 - [x] Fix to remove guava (9 classes)
