### PR TITLE
Remove code related to Access-Control-Allow-Origin

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/HLSController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/HLSController.java
@@ -84,8 +84,6 @@ public class HLSController {
     public void handleRequest(HttpServletRequest request, HttpServletResponse response)
             throws ServletRequestBindingException, IOException {
 
-        response.setHeader("Access-Control-Allow-Origin", "*");
-
         int id = ServletRequestUtils.getIntParameter(request, Attributes.Request.ID.value(), 0);
         MediaFile mediaFile = mediaFileService.getMediaFile(id);
         if (mediaFile == null) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StreamController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StreamController.java
@@ -387,7 +387,6 @@ public class StreamController {
         }
 
         // Processing for all responses
-        res.setHeader("Access-Control-Allow-Origin", "*");
         String contentType = getMimeType(req.getParameter(Attributes.Request.SUFFIX.value()));
         res.setContentType(contentType);
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/filter/RESTFilter.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/filter/RESTFilter.java
@@ -59,8 +59,6 @@ public class RESTFilter implements Filter {
     @Override
     public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) {
         try {
-            HttpServletResponse response = (HttpServletResponse) res;
-            response.setHeader("Access-Control-Allow-Origin", "*");
             chain.doFilter(req, res);
         } catch (IOException | ServletException e) {
             handleException(e, (HttpServletRequest) req, (HttpServletResponse) res);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/StreamControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/StreamControllerTest.java
@@ -777,7 +777,7 @@ class StreamControllerTest {
             initMocksWithTranscoding(false, false);
             mockMvc.perform(MockMvcRequestBuilders.get("/stream").param(Attributes.Request.ID.value(),
                     Integer.toString(song.getId()))).andExpect(MockMvcResultMatchers.status().isOk())
-                    .andExpect(MockMvcResultMatchers.header().string("Access-Control-Allow-Origin", "*"))
+                    .andExpect(MockMvcResultMatchers.header().doesNotExist("Access-Control-Allow-Origin"))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.ACCEPT_RANGES))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.CONTENT_RANGE))
                     .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.CONTENT_LENGTH, "358406"))
@@ -800,7 +800,7 @@ class StreamControllerTest {
                     .param(Attributes.Request.MAX_BIT_RATE.value(),
                             Integer.toString(TranscodeScheme.MAX_320.getMaxBitRate())))
                     .andExpect(MockMvcResultMatchers.status().isOk())
-                    .andExpect(MockMvcResultMatchers.header().string("Access-Control-Allow-Origin", "*"))
+                    .andExpect(MockMvcResultMatchers.header().doesNotExist("Access-Control-Allow-Origin"))
                     .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.ACCEPT_RANGES, "none"))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.CONTENT_RANGE))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.CONTENT_LENGTH))
@@ -820,7 +820,7 @@ class StreamControllerTest {
             player.setTranscodeScheme(TranscodeScheme.MAX_320);
             mockMvc.perform(MockMvcRequestBuilders.get("/stream").param(Attributes.Request.ID.value(),
                     Integer.toString(song.getId()))).andExpect(MockMvcResultMatchers.status().isOk())
-                    .andExpect(MockMvcResultMatchers.header().string("Access-Control-Allow-Origin", "*"))
+                    .andExpect(MockMvcResultMatchers.header().doesNotExist("Access-Control-Allow-Origin"))
                     .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.ACCEPT_RANGES, "none"))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.CONTENT_RANGE))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.CONTENT_LENGTH))
@@ -841,7 +841,7 @@ class StreamControllerTest {
             mockMvc.perform(MockMvcRequestBuilders.get("/stream")
                     .param(Attributes.Request.ID.value(), Integer.toString(song.getId())).param("format", "mp3"))
                     .andExpect(MockMvcResultMatchers.status().isOk())
-                    .andExpect(MockMvcResultMatchers.header().string("Access-Control-Allow-Origin", "*"))
+                    .andExpect(MockMvcResultMatchers.header().doesNotExist("Access-Control-Allow-Origin"))
                     .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.ACCEPT_RANGES, "none"))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.CONTENT_RANGE))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.CONTENT_LENGTH))
@@ -861,7 +861,7 @@ class StreamControllerTest {
             initMocksWithTranscoding(true, false);
             mockMvc.perform(MockMvcRequestBuilders.get("/stream").param(Attributes.Request.ID.value(),
                     Integer.toString(song.getId())))
-                    .andExpect(MockMvcResultMatchers.header().string("Access-Control-Allow-Origin", "*"))
+                    .andExpect(MockMvcResultMatchers.header().doesNotExist("Access-Control-Allow-Origin"))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.ACCEPT_RANGES))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.CONTENT_RANGE))
                     .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.CONTENT_LENGTH, "358406"))
@@ -882,7 +882,7 @@ class StreamControllerTest {
             initMocksWithTranscoding(true, false);
             mockMvc.perform(MockMvcRequestBuilders.get("/stream").param(Attributes.Request.ID.value(),
                     Integer.toString(song.getId())))
-                    .andExpect(MockMvcResultMatchers.header().string("Access-Control-Allow-Origin", "*"))
+                    .andExpect(MockMvcResultMatchers.header().doesNotExist("Access-Control-Allow-Origin"))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.ACCEPT_RANGES))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.CONTENT_RANGE))
                     .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.CONTENT_LENGTH, "358406"))
@@ -901,7 +901,7 @@ class StreamControllerTest {
             initMocksWithTranscoding(false, true);
             mockMvc.perform(MockMvcRequestBuilders.get("/stream").param(Attributes.Request.ID.value(),
                     Integer.toString(song.getId()))).andExpect(MockMvcResultMatchers.status().isOk())
-                    .andExpect(MockMvcResultMatchers.header().string("Access-Control-Allow-Origin", "*"))
+                    .andExpect(MockMvcResultMatchers.header().doesNotExist("Access-Control-Allow-Origin"))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.ACCEPT_RANGES))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.CONTENT_RANGE))
                     .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.CONTENT_LENGTH, "358406"))
@@ -924,7 +924,7 @@ class StreamControllerTest {
                     .param(Attributes.Request.MAX_BIT_RATE.value(),
                             Integer.toString(TranscodeScheme.MAX_320.getMaxBitRate())))
                     .andExpect(MockMvcResultMatchers.status().isOk())
-                    .andExpect(MockMvcResultMatchers.header().string("Access-Control-Allow-Origin", "*"))
+                    .andExpect(MockMvcResultMatchers.header().doesNotExist("Access-Control-Allow-Origin"))
                     .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.ACCEPT_RANGES, "none"))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.CONTENT_RANGE))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.CONTENT_LENGTH))
@@ -944,7 +944,7 @@ class StreamControllerTest {
             player.setTranscodeScheme(TranscodeScheme.MAX_320);
             mockMvc.perform(MockMvcRequestBuilders.get("/stream").param(Attributes.Request.ID.value(),
                     Integer.toString(song.getId()))).andExpect(MockMvcResultMatchers.status().isOk())
-                    .andExpect(MockMvcResultMatchers.header().string("Access-Control-Allow-Origin", "*"))
+                    .andExpect(MockMvcResultMatchers.header().doesNotExist("Access-Control-Allow-Origin"))
                     .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.ACCEPT_RANGES, "none"))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.CONTENT_RANGE))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.CONTENT_LENGTH))
@@ -965,7 +965,7 @@ class StreamControllerTest {
             mockMvc.perform(MockMvcRequestBuilders.get("/stream")
                     .param(Attributes.Request.ID.value(), Integer.toString(song.getId())).param("format", "mp3"))
                     .andExpect(MockMvcResultMatchers.status().isOk())
-                    .andExpect(MockMvcResultMatchers.header().string("Access-Control-Allow-Origin", "*"))
+                    .andExpect(MockMvcResultMatchers.header().doesNotExist("Access-Control-Allow-Origin"))
                     .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.ACCEPT_RANGES, "none"))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.CONTENT_RANGE))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.CONTENT_LENGTH))
@@ -985,7 +985,7 @@ class StreamControllerTest {
             initMocksWithTranscoding(true, true);
             mockMvc.perform(MockMvcRequestBuilders.get("/stream").param(Attributes.Request.ID.value(),
                     Integer.toString(song.getId())))
-                    .andExpect(MockMvcResultMatchers.header().string("Access-Control-Allow-Origin", "*"))
+                    .andExpect(MockMvcResultMatchers.header().doesNotExist("Access-Control-Allow-Origin"))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.ACCEPT_RANGES))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.CONTENT_RANGE))
                     .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.CONTENT_LENGTH, "358406"))
@@ -1006,7 +1006,7 @@ class StreamControllerTest {
             initMocksWithTranscoding(true, true);
             mockMvc.perform(MockMvcRequestBuilders.get("/stream").param(Attributes.Request.ID.value(),
                     Integer.toString(song.getId())))
-                    .andExpect(MockMvcResultMatchers.header().string("Access-Control-Allow-Origin", "*"))
+                    .andExpect(MockMvcResultMatchers.header().doesNotExist("Access-Control-Allow-Origin"))
                     .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.ACCEPT_RANGES, "none"))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.CONTENT_RANGE))
                     .andExpect(MockMvcResultMatchers.header().doesNotExist(HttpHeaders.CONTENT_LENGTH))


### PR DESCRIPTION
There is some source code that sets `Access-Control-Allow-Origin : *` in the header. This does not work with current application servers. Instead of fixing it to achieve cross-domain, the relevant code is removed. 

It seems to work with Same origin in the same way as a general application. In addition, since communication is also performed by applications other than browsers, there is no need for excessive browser-dependent extension features.