### PR TITLE
Change specification of font

### DIFF
--- a/install/docker/alpine-jdk17/Dockerfile
+++ b/install/docker/alpine-jdk17/Dockerfile
@@ -13,12 +13,16 @@ ENV JPSONIC_DIR=/jpsonic \
     LANG=C.UTF-8 \
     TIME_ZONE=GB \
     BANNER_MODE=on \
+    SCAN_ON_BOOT=false \
+    EMBEDDED_FONT=false \
+    MIME_DSF=audio/x-dsd \
+    MIME_DFF=audio/x-dsd \
     JAVA_OPTS=-Xmx512m
 
 WORKDIR $JPSONIC_DIR
 
 RUN apk --no-cache add \
-    su-exec \ 
+    su-exec \
     musl-locales \
     ffmpeg \
     bash \

--- a/install/docker/alpine-jdk17/entry-point.sh
+++ b/install/docker/alpine-jdk17/entry-point.sh
@@ -42,6 +42,10 @@ if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
      -Djpsonic.defaultMusicFolder="$JPSONIC_DIR"/music \
      -Djpsonic.defaultPodcastFolder="$JPSONIC_DIR"/podcasts \
      -Djpsonic.defaultPlaylistFolder="$JPSONIC_DIR"/playlists \
+     -Djpsonic.scan.onboot="$SCAN_ON_BOOT" \
+     -Djpsonic.embeddedfont="$EMBEDDED_FONT" \
+     -Djpsonic.mime.dsf="$MIME_DSF" \
+     -Djpsonic.mime.dff="$MIME_DFF" \
      -DUPNP_PORT="$UPNP_PORT" \
      -Dspring.main.banner-mode="$BANNER_MODE" \
      -Djava.awt.headless=true \

--- a/install/docker/alpine-jdk17/entry-point.sh
+++ b/install/docker/alpine-jdk17/entry-point.sh
@@ -21,9 +21,10 @@ fi
 addgroup "$username" "$groupname"
 
 su-exec "$username":"$groupname" mkdir -p "$JPSONIC_DIR"/data/transcode
-if [ ! -e "$JPSONIC_DIR"/data/transcode/ffmpeg ]; then
-    su-exec "$username":"$groupname" ln -fs /usr/bin/ffmpeg "$JPSONIC_DIR"/data/transcode/ffmpeg
-fi
+rm -f "$JPSONIC_DIR"/data/transcode/ffmpeg
+su-exec "$username":"$groupname" ln -fs /usr/bin/ffmpeg "$JPSONIC_DIR"/data/transcode/ffmpeg
+rm -f "$JPSONIC_DIR"/data/transcode/ffprobe
+su-exec "$username":"$groupname" ln -fs /usr/bin/ffprobe "$JPSONIC_DIR"/data/transcode/ffprobe
 
 if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
 

--- a/install/docker/jammy/Dockerfile
+++ b/install/docker/jammy/Dockerfile
@@ -13,6 +13,10 @@ ENV JPSONIC_DIR=/jpsonic \
     LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8 \
     TIME_ZONE=GB \
     BANNER_MODE=on \
+    SCAN_ON_BOOT=false \
+    EMBEDDED_FONT=false \
+    MIME_DSF=audio/x-dsd \
+    MIME_DFF=audio/x-dsd \
     JAVA_OPTS=-Xmx512m
 
 WORKDIR $JPSONIC_DIR

--- a/install/docker/jammy/entry-point.sh
+++ b/install/docker/jammy/entry-point.sh
@@ -42,6 +42,10 @@ if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
      -Djpsonic.defaultMusicFolder="$JPSONIC_DIR"/music \
      -Djpsonic.defaultPodcastFolder="$JPSONIC_DIR"/podcasts \
      -Djpsonic.defaultPlaylistFolder="$JPSONIC_DIR"/playlists \
+     -Djpsonic.scan.onboot="$SCAN_ON_BOOT" \
+     -Djpsonic.embeddedfont="$EMBEDDED_FONT" \
+     -Djpsonic.mime.dsf="$MIME_DSF" \
+     -Djpsonic.mime.dff="$MIME_DFF" \
      -DUPNP_PORT="$UPNP_PORT" \
      -Dspring.main.banner-mode="$BANNER_MODE" \
      -Djava.awt.headless=true \

--- a/install/docker/jammy/entry-point.sh
+++ b/install/docker/jammy/entry-point.sh
@@ -21,9 +21,10 @@ fi
 addgroup "$username" "$groupname"
 
 gosu "$username":"$groupname" mkdir -p "$JPSONIC_DIR"/data/transcode
-if [ ! -e "$JPSONIC_DIR"/data/transcode/ffmpeg ]; then
-    gosu "$username":"$groupname" ln -fs /usr/bin/ffmpeg "$JPSONIC_DIR"/data/transcode/ffmpeg
-fi
+rm -f "$JPSONIC_DIR"/data/transcode/ffmpeg
+gosu "$username":"$groupname" ln -fs /usr/bin/ffmpeg "$JPSONIC_DIR"/data/transcode/ffmpeg
+rm -f "$JPSONIC_DIR"/data/transcode/ffprobe
+gosu "$username":"$groupname" ln -fs /usr/bin/ffprobe "$JPSONIC_DIR"/data/transcode/ffprobe
 
 if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
 

--- a/install/docker/liberica-jdk11/Dockerfile
+++ b/install/docker/liberica-jdk11/Dockerfile
@@ -13,22 +13,22 @@ ENV JPSONIC_DIR=/jpsonic \
     LANG=en_US.UTF-8 \
     TIME_ZONE=GB \
     BANNER_MODE=on \
+    SCAN_ON_BOOT=false \
+    EMBEDDED_FONT=false \
+    MIME_DSF=audio/x-dsd \
+    MIME_DFF=audio/x-dsd \
     JAVA_OPTS=-Xmx256m
 
 WORKDIR $JPSONIC_DIR
 
 RUN apk --no-cache add \
-    su-exec \ 
+    su-exec \
     ffmpeg \
     bash \
-    fontconfig \
-    font-noto-cjk \
     tini \
     curl \
-    && rm -rf /var/cache/apk/* \
-    && rm /usr/share/fonts/noto/NotoSansCJK-Bold.ttc \
-    && rm /usr/share/fonts/noto/NotoSerifCJK-Bold.ttc \
-    && rm /usr/share/fonts/noto/NotoSerifCJK-Regular.ttc
+    && rm -rf /var/cache/apk/*
+COPY fontconfig.properties "$JAVA_HOME"/lib/fontconfig.properties
 
 EXPOSE $JPSONIC_PORT
 EXPOSE $UPNP_PORT
@@ -36,9 +36,9 @@ EXPOSE 1900/udp
 EXPOSE 3333
 
 VOLUME \
-    $JPSONIC_DIR/data  \
-    $JPSONIC_DIR/music  \
-    $JPSONIC_DIR/playlists  \
+    $JPSONIC_DIR/data \
+    $JPSONIC_DIR/music \
+    $JPSONIC_DIR/playlists \
     $JPSONIC_DIR/podcasts
 
 HEALTHCHECK --interval=30s --timeout=2s CMD wget -q http://localhost:"$JPSONIC_PORT""$CONTEXT_PATH"rest/ping -O /dev/null || exit 1

--- a/install/docker/liberica-jdk11/entry-point.sh
+++ b/install/docker/liberica-jdk11/entry-point.sh
@@ -42,6 +42,10 @@ if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
      -Djpsonic.defaultMusicFolder="$JPSONIC_DIR"/music \
      -Djpsonic.defaultPodcastFolder="$JPSONIC_DIR"/podcasts \
      -Djpsonic.defaultPlaylistFolder="$JPSONIC_DIR"/playlists \
+     -Djpsonic.scan.onboot="$SCAN_ON_BOOT" \
+     -Djpsonic.embeddedfont="$EMBEDDED_FONT" \
+     -Djpsonic.mime.dsf="$MIME_DSF" \
+     -Djpsonic.mime.dff="$MIME_DFF" \
      -DUPNP_PORT="$UPNP_PORT" \
      -Dspring.main.banner-mode="$BANNER_MODE" \
      -Djava.awt.headless=true \

--- a/install/docker/liberica-jdk11/entry-point.sh
+++ b/install/docker/liberica-jdk11/entry-point.sh
@@ -21,9 +21,10 @@ fi
 addgroup "$username" "$groupname"
 
 su-exec "$username":"$groupname" mkdir -p "$JPSONIC_DIR"/data/transcode
-if [ ! -e "$JPSONIC_DIR"/data/transcode/ffmpeg ]; then
-    su-exec "$username":"$groupname" ln -fs /usr/bin/ffmpeg "$JPSONIC_DIR"/data/transcode/ffmpeg
-fi
+rm -f "$JPSONIC_DIR"/data/transcode/ffmpeg
+su-exec "$username":"$groupname" ln -fs /usr/bin/ffmpeg "$JPSONIC_DIR"/data/transcode/ffmpeg
+rm -f "$JPSONIC_DIR"/data/transcode/ffprobe
+su-exec "$username":"$groupname" ln -fs /usr/bin/ffprobe "$JPSONIC_DIR"/data/transcode/ffprobe
 
 if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
 

--- a/install/docker/liberica-jdk11/fontconfig.properties
+++ b/install/docker/liberica-jdk11/fontconfig.properties
@@ -1,0 +1,2 @@
+version=1
+sequence.allfonts=default

--- a/install/docker/production.yml
+++ b/install/docker/production.yml
@@ -66,6 +66,11 @@ services:
      # Whether to scan at startup. False is recommended for Docker.
      SCAN_ON_BOOT: false
 
+     # If false, use the logical font of JRE (JDK) for Cover Art.
+     # If true, preferentially use embedded fonts.
+     # If using Liberica JDK11, set to true.
+     EMBEDDED_FONT: false
+
      # You can override the MIME of DSD according to your device.
      MIME_DSF: 'audio/x-dsd'
      MIME_DFF: 'audio/x-dsd'

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/FontLoader.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/FontLoader.java
@@ -23,6 +23,7 @@ import java.awt.Font;
 import java.awt.FontFormatException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 
 import net.sf.ehcache.Ehcache;
 import net.sf.ehcache.Element;
@@ -42,23 +43,21 @@ public class FontLoader {
         this.fontCache = fontCache;
     }
 
+    public boolean isEmbeddedFonts() {
+        return Optional.ofNullable(System.getProperty("jpsonic.embeddedfont")).map(Boolean::parseBoolean).orElse(false);
+    }
+
     public Font getFont(float fontSize) {
         Font font = null;
         String key = Float.toString(fontSize);
         synchronized (FONT_LOCK) {
             Element element = fontCache.get(key);
             if (element == null) {
-                try (InputStream fontStream = CoverArtController.class
-                        .getResourceAsStream("/fonts/kazesawa/Kazesawa-Regular.ttf")) {
-                    font = Font.createFont(Font.TRUETYPE_FONT, fontStream).deriveFont(fontSize);
-                } catch (IOException | FontFormatException e) {
-                    if (LOG.isWarnEnabled()) {
-                        LOG.warn("Failed to load font.");
-                    }
-                } finally {
-                    if (font == null) {
-                        font = new Font(Font.SANS_SERIF, Font.BOLD, (int) fontSize);
-                    }
+                if (isEmbeddedFonts()) {
+                    font = getFontFromResource(fontSize);
+                }
+                if (font == null) {
+                    font = new Font(Font.SANS_SERIF, Font.PLAIN, (int) fontSize);
                 }
                 fontCache.put(new Element(key, font));
             } else {
@@ -67,4 +66,21 @@ public class FontLoader {
         }
         return font;
     }
+
+    /*
+     * Font stream may not be obtained except for general OpenJDK (based on Windows or Linux glibc).
+     */
+    private Font getFontFromResource(float fontSize) {
+        Font font = null;
+        try (InputStream fontStream = FontLoader.class.getResourceAsStream("/fonts/kazesawa/Kazesawa-Regular.ttf")) {
+            font = Font.createFont(Font.TRUETYPE_FONT, fontStream).deriveFont(fontSize);
+        } catch (IOException | FontFormatException e) {
+            // do nothing if not available
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Failed to load font.");
+            }
+        }
+        return font;
+    }
+
 }


### PR DESCRIPTION
### (1/2)Change specification of font used for embedded cover art

The font specification has been changed to use the Java logical font by default. If you want to use Japanese fonts like before, use the option below. Default is false.

`-Djpsonic.embeddedfont=true`

For Docker, change the following items in production.yml. Set to true when using Liberica JDK11.

`EMBEDDED_FONT: true`

#### Background

The reason why Jpsonic had been used embedded fonts by default is as follows

 - Tofu happens when the JDK is not configured to use the font system correctly. Many Japanese will see tofu on Linux. Of course it can be avoided by properly configuring fonts, but it may not be easy.
 - JDK transition from Oracle to OpenJDK  (8-11, and more) could caused font problems. The cause is due to deployment and also related to which compiler the JDK was compiled with. Errors can occur in relatively different cause. In order to avoid these, embedded font stream was used instead of the system font.
 - Rendering with embedded fonts is possible even on systems where fonts do not exist. Function as insurance that can be used in the future.

The environment surrounding fonts is a little different than it was 5 or 10 years ago. The current Jpsonic can render like the following with Docker's initial configuration. No Tofu. (The Docker Image for armv7 may have more limited choices than other images. Whe use Liberica JDK11, set embedded fonts true. Japanese fonts has a relatively wide character set, but in the example below, Hangul cannot be supported. )

![image](https://user-images.githubusercontent.com/27724847/182871105-c6848665-9012-49bb-946c-d276b7d6ef72.png)


#### (2/2)Fix ffmpeg/ffprobe links

Fixed ffmpeg/ffprobe links.

 - Current ffmpeg latest is 5.1.
 - `ffmpeg -version`
 - Alpine uses ffmpeg 5.0.1. Almost the same as the latest version.
 - Ubuntu uses ffmpeg 4.x. It's a little old, but the composition is almost the same
 - `ffmpeg -formats`
 - If we grep ffmpeg supported formats with Jpsonic's standard format, the results are the same between Alpine and Ubuntu.

By compiling ffmpeg using multi-staging, more formats can be supported. However, it takes several tens of minutes, so I would like to avoid it if possible. FFmpeg lib binaries for Alpine and Ubuntu are available from their respective repositories. On AWS (or Cent family),  we are forced to compile ffmpeg.







