### PR TITLE
Add findsecbugs-plugin

### DIFF
--- a/contrib/i18n_fix_encoding.go
+++ b/contrib/i18n_fix_encoding.go
@@ -25,7 +25,7 @@ func main() {
 
 	// Iterate over files
 	for _, path := range files {
-		f, err := os.Open(path)
+		f, err := os.Open(filepath.Clean(path))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/contrib/i18n_fix_encoding.go
+++ b/contrib/i18n_fix_encoding.go
@@ -46,7 +46,7 @@ func main() {
 		// If any changes where made write them to file
 		if string(data) != out {
 			fmt.Printf("Changes where made for %s\n", path)
-			if err := ioutil.WriteFile(path, []byte(out), 0644); err != nil {
+			if err := ioutil.WriteFile(path, []byte(out), 0600); err != nil {
 				log.Fatal(err)
 			}
 		}

--- a/jpsonic-main/src/main/webapp/script/jpsonic/coverartContainer.js
+++ b/jpsonic-main/src/main/webapp/script/jpsonic/coverartContainer.js
@@ -11,6 +11,6 @@ function adjustCoverartContainer() {
 
 $(document).ready(function () {
   adjustCoverartContainer();
-  function onResize(c,t){onresize=function(){clearTimeout(t);t=setTimeout(c,300)};return c};
+  function onResize(c,t){onresize=function(){clearTimeout(t);t=setTimeout(c,300)};return c}
   onResize(function() {adjustCoverartContainer();})();
 });

--- a/jpsonic-main/src/main/webapp/script/jpsonic/dialogsTop.js
+++ b/jpsonic-main/src/main/webapp/script/jpsonic/dialogsTop.js
@@ -1,7 +1,7 @@
-function refShowPlaylist4Album() {};
-function refAppendPlaylist4Album(playlistId) {};
-function refShowPlaylist4Playqueue() {};
-function refAppendPlaylist4Playqueue(playlistId) {};
+function refShowPlaylist4Album() {}
+function refAppendPlaylist4Album(playlistId) {}
+function refShowPlaylist4Playqueue() {}
+function refAppendPlaylist4Playqueue(playlistId) {}
 
 function createDialogVoiceInput(lang, closeText) {
     const ps = new PrefferedSize(480, 180);
@@ -38,7 +38,7 @@ function createDialogVoiceInput(lang, closeText) {
                         $("#query").val(top.$("#voice-input-result").text());
                         executeInstantSearch();
                     }
-                };
+                }
                 sr.onend = onEnd;
                 sr.onerror = function(e) {console.log(e);onEnd(e)}
                 sr.start();

--- a/jpsonic-main/src/main/webapp/script/jpsonic/truncate.js
+++ b/jpsonic-main/src/main/webapp/script/jpsonic/truncate.js
@@ -22,6 +22,6 @@ function checkTruncate(tabularWidthBase, tabular, controlLength, cols) {
 }
 function initTruncate(tabularWidthBase, tabular, controlLength, cols) {
     checkTruncate(tabularWidthBase, tabular, controlLength, cols);
-    function onResize(c, t){onresize=function(){clearTimeout(t);t=setTimeout(c, 500)};return c};
+    function onResize(c, t){onresize=function(){clearTimeout(t);t=setTimeout(c, 500)};return c}
     onResize(function() {checkTruncate(tabularWidthBase, tabular, controlLength, cols)})();
 }

--- a/pom.xml
+++ b/pom.xml
@@ -541,6 +541,15 @@
                             <version>4.7.0</version>
                         </dependency>
                     </dependencies>
+                    <configuration>
+                        <plugins>
+                            <plugin>
+                                <groupId>com.h3xstream.findsecbugs</groupId>
+                                <artifactId>findsecbugs-plugin</artifactId>
+                                <version>1.12.0</version>
+                            </plugin>
+                        </plugins>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.owasp</groupId>


### PR DESCRIPTION
Related #1561

  - FindSecBugs will be sorted out(It's the second most complaining after error-prone). findsecbugs-plugin is added.   -   
    - However, it is not executed at build time. findbugs and findsecbugs will be used by manual execution.
  - Small fix for GoSec, ESLint
  - Static tools other than error-prone/FindSecBugs are not very high priority. After organizing FindSecBugs to some extent, the whole review will be done again. 
    - This is due to a lot of false positives and duplication between multiple tools.
    - Also, due to the nature of the tool, if there are too many warnings and noises, the check process will stop and you will not be able to grasp the entire problem. While organizing, another Sub-issues will be issued as needed.
