### PR TITLE
Bump Jetty from 9 to 10.0.11

### DIFF
--- a/jpsonic-main/cve-suppressed.xml
+++ b/jpsonic-main/cve-suppressed.xml
@@ -38,6 +38,63 @@
         <cve>CVE-2022-31569</cve>
     </suppress>
 
+    <!-- Temporary false positive(Jetty10.x) -->
+    <suppress>
+        <notes><![CDATA[It's affects the versions of jetty embedded in the nutch package as shipped with Red Hat Satellite 5.]]></notes>
+        <gav regex="true">.*jetty-servlet-api.*$</gav>
+        <cve>CVE-2017-7656</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[It's affects the versions of jetty embedded in the nutch package as shipped with Red Hat Satellite 5.]]></notes>
+        <gav regex="true">.*jetty-servlet-api.*$</gav>
+        <cve>CVE-2017-7657</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[It's affects the versions of jetty embedded in the nutch package as shipped with Red Hat Satellite 5.]]></notes>
+        <gav regex="true">.*jetty-servlet-api.*$</gav>
+        <cve>CVE-2017-7658</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[False positive for the dumping servlet information leak in jetty before 6.1.22.]]></notes>
+        <gav regex="true">.*jetty.*$</gav>
+        <cve>CVE-2009-5045</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[False positive. Up to (excluding)9.4.6.]]></notes>
+        <gav regex="true">.*jetty.*$</gav>
+        <cve>CVE-2017-9735</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[False positive. 10.0.0.alpha1 thru 10.0.0.beta2 on Unix like systems.]]></notes>
+        <gav regex="true">.*jetty.*$</gav>
+        <cve>CVE-2020-27216</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[False positive. In jetty before 6.1.22.]]></notes>
+        <gav regex="true">.*jetty.*$</gav>
+        <cve>CVE-2009-5046</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[False positive(<= 10.0.2). ConcatServlet is also not used.]]></notes>
+        <gav regex="true">.*jetty.*$</gav>
+        <cve>CVE-2021-28169</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[False positive(<= 10.0.2).]]></notes>
+        <gav regex="true">.*jetty.*$</gav>
+        <cve>CVE-2021-34428</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[False positive(<= 10.0.9).]]></notes>
+        <gav regex="true">.*jetty-servlet-api.*$</gav>
+        <cve>CVE-2022-2047</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[False positive(<= 10.0.9).]]></notes>
+        <gav regex="true">.*jetty-servlet-api.*$</gav>
+        <cve>CVE-2022-2048</cve>
+    </suppress>
+
     <!-- Permanent false positive -->
     <suppress>
         <notes>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -510,20 +510,14 @@
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>jakarta.websocket</groupId>
-                    <artifactId>jakarta.websocket-all</artifactId>
+                    <groupId>org.eclipse.jetty.websocket</groupId>
+                    <artifactId>websocket-server</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>jakarta.websocket</groupId>
-                    <artifactId>jakarta.websocket-api</artifactId>
+                    <groupId>org.eclipse.jetty.websocket</groupId>
+                    <artifactId>javax-websocket-server-impl</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.websocket</groupId>
-            <artifactId>jakarta.websocket-all</artifactId>
-            <version>2.1.0</version>
-            <type>pom</type>
         </dependency>
 
         <dependency>

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/JettyApplicationHelper.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/JettyApplicationHelper.java
@@ -21,9 +21,6 @@ package com.tesshu.jpsonic;
 
 import java.util.Arrays;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.eclipse.jetty.http.HttpCompliance;
-import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.ServerConnector;
 import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory;
 
@@ -37,12 +34,6 @@ public final class JettyApplicationHelper {
             Arrays.stream(server.getConnectors()).filter(c -> c instanceof ServerConnector).forEach(c -> {
                 ServerConnector serverConnector = (ServerConnector) c;
                 serverConnector.setIdleTimeout(300_000);
-                @Nullable
-                HttpConnectionFactory hcf = serverConnector.getConnectionFactory(HttpConnectionFactory.class);
-                if (hcf != null) {
-                    // #953
-                    hcf.setHttpCompliance(HttpCompliance.RFC7230_NO_AMBIGUOUS_URIS);
-                }
             });
         });
     }

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <jackson.version>2.13.3</jackson.version>
         <tomcat.version>9.0.64</tomcat.version>
         <jetty.schema.version>3.1.2</jetty.schema.version>
-        <jetty.version>9.4.48.v20220622</jetty.version>
+        <jetty.version>10.0.10</jetty.version>
         <jetty-jsp.version>9.4.48.v20220622</jetty-jsp.version>
         <pmd.version>6.47.0</pmd.version>
         <log4j.version>2.18.0</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
         <jackson.version>2.13.3</jackson.version>
         <tomcat.version>9.0.64</tomcat.version>
         <jetty.schema.version>3.1.2</jetty.schema.version>
-        <jetty.version>10.0.10</jetty.version>
-        <jetty-jsp.version>9.4.48.v20220622</jetty-jsp.version>
+        <jetty.version>10.0.11</jetty.version>
+        <jetty-jsp.version>10.0.11</jetty-jsp.version>
         <pmd.version>6.47.0</pmd.version>
         <log4j.version>2.18.0</log4j.version>
         <logback.version>1.2.11</logback.version>
@@ -301,38 +301,8 @@
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.eclipse.jetty.websocket</groupId>
-                <artifactId>websocket-server</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty.websocket</groupId>
-                <artifactId>websocket-common</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty.websocket</groupId>
-                <artifactId>websocket-api</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty.websocket</groupId>
-                <artifactId>websocket-client</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-client</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty.websocket</groupId>
-                <artifactId>websocket-servlet</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty.websocket</groupId>
-                <artifactId>javax-websocket-server-impl</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
@@ -358,11 +328,6 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-jndi</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty.websocket</groupId>
-                <artifactId>javax-websocket-client-impl</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
@@ -729,8 +694,6 @@
                                 <ignoredUnusedDeclaredDependency>org.springframework.boot:spring-boot*</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>jakarta.xml.bind:jakarta.xml.bind-api</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api</ignoredUnusedDeclaredDependency>
-                                <!-- Needed by Jetty compile only -->
-                                <ignoredUnusedDeclaredDependency>jakarta.websocket:jakarta.websocket-all</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                             <ignoredNonTestScopedDependencies>


### PR DESCRIPTION
Jetty 9.x was very long-lived, but already used to the limit.
 - Announcement for End of Community Support for Jetty 9.x
 - ``https://github.com/eclipse/jetty.project/issues/7958``

10.x will be the current standard. As in #839