### PR TITLE
Fix FindSecBugs warnings

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/TagService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/TagService.java
@@ -130,7 +130,7 @@ public class TagService {
         }
         mediaFileService.refreshMediaFile(file);
         file = mediaFileService.getMediaFileStrict(file.getId());
-        mediaFileService.refreshMediaFile(mediaFileService.getParentOf(file));
+        mediaFileService.getParent(file).ifPresent(parent -> mediaFileService.refreshMediaFile(parent));
         return "UPDATED";
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DownloadController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DownloadController.java
@@ -159,6 +159,9 @@ public class DownloadController {
 
             } else if (playerId != null) {
                 Player player = playerService.getPlayerById(playerId);
+                if (player == null) {
+                    throw new IllegalArgumentException("The specified Player cannot be found.");
+                }
                 PlayQueue playQueue = player.getPlayQueue();
                 playQueue.setName("Playlist");
                 downloadFiles(response, status, playQueue.getFiles(), indexes, null, range, "download.zip");

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/IndexController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/IndexController.java
@@ -22,7 +22,6 @@
 package com.tesshu.jpsonic.controller;
 
 import java.util.Map;
-import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -31,12 +30,14 @@ import com.tesshu.jpsonic.service.SecurityService;
 import com.tesshu.jpsonic.service.SettingsService;
 import com.tesshu.jpsonic.util.LegacyMap;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
 @Controller
+@RequestMapping({ "/index", "/index.view" })
 public class IndexController {
 
     private final SecurityService securityService;
@@ -46,12 +47,21 @@ public class IndexController {
         this.securityService = securityService;
     }
 
-    @RequestMapping(value = { "/index", "/index.view" }, method = { RequestMethod.GET, RequestMethod.POST })
-    public ModelAndView index(HttpServletRequest request, @RequestParam("mainView") Optional<String> mainView) {
-        UserSettings userSettings = securityService.getUserSettings(securityService.getCurrentUsernameStrict(request));
-        Map<String, Object> model = LegacyMap.of("keyboardShortcutsEnabled", userSettings.isKeyboardShortcutsEnabled(),
-                "showLeft", userSettings.isCloseDrawer(), "brand", SettingsService.getBrand());
-        mainView.ifPresent(v -> model.put("mainView", v));
+    @GetMapping
+    public ModelAndView get(HttpServletRequest request) {
+        return new ModelAndView("index", "model", createModel(request));
+    }
+
+    @PostMapping
+    public ModelAndView post(HttpServletRequest request, @RequestParam("mainView") String mainView) {
+        Map<String, Object> model = createModel(request);
+        model.put("mainView", mainView);
         return new ModelAndView("index", "model", model);
+    }
+
+    private Map<String, Object> createModel(HttpServletRequest request) {
+        UserSettings userSettings = securityService.getUserSettings(securityService.getCurrentUsernameStrict(request));
+        return LegacyMap.of("keyboardShortcutsEnabled", userSettings.isKeyboardShortcutsEnabled(), "showLeft",
+                userSettings.isCloseDrawer(), "brand", SettingsService.getBrand());
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/JAXBWriter.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/JAXBWriter.java
@@ -41,6 +41,7 @@ import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
+import com.tesshu.jpsonic.SuppressFBWarnings;
 import com.tesshu.jpsonic.util.StringUtil;
 import org.eclipse.persistence.jaxb.JAXBContext;
 import org.eclipse.persistence.jaxb.MarshallerProperties;
@@ -119,6 +120,7 @@ public class JAXBWriter {
         return response;
     }
 
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "Limited threat. It's not a free-for-all can write, and APIs are mostly not used by browsers.")
     public void writeResponse(HttpServletRequest request, HttpServletResponse httpResponse, Response jaxbResponse) {
 
         String format = getStringParameter(request, Attributes.Request.F.value(), "xml");

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MainController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MainController.java
@@ -283,7 +283,10 @@ public class MainController {
         for (MediaFile mediaFile : mediaFiles) {
             MediaFile m = mediaFile;
             if (m.isFile()) {
-                m = mediaFileService.getParentOf(m);
+                MediaFile parent = mediaFileService.getParentOf(m);
+                if (parent != null) {
+                    m = parent;
+                }
             }
             result.addAll(mediaFileService.getChildrenOf(m, true, true, true));
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PodcastReceiverAdminController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PodcastReceiverAdminController.java
@@ -34,8 +34,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.ServletRequestUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 
@@ -57,16 +58,10 @@ public class PodcastReceiverAdminController {
         this.mediaScannerService = mediaScannerService;
     }
 
-    @RequestMapping(method = { RequestMethod.POST, RequestMethod.GET })
-    protected ModelAndView handleRequestInternal(HttpServletRequest request) throws ServletRequestBindingException {
+    @GetMapping
+    protected ModelAndView get(HttpServletRequest request) throws ServletRequestBindingException {
 
         if (mediaScannerService.isScanning()) {
-            return createModelAndView();
-        }
-
-        String addURL = request.getParameter(Attributes.Request.ADD.value());
-        if (!isEmpty(addURL)) {
-            podcastService.createChannel(StringUtils.trim(addURL));
             return createModelAndView();
         }
 
@@ -103,6 +98,15 @@ public class PodcastReceiverAdminController {
         return createModelAndView();
     }
 
+    @PostMapping
+    protected ModelAndView post(HttpServletRequest request) throws ServletRequestBindingException {
+        String addURL = request.getParameter(Attributes.Request.ADD.value());
+        if (!isEmpty(addURL)) {
+            podcastService.createChannel(StringUtils.trim(addURL));
+        }
+        return createModelAndView();
+    }
+
     private ModelAndView createModelAndView() {
         return new ModelAndView(new RedirectView(ViewName.PODCAST_CHANNELS.value()));
     }
@@ -131,5 +135,4 @@ public class PodcastReceiverAdminController {
             }
         }
     }
-
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PodcastReceiverAdminController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PodcastReceiverAdminController.java
@@ -67,7 +67,7 @@ public class PodcastReceiverAdminController {
 
         final Integer channelId = ServletRequestUtils.getIntParameter(request, Attributes.Request.CHANNEL_ID.value());
         if (!isEmpty(request.getParameter(Attributes.Request.REFRESH.value()))) {
-            if (isEmpty(channelId)) {
+            if (channelId == null) {
                 podcastService.refreshAllChannels(true);
                 return createModelAndView();
             } else {
@@ -91,7 +91,7 @@ public class PodcastReceiverAdminController {
             return createRedirect(channelId);
         }
 
-        if (!isEmpty(request.getParameter(Attributes.Request.DELETE_CHANNEL.value()))) {
+        if (!isEmpty(request.getParameter(Attributes.Request.DELETE_CHANNEL.value())) && channelId != null) {
             podcastService.deleteChannel(channelId);
         }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/ShareManagementController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/ShareManagementController.java
@@ -115,6 +115,9 @@ public class ShareManagementController {
             }
         } else if (playerId != null) {
             Player player = playerService.getPlayerById(playerId);
+            if (player == null) {
+                throw new IllegalArgumentException("The specified Player cannot be found.");
+            }
             PlayQueue playQueue = player.getPlayQueue();
             result = playQueue.getFiles();
         } else if (playlistId != null) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SubsonicRESTController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SubsonicRESTController.java
@@ -163,7 +163,7 @@ import org.subsonic.restapi.Videos;
  * many loop instances because it is responsible for conversion objects. [LinguisticNaming] This is a naming convention
  * specific to this REST class that writes directly to the HTTP response without returning a return value.
  */
-@SuppressFBWarnings(value = "SPRING_CSRF_UNRESTRICTED_REQUEST_MAPPING", justification = "This is because the modification will deviate from the ecosystem.")
+@SuppressFBWarnings(value = "SPRING_CSRF_UNRESTRICTED_REQUEST_MAPPING", justification = "Difficult to change as it affects existing apps(Protected by a token).")
 @Controller
 @RequestMapping(value = "/rest", method = { RequestMethod.GET, RequestMethod.POST })
 public class SubsonicRESTController {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SubsonicRESTController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SubsonicRESTController.java
@@ -303,8 +303,9 @@ public class SubsonicRESTController {
         HttpServletRequest request = wrapRequest(req);
 
         MusicFolders musicFolders = new MusicFolders();
-        String username = securityService.getCurrentUsername(request);
-        for (com.tesshu.jpsonic.domain.MusicFolder musicFolder : musicFolderService.getMusicFoldersForUser(username)) {
+        User user = securityService.getCurrentUserStrict(request);
+        for (com.tesshu.jpsonic.domain.MusicFolder musicFolder : musicFolderService
+                .getMusicFoldersForUser(user.getUsername())) {
             org.subsonic.restapi.MusicFolder mf = new org.subsonic.restapi.MusicFolder();
             mf.setId(musicFolder.getId());
             mf.setName(musicFolder.getName());
@@ -413,7 +414,7 @@ public class SubsonicRESTController {
             throws ServletRequestBindingException {
         HttpServletRequest request = wrapRequest(req);
         Player player = playerService.getPlayer(request, response);
-        String username = securityService.getCurrentUsername(request);
+        User user = securityService.getCurrentUserStrict(request);
 
         Songs songs = new Songs();
 
@@ -423,11 +424,11 @@ public class SubsonicRESTController {
         count = Math.max(0, Math.min(count, 500));
         Integer musicFolderId = ServletRequestUtils.getIntParameter(request,
                 Attributes.Request.MUSIC_FOLDER_ID.value());
-        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(username,
-                musicFolderId);
+        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService
+                .getMusicFoldersForUser(user.getUsername(), musicFolderId);
 
         for (MediaFile mediaFile : searchService.getSongsByGenres(genre, offset, count, musicFolders)) {
-            songs.getSong().add(createJaxbChild(player, mediaFile, username));
+            songs.getSong().add(createJaxbChild(player, mediaFile, user.getUsername()));
         }
         Response res = createResponse();
         res.setSongsByGenre(songs);
@@ -437,11 +438,12 @@ public class SubsonicRESTController {
     @RequestMapping({ "/getArtists", "/getArtists.view" })
     public void getArtists(HttpServletRequest req, HttpServletResponse response) {
         HttpServletRequest request = wrapRequest(req);
-        String username = securityService.getCurrentUsername(request);
+        User user = securityService.getCurrentUserStrict(request);
 
         ArtistsID3 result = new ArtistsID3();
         result.setIgnoredArticles(settingsService.getIgnoredArticles());
-        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(username);
+        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService
+                .getMusicFoldersForUser(user.getUsername());
 
         List<com.tesshu.jpsonic.domain.Artist> artists = artistDao.getAlphabetialArtists(0, Integer.MAX_VALUE,
                 musicFolders);
@@ -451,7 +453,8 @@ public class SubsonicRESTController {
             IndexID3 index = new IndexID3();
             index.setName(entry.getKey().getIndex());
             for (MusicIndex.SortableArtistWithArtist sortableArtist : entry.getValue()) {
-                index.getArtist().add(createJaxbArtist(new ArtistID3(), sortableArtist.getArtist(), username));
+                index.getArtist()
+                        .add(createJaxbArtist(new ArtistID3(), sortableArtist.getArtist(), user.getUsername()));
             }
             result.getIndex().add(index);
         }
@@ -473,15 +476,16 @@ public class SubsonicRESTController {
             return;
         }
 
-        String username = securityService.getCurrentUsername(request);
+        User user = securityService.getCurrentUserStrict(request);
         int count = ServletRequestUtils.getIntParameter(request, Attributes.Request.COUNT.value(), 50);
         SimilarSongs result = new SimilarSongs();
 
-        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(username);
+        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService
+                .getMusicFoldersForUser(user.getUsername());
         List<MediaFile> similarSongs = lastFmService.getSimilarSongs(mediaFile, count, musicFolders);
         Player player = playerService.getPlayer(request, response);
         for (MediaFile similarSong : similarSongs) {
-            result.getSong().add(createJaxbChild(player, similarSong, username));
+            result.getSong().add(createJaxbChild(player, similarSong, user.getUsername()));
         }
 
         Response res = createResponse();
@@ -501,14 +505,15 @@ public class SubsonicRESTController {
             return;
         }
 
-        String username = securityService.getCurrentUsername(request);
+        User user = securityService.getCurrentUserStrict(request);
         int count = ServletRequestUtils.getIntParameter(request, Attributes.Request.COUNT.value(), 50);
         SimilarSongs2 result = new SimilarSongs2();
-        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(username);
+        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService
+                .getMusicFoldersForUser(user.getUsername());
         List<MediaFile> similarSongs = lastFmService.getSimilarSongs(artist, count, musicFolders);
         Player player = playerService.getPlayer(request, response);
         for (MediaFile similarSong : similarSongs) {
-            result.getSong().add(createJaxbChild(player, similarSong, username));
+            result.getSong().add(createJaxbChild(player, similarSong, user.getUsername()));
         }
 
         Response res = createResponse();
@@ -520,18 +525,19 @@ public class SubsonicRESTController {
     public void getTopSongs(HttpServletRequest req, HttpServletResponse response)
             throws ServletRequestBindingException {
         HttpServletRequest request = wrapRequest(req);
-        String username = securityService.getCurrentUsername(request);
+        User user = securityService.getCurrentUserStrict(request);
 
         String artist = ServletRequestUtils.getRequiredStringParameter(request, Attributes.Request.ARTIST.value());
         int count = ServletRequestUtils.getIntParameter(request, Attributes.Request.COUNT.value(), 50);
 
         TopSongs result = new TopSongs();
 
-        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(username);
+        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService
+                .getMusicFoldersForUser(user.getUsername());
         List<MediaFile> topSongs = lastFmService.getTopSongs(artist, count, musicFolders);
         Player player = playerService.getPlayer(request, response);
         for (MediaFile topSong : topSongs) {
-            result.getSong().add(createJaxbChild(player, topSong, username));
+            result.getSong().add(createJaxbChild(player, topSong, user.getUsername()));
         }
 
         Response res = createResponse();
@@ -656,7 +662,8 @@ public class SubsonicRESTController {
             return;
         }
 
-        String username = securityService.getCurrentUsername(request);
+        User user = securityService.getCurrentUserStrict(request);
+        String username = user.getUsername();
         List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(username);
         ArtistWithAlbumsID3 result = createJaxbArtist(new ArtistWithAlbumsID3(), artist, username);
         for (Album album : albumDao.getAlbumsForArtist(artist.getName(), musicFolders)) {
@@ -828,10 +835,11 @@ public class SubsonicRESTController {
 
         int offset = ServletRequestUtils.getIntParameter(request, Attributes.Request.OFFSET.value(), 0);
         int count = ServletRequestUtils.getIntParameter(request, Attributes.Request.COUNT.value(), 20);
-        String username = securityService.getCurrentUsername(request);
+        User user = securityService.getCurrentUserStrict(request);
         boolean includeComposer = settingsService.isSearchComposer()
-                || securityService.getUserSettings(username).getMainVisibility().isComposerVisible();
-        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(username);
+                || securityService.getUserSettings(user.getUsername()).getMainVisibility().isComposerVisible();
+        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService
+                .getMusicFoldersForUser(user.getUsername());
         SearchCriteria criteria = director.construct(query.toString().trim(), offset, count, includeComposer,
                 musicFolders, IndexType.SONG);
 
@@ -842,7 +850,7 @@ public class SubsonicRESTController {
 
         Player player = playerService.getPlayer(request, response);
         for (MediaFile mediaFile : result.getMediaFiles()) {
-            searchResult.getMatch().add(createJaxbChild(player, mediaFile, username));
+            searchResult.getMatch().add(createJaxbChild(player, mediaFile, user.getUsername()));
         }
         Response res = createResponse();
         res.setSearchResult(searchResult);
@@ -855,7 +863,8 @@ public class SubsonicRESTController {
             throws IOException, ServletRequestBindingException {
         HttpServletRequest request = wrapRequest(req);
         Player player = playerService.getPlayer(request, response);
-        String username = securityService.getCurrentUsername(request);
+        User user = securityService.getCurrentUserStrict(request);
+        String username = user.getUsername();
         Integer musicFolderId = ServletRequestUtils.getIntParameter(request,
                 Attributes.Request.MUSIC_FOLDER_ID.value());
 
@@ -903,7 +912,8 @@ public class SubsonicRESTController {
             throws ServletRequestBindingException, IOException {
         HttpServletRequest request = wrapRequest(req);
         Player player = playerService.getPlayer(request, response);
-        String username = securityService.getCurrentUsername(request);
+        User user = securityService.getCurrentUserStrict(request);
+        String username = user.getUsername();
         Integer musicFolderId = ServletRequestUtils.getIntParameter(request,
                 Attributes.Request.MUSIC_FOLDER_ID.value());
 
@@ -1154,15 +1164,15 @@ public class SubsonicRESTController {
     public void getAlbumList(HttpServletRequest req, HttpServletResponse response)
             throws ServletRequestBindingException, ExecutionException {
         HttpServletRequest request = wrapRequest(req);
-        String username = securityService.getCurrentUsername(request);
+        User user = securityService.getCurrentUserStrict(request);
 
         int size = ServletRequestUtils.getIntParameter(request, Attributes.Request.SIZE.value(), 10);
         int offset = ServletRequestUtils.getIntParameter(request, Attributes.Request.OFFSET.value(), 0);
         Integer musicFolderId = ServletRequestUtils.getIntParameter(request,
                 Attributes.Request.MUSIC_FOLDER_ID.value());
 
-        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(username,
-                musicFolderId);
+        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService
+                .getMusicFoldersForUser(user.getUsername(), musicFolderId);
 
         size = Math.max(0, Math.min(size, 500));
         String type = ServletRequestUtils.getRequiredStringParameter(request, Attributes.Request.TYPE.value());
@@ -1177,7 +1187,7 @@ public class SubsonicRESTController {
         } else if ("newest".equals(type)) {
             albums = mediaFileService.getNewestAlbums(offset, size, musicFolders);
         } else if ("starred".equals(type)) {
-            albums = mediaFileService.getStarredAlbums(offset, size, username, musicFolders);
+            albums = mediaFileService.getStarredAlbums(offset, size, user.getUsername(), musicFolders);
         } else if ("alphabeticalByArtist".equals(type)) {
             albums = mediaFileService.getAlphabeticalAlbums(offset, size, true, musicFolders);
         } else if ("alphabeticalByName".equals(type)) {
@@ -1200,7 +1210,7 @@ public class SubsonicRESTController {
         Player player = playerService.getPlayer(request, response);
         AlbumList result = new AlbumList();
         for (MediaFile album : albums) {
-            result.getAlbum().add(createJaxbChild(player, album, username));
+            result.getAlbum().add(createJaxbChild(player, album, user.getUsername()));
         }
 
         Response res = createResponse();
@@ -1217,11 +1227,11 @@ public class SubsonicRESTController {
         int offset = ServletRequestUtils.getIntParameter(request, Attributes.Request.OFFSET.value(), 0);
         size = Math.max(0, Math.min(size, 500));
         String type = ServletRequestUtils.getRequiredStringParameter(request, Attributes.Request.TYPE.value());
-        String username = securityService.getCurrentUsername(request);
+        User user = securityService.getCurrentUserStrict(request);
         Integer musicFolderId = ServletRequestUtils.getIntParameter(request,
                 Attributes.Request.MUSIC_FOLDER_ID.value());
-        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(username,
-                musicFolderId);
+        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService
+                .getMusicFoldersForUser(user.getUsername(), musicFolderId);
 
         List<Album> albums;
         if ("frequent".equals(type)) {
@@ -1253,7 +1263,7 @@ public class SubsonicRESTController {
         }
         AlbumList2 result = new AlbumList2();
         for (Album album : albums) {
-            result.getAlbum().add(createJaxbAlbum(new AlbumID3(), album, username));
+            result.getAlbum().add(createJaxbAlbum(new AlbumID3(), album, user.getUsername()));
         }
         Response res = createResponse();
         res.setAlbumList2(result);
@@ -1265,7 +1275,7 @@ public class SubsonicRESTController {
             throws ServletRequestBindingException {
         HttpServletRequest request = wrapRequest(req);
         Player player = playerService.getPlayer(request, response);
-        String username = securityService.getCurrentUsername(request);
+        User user = securityService.getCurrentUserStrict(request);
 
         int size = ServletRequestUtils.getIntParameter(request, Attributes.Request.SIZE.value(), 10);
         size = Math.max(0, Math.min(size, 500));
@@ -1279,13 +1289,13 @@ public class SubsonicRESTController {
         Integer toYear = ServletRequestUtils.getIntParameter(request, Attributes.Request.TO_YEAR.value());
         Integer musicFolderId = ServletRequestUtils.getIntParameter(request,
                 Attributes.Request.MUSIC_FOLDER_ID.value());
-        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(username,
-                musicFolderId);
+        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService
+                .getMusicFoldersForUser(user.getUsername(), musicFolderId);
         RandomSearchCriteria criteria = new RandomSearchCriteria(size, genres, fromYear, toYear, musicFolders);
 
         Songs result = new Songs();
         for (MediaFile mediaFile : searchService.getRandomSongs(criteria)) {
-            result.getSong().add(createJaxbChild(player, mediaFile, username));
+            result.getSong().add(createJaxbChild(player, mediaFile, user.getUsername()));
         }
         Response res = createResponse();
         res.setRandomSongs(result);
@@ -1296,15 +1306,16 @@ public class SubsonicRESTController {
     public void getVideos(HttpServletRequest req, HttpServletResponse response) throws ServletRequestBindingException {
         HttpServletRequest request = wrapRequest(req);
         Player player = playerService.getPlayer(request, response);
-        String username = securityService.getCurrentUsername(request);
+        User user = securityService.getCurrentUserStrict(request);
 
         int size = ServletRequestUtils.getIntParameter(request, Attributes.Request.SIZE.value(), Integer.MAX_VALUE);
         int offset = ServletRequestUtils.getIntParameter(request, Attributes.Request.OFFSET.value(), 0);
-        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(username);
+        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService
+                .getMusicFoldersForUser(user.getUsername());
 
         Videos result = new Videos();
         for (MediaFile mediaFile : mediaFileDao.getVideos(size, offset, musicFolders)) {
-            result.getVideo().add(createJaxbChild(player, mediaFile, username));
+            result.getVideo().add(createJaxbChild(player, mediaFile, user.getUsername()));
         }
         Response res = createResponse();
         res.setVideos(result);
@@ -1629,7 +1640,8 @@ public class SubsonicRESTController {
     public void getStarred(HttpServletRequest req, HttpServletResponse response) throws ServletRequestBindingException {
         HttpServletRequest request = wrapRequest(req);
         Player player = playerService.getPlayer(request, response);
-        String username = securityService.getCurrentUsername(request);
+        User user = securityService.getCurrentUserStrict(request);
+        String username = user.getUsername();
         Integer musicFolderId = ServletRequestUtils.getIntParameter(request,
                 Attributes.Request.MUSIC_FOLDER_ID.value());
         List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(username,
@@ -1655,7 +1667,8 @@ public class SubsonicRESTController {
             throws ServletRequestBindingException {
         HttpServletRequest request = wrapRequest(req);
         Player player = playerService.getPlayer(request, response);
-        String username = securityService.getCurrentUsername(request);
+        User user = securityService.getCurrentUserStrict(request);
+        String username = user.getUsername();
         Integer musicFolderId = ServletRequestUtils.getIntParameter(request,
                 Attributes.Request.MUSIC_FOLDER_ID.value());
         List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(username,
@@ -1744,8 +1757,10 @@ public class SubsonicRESTController {
         String path = episode.getPath();
         if (path != null) {
             MediaFile mediaFile = mediaFileService.getMediaFile(path);
-            e = createJaxbChild(new org.subsonic.restapi.PodcastEpisode(), player, mediaFile, username);
-            e.setStreamId(String.valueOf(mediaFile.getId()));
+            if (mediaFile != null) {
+                e = createJaxbChild(new org.subsonic.restapi.PodcastEpisode(), player, mediaFile, username);
+                e.setStreamId(String.valueOf(mediaFile.getId()));
+            }
         }
 
         e.setId(String.valueOf(episode.getId())); // Overwrites the previous "id" attribute.
@@ -1876,10 +1891,10 @@ public class SubsonicRESTController {
             throws ServletRequestBindingException {
         HttpServletRequest request = wrapRequest(req);
         Player player = playerService.getPlayer(request, response);
-        String username = securityService.getCurrentUsername(request);
+        User user = securityService.getCurrentUserStrict(request);
 
         Bookmarks result = new Bookmarks();
-        for (Bookmark bookmark : bookmarkService.getBookmarks(username)) {
+        for (Bookmark bookmark : bookmarkService.getBookmarks(user.getUsername())) {
             org.subsonic.restapi.Bookmark b = new org.subsonic.restapi.Bookmark();
             result.getBookmark().add(b);
             b.setPosition(bookmark.getPositionMillis());
@@ -1889,7 +1904,9 @@ public class SubsonicRESTController {
             b.setChanged(jaxbWriter.convertDate(bookmark.getChanged()));
 
             MediaFile mediaFile = mediaFileService.getMediaFile(bookmark.getMediaFileId());
-            b.setEntry(createJaxbChild(player, mediaFile, username));
+            if (mediaFile != null) {
+                b.setEntry(createJaxbChild(player, mediaFile, user.getUsername()));
+            }
         }
 
         Response res = createResponse();
@@ -1982,9 +1999,9 @@ public class SubsonicRESTController {
     public void getShares(HttpServletRequest req, HttpServletResponse response) throws ServletRequestBindingException {
         HttpServletRequest request = wrapRequest(req);
         Player player = playerService.getPlayer(request, response);
-        String username = securityService.getCurrentUsername(request);
         User user = securityService.getCurrentUserStrict(request);
-        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(username);
+        List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService
+                .getMusicFoldersForUser(user.getUsername());
 
         Shares result = new Shares();
         for (com.tesshu.jpsonic.domain.Share share : shareService.getSharesForUser(user)) {
@@ -1992,7 +2009,7 @@ public class SubsonicRESTController {
             result.getShare().add(s);
 
             for (MediaFile mediaFile : shareService.getSharedFiles(share.getId(), musicFolders)) {
-                s.getEntry().add(createJaxbChild(player, mediaFile, username));
+                s.getEntry().add(createJaxbChild(player, mediaFile, user.getUsername()));
             }
         }
         Response res = createResponse();
@@ -2030,6 +2047,9 @@ public class SubsonicRESTController {
 
         Player player = playerService.getPlayer(request, response);
         String username = securityService.getCurrentUsername(request);
+        if (username == null) {
+            writeError(request, response, ErrorCode.NOT_AUTHENTICATED, "Wrong username.");
+        }
         List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(username);
         for (MediaFile mediaFile : shareService.getSharedFiles(share.getId(), musicFolders)) {
             s.getEntry().add(createJaxbChild(player, mediaFile, username));
@@ -2540,6 +2560,9 @@ public class SubsonicRESTController {
         try {
             String path = StringUtil.utf8HexDecode(id);
             MediaFile mediaFile = mediaFileService.getMediaFile(path);
+            if (mediaFile == null) {
+                return id;
+            }
             return String.valueOf(mediaFile.getId());
         } catch (DecoderException e) {
             return id;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
@@ -177,6 +177,10 @@ public class MediaFileService {
         return getMediaFile(mediaFile.getParentPathString());
     }
 
+    public Optional<MediaFile> getParent(MediaFile mediaFile) {
+        return Optional.ofNullable(getParentOf(mediaFile));
+    }
+
     boolean isSchemeLastModified() {
         return FileModifiedCheckScheme.LAST_MODIFIED == FileModifiedCheckScheme
                 .valueOf(settingsService.getFileModifiedCheckSchemeName());
@@ -267,7 +271,10 @@ public class MediaFileService {
         return result;
     }
 
-    public boolean isRoot(@NonNull MediaFile mediaFile) {
+    public boolean isRoot(@Nullable MediaFile mediaFile) {
+        if (mediaFile == null) {
+            return false;
+        }
         for (MusicFolder musicFolder : musicFolderService.getAllMusicFolders(false, true)) {
             if (mediaFile.toPath().equals(musicFolder.toPath())) {
                 return true;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PodcastService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PodcastService.java
@@ -596,6 +596,11 @@ public class PodcastService {
             try (CloseableHttpClient client = HttpClients.createDefault()) {
 
                 PodcastChannel channel = getChannel(episode.getChannelId());
+                if (channel == null) {
+                    writeInfo("Podcast channel for " + episode.getUrl() + " was deleted. Aborting download.");
+                    return;
+                }
+
                 HttpGet httpGet = createHttpGet(episode.getUrl());
 
                 try (CloseableHttpResponse response = client.execute(httpGet);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
@@ -214,6 +214,7 @@ public class SecurityService implements UserDetailsService {
         return username == null ? null : getUserByName(username);
     }
 
+    // TODO For REST, fix to return response instead of exception.
     public @NonNull User getCurrentUserStrict(@NonNull HttpServletRequest request) {
         String username = getCurrentUsername(request);
         if (username == null) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/SearchServiceImpl.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/SearchServiceImpl.java
@@ -51,6 +51,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TopDocs;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -130,7 +131,7 @@ public class SearchServiceImpl implements SearchService {
         result.setOffset(offset);
 
         IndexType indexType = searchableIndex(criteria);
-        if (count <= 0 || isEmpty(indexType)) {
+        if (count <= 0 || indexType == null) {
             return result;
         }
 
@@ -188,7 +189,7 @@ public class SearchServiceImpl implements SearchService {
         }
     }
 
-    private IndexType searchableIndex(UPnPSearchCriteria criteria) {
+    private @Nullable IndexType searchableIndex(UPnPSearchCriteria criteria) {
         IndexType indexType = null;
         if (Artist.class == criteria.getAssignableClass()) {
             indexType = IndexType.ARTIST_ID3;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/TagServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/TagServiceTest.java
@@ -27,6 +27,7 @@ import java.io.OutputStream;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 
 import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.service.MediaFileService;
@@ -75,7 +76,7 @@ class TagServiceTest {
         parent.setPathString(copy.getParent().toString());
 
         Mockito.when(mediaFileService.getMediaFileStrict(mediaFile.getId())).thenReturn(mediaFile);
-        Mockito.when(mediaFileService.getParentOf(mediaFile)).thenReturn(parent);
+        Mockito.when(mediaFileService.getParent(mediaFile)).thenReturn(Optional.of(parent));
         Mockito.when(metaDataParserFactory.getParser(Path.of(mediaFile.getPathString()))).thenReturn(parser);
 
         Mockito.when(mediaScannerService.isScanning()).thenReturn(false);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/PodcastReceiverAdminControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/PodcastReceiverAdminControllerTest.java
@@ -68,16 +68,20 @@ class PodcastReceiverAdminControllerTest {
     }
 
     @Nested
-    class GetTest {
+    class PostTest {
 
         @Test
         void testAdd() throws ServletRequestBindingException {
             MockHttpServletRequest req = mock(MockHttpServletRequest.class);
             String url = "http://boo.foo";
             Mockito.when(req.getParameter(Attributes.Request.ADD.value())).thenReturn(url);
-            controller.handleRequestInternal(req);
+            controller.post(req);
             Mockito.verify(podcastService, Mockito.times(1)).createChannel(url);
         }
+    }
+
+    @Nested
+    class GetTest {
 
         @Test
         void testDownload() throws ServletRequestBindingException {
@@ -92,7 +96,7 @@ class PodcastReceiverAdminControllerTest {
             Mockito.when(req.getParameter(Attributes.Request.CHANNEL_ID.value()))
                     .thenReturn(Integer.toString(channelId));
 
-            controller.handleRequestInternal(req);
+            controller.get(req);
             Mockito.verify(podcastService, Mockito.times(1)).downloadEpisode(episode);
         }
 
@@ -103,12 +107,12 @@ class PodcastReceiverAdminControllerTest {
             Mockito.when(req.getParameter(Attributes.Request.CHANNEL_ID.value()))
                     .thenReturn(Integer.toString(channelId));
 
-            controller.handleRequestInternal(req);
+            controller.get(req);
             Mockito.verify(podcastService, Mockito.never()).deleteChannel(channelId);
 
             Mockito.when(req.getParameter(Attributes.Request.DELETE_CHANNEL.value()))
                     .thenReturn(Integer.toString(channelId));
-            controller.handleRequestInternal(req);
+            controller.get(req);
             Mockito.verify(podcastService, Mockito.times(1)).deleteChannel(channelId);
         }
 
@@ -120,7 +124,7 @@ class PodcastReceiverAdminControllerTest {
                     .thenReturn(Integer.toString(episodeId));
             Mockito.when(req.getParameter(Attributes.Request.DELETE_EPISODE.value()))
                     .thenReturn(Integer.toString(episodeId));
-            controller.handleRequestInternal(req);
+            controller.get(req);
             Mockito.verify(podcastService, Mockito.times(1)).deleteEpisode(episodeId, true);
         }
 
@@ -129,14 +133,14 @@ class PodcastReceiverAdminControllerTest {
             MockHttpServletRequest req = mock(MockHttpServletRequest.class);
             int channelId = 99;
             Mockito.when(req.getParameter(Attributes.Request.REFRESH.value())).thenReturn(Integer.toString(channelId));
-            controller.handleRequestInternal(req);
+            controller.get(req);
             Mockito.verify(podcastService, Mockito.times(1)).refreshAllChannels(true);
             Mockito.verify(podcastService, Mockito.never()).refreshChannel(channelId, true);
             Mockito.clearInvocations(podcastService);
 
             Mockito.when(req.getParameter(Attributes.Request.CHANNEL_ID.value()))
                     .thenReturn(Integer.toString(channelId));
-            controller.handleRequestInternal(req);
+            controller.get(req);
             Mockito.verify(podcastService, Mockito.never()).refreshAllChannels(true);
             Mockito.verify(podcastService, Mockito.times(1)).refreshChannel(channelId, true);
         }
@@ -162,7 +166,7 @@ class PodcastReceiverAdminControllerTest {
             Mockito.when(req.getParameter(Attributes.Request.REFRESH.value())).thenReturn(Integer.toString(channelId));
 
             Mockito.when(mediaScannerService.isScanning()).thenReturn(true);
-            controller.handleRequestInternal(req);
+            controller.get(req);
 
             Mockito.verify(podcastService, Mockito.never()).createChannel(url);
             Mockito.verify(podcastService, Mockito.never()).downloadEpisode(episode);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/RecoverControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/RecoverControllerTest.java
@@ -204,7 +204,7 @@ class RecoverControllerTest {
 
         MockHttpServletRequest req = new MockHttpServletRequest();
         req.addParameter(Attributes.Request.USERNAME_OR_EMAIL.value(), ServiceMockUtils.ADMIN_NAME);
-        ModelAndView modelAndView = controller.recover(req);
+        ModelAndView modelAndView = controller.post(req);
         @SuppressWarnings("unchecked")
         Map<String, Object> model = (Map<String, Object>) modelAndView.getModel().get(ATTR_MODEL);
 
@@ -229,7 +229,7 @@ class RecoverControllerTest {
 
         MockHttpServletRequest req = new MockHttpServletRequest();
         req.addParameter(Attributes.Request.USERNAME_OR_EMAIL.value(), ServiceMockUtils.ADMIN_NAME);
-        ModelAndView modelAndView = controller.recover(req);
+        ModelAndView modelAndView = controller.post(req);
         @SuppressWarnings("unchecked")
         Map<String, Object> model = (Map<String, Object>) modelAndView.getModel().get(ATTR_MODEL);
 
@@ -257,7 +257,7 @@ class RecoverControllerTest {
 
         MockHttpServletRequest req = new MockHttpServletRequest();
         req.addParameter(Attributes.Request.USERNAME_OR_EMAIL.value(), ServiceMockUtils.ADMIN_NAME);
-        ModelAndView modelAndView = controller.recover(req);
+        ModelAndView modelAndView = controller.post(req);
         @SuppressWarnings("unchecked")
         Map<String, Object> model = (Map<String, Object>) modelAndView.getModel().get(ATTR_MODEL);
 
@@ -287,7 +287,7 @@ class RecoverControllerTest {
 
         MockHttpServletRequest req = new MockHttpServletRequest();
         req.addParameter(Attributes.Request.USERNAME_OR_EMAIL.value(), ServiceMockUtils.ADMIN_NAME);
-        ModelAndView modelAndView = controller.recover(req);
+        ModelAndView modelAndView = controller.post(req);
         @SuppressWarnings("unchecked")
         Map<String, Object> model = (Map<String, Object>) modelAndView.getModel().get(ATTR_MODEL);
 
@@ -317,7 +317,7 @@ class RecoverControllerTest {
 
         MockHttpServletRequest req = new MockHttpServletRequest();
         req.addParameter(Attributes.Request.USERNAME_OR_EMAIL.value(), ServiceMockUtils.ADMIN_NAME);
-        ModelAndView modelAndView = controller.recover(req);
+        ModelAndView modelAndView = controller.post(req);
         @SuppressWarnings("unchecked")
         Map<String, Object> model = (Map<String, Object>) modelAndView.getModel().get(ATTR_MODEL);
 
@@ -349,7 +349,7 @@ class RecoverControllerTest {
 
         MockHttpServletRequest req = new MockHttpServletRequest();
         req.addParameter(Attributes.Request.USERNAME_OR_EMAIL.value(), ServiceMockUtils.ADMIN_NAME);
-        ModelAndView modelAndView = controller.recover(req);
+        ModelAndView modelAndView = controller.post(req);
         @SuppressWarnings("unchecked")
         Map<String, Object> model = (Map<String, Object>) modelAndView.getModel().get(ATTR_MODEL);
 
@@ -381,7 +381,7 @@ class RecoverControllerTest {
 
         MockHttpServletRequest req = new MockHttpServletRequest();
         req.addParameter(Attributes.Request.USERNAME_OR_EMAIL.value(), ServiceMockUtils.ADMIN_NAME);
-        ModelAndView modelAndView = controller.recover(req);
+        ModelAndView modelAndView = controller.post(req);
         @SuppressWarnings("unchecked")
         Map<String, Object> model = (Map<String, Object>) modelAndView.getModel().get(ATTR_MODEL);
 


### PR DESCRIPTION
Fix some FindSecBugs warnings.

 - FindSecBugs is used by Sonatype Lift. However, since the version is not the latest, it is often overlooked.
 - The latest Spotbugs/FindSecBugs are relatively glitchy, so Jpsonic doesn't specify fail on error. Checked manually on a regular basis.
 - NPE detection is supported by many tools, but the accuracy is not uniform, and each has good and bad detection. Therefore, Jpsonic uses several tools together. Spotbugs/FindSecBugs are relatively good at this.

Fixing ``PERMISSIVE_CORS`` only will be handled separately in a separate pull request as it's not straightforward.