### PR TITLE
Revert maven-pmd-plugin from 3.18.0 to 3.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -441,7 +441,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-pmd-plugin</artifactId>
-                    <version>3.18.0</version>
+                    <version>3.17.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>net.sourceforge.pmd</groupId>


### PR DESCRIPTION
Ansi-related bug in 3.18.0 prevents PMD from running on Windows. Can be avoided by downgrading maven-pmd-plugin.

 - Related #1658.
 - Pull requests that may be relevant : ``https://github.com/apache/maven-pmd-plugin/pull/91``

 > ![image](https://user-images.githubusercontent.com/27724847/187139770-0d617b76-1a79-4505-b462-b352ac81ab46.png)

This is probably the reason for the low compatibility.

Since the problem is not reproduced on Linux so far, there seems to be no problem in running CI. So no urgent master merge needed.


