### PR TITLE
Change shutdown timeout

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/concurrent/ExecutorConfiguration.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/concurrent/ExecutorConfiguration.java
@@ -42,10 +42,10 @@ public class ExecutorConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(ExecutorConfiguration.class);
 
-    protected static final int SHORT_AWAIT_TERMINATION = 20_000;
-    protected static final int PODCAST_DOWNLOAD_AWAIT_TERMINATION = 30_000;
-    protected static final int PODCAST_REFRESH_AWAIT_TERMINATION = 30_000;
-    protected static final int SCAN_AWAIT_TERMINATION = 30_000;
+    protected static final int SHORT_AWAIT_TERMINATION = 10_000;
+    protected static final int PODCAST_DOWNLOAD_AWAIT_TERMINATION = 25_000;
+    protected static final int PODCAST_REFRESH_AWAIT_TERMINATION = 25_000;
+    protected static final int SCAN_AWAIT_TERMINATION = 25_000;
 
     private final ShortTaskPoolConfiguration poolConf;
 

--- a/jpsonic-main/src/main/resources/application.properties
+++ b/jpsonic-main/src/main/resources/application.properties
@@ -20,7 +20,7 @@ logging.pattern.file=%d{yyyy-MM-dd HH:mm:ss.SSS} %5p --- %-40.40logger{32} : %m%
 
 
 server.shutdown=graceful
-spring.lifecycle.timeout-per-shutdown-phase=40s
+spring.lifecycle.timeout-per-shutdown-phase=29s
 spring.mvc.async.request-timeout=300000
 
 server.max-http-header-size=65536

--- a/jpsonic-main/src/test/resources/application.properties
+++ b/jpsonic-main/src/test/resources/application.properties
@@ -20,7 +20,7 @@ DatabaseConfigEmbedUsername=sa
 DatabaseConfigEmbedPassword=
 
 server.shutdown=graceful
-spring.lifecycle.timeout-per-shutdown-phase=40s
+spring.lifecycle.timeout-per-shutdown-phase=29s
 spring.mvc.async.request-timeout=300000
 
 server.max-http-header-size=65536


### PR DESCRIPTION
### Problem description

Change shutdown timeout to 29 seconds. This is because the timeout phase timeout value, including Docker, is fix.

 - In a general environment, it is often set to about 30 seconds.
 - For this reason, important processing had a grace period of about 30 seconds. (Many threading await times had been set to 30 seconds)
 - This fix will change the entire shutdown phase to 29 seconds (Many threading await times will be set to 25 seconds)


### Additional notes

 - In Docker this value is managed by stop_grace_period, which is 10 seconds by default. A light weight shutdown. That's good, but 10 seconds is rough.
 - Jpdonic assumes that stop_grace_period is 30s.
 - The settings related to the number of seconds should be as follows:
   - **Docker : stop_grace_period**  > **Spring : spring.lifecycle.timeout-per-shutdown-phase**  > **The await termination value of ThreadPool**
   - ExecutorConfiguration manages threads with long processing time. We can protect from a violent shutdown, by setting the appropriate '@DependOn' for these Pooling, cache, and 'liquibase' been.

This is the current workaround.

