### PR TITLE
Migrating to the Date Time API

### DIFF
--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -543,6 +543,11 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+        	<groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.sun.mail</groupId>
             <artifactId>jakarta.mail</artifactId>
             <scope>runtime</scope>

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/MultiService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/MultiService.java
@@ -21,9 +21,10 @@
 
 package com.tesshu.jpsonic.ajax;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
+
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
@@ -123,7 +124,7 @@ public class MultiService {
         String username = securityService.getCurrentUsername(request);
         UserSettings userSettings = securityService.getUserSettings(username);
         userSettings.setCloseDrawer(b);
-        userSettings.setChanged(new Date());
+        userSettings.setChanged(now());
         securityService.updateUserSettings(userSettings);
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/PlayQueueInfo.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/PlayQueueInfo.java
@@ -94,6 +94,7 @@ public class PlayQueueInfo {
         this.startPlayerAt = startPlayerAt;
     }
 
+    @SuppressWarnings("CanIgnoreReturnValueSuggester")
     public PlayQueueInfo startPlayerAtAndGetInfo(int startPlayerAt) {
         setStartPlayerAt(startPlayerAt);
         return this;
@@ -107,6 +108,7 @@ public class PlayQueueInfo {
         this.startPlayerAtPosition = startPlayerAtPosition;
     }
 
+    @SuppressWarnings("CanIgnoreReturnValueSuggester")
     public PlayQueueInfo startPlayerAtPositionAndGetInfo(long startPlayerAtPosition) {
         setStartPlayerAtPosition(startPlayerAtPosition);
         return this;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/PlayQueueService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/PlayQueueService.java
@@ -24,12 +24,12 @@ package com.tesshu.jpsonic.ajax;
 import static com.tesshu.jpsonic.domain.JpsonicComparators.OrderBy.ALBUM;
 import static com.tesshu.jpsonic.domain.JpsonicComparators.OrderBy.ARTIST;
 import static com.tesshu.jpsonic.domain.JpsonicComparators.OrderBy.TRACK;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.ExecutionException;
@@ -195,7 +195,7 @@ public class PlayQueueService {
         List<Integer> ids = MediaFile.toIdList(playQueue.getFiles());
 
         Integer currentId = currentSongIndex == -1 ? null : playQueue.getFile(currentSongIndex).getId();
-        SavedPlayQueue savedPlayQueue = new SavedPlayQueue(null, username, ids, currentId, positionMillis, new Date(),
+        SavedPlayQueue savedPlayQueue = new SavedPlayQueue(null, username, ids, currentId, positionMillis, now(),
                 "Airsonic");
         playQueueDao.savePlayQueue(savedPlayQueue);
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/MusicFolderSettingsCommand.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/MusicFolderSettingsCommand.java
@@ -21,9 +21,10 @@
 
 package com.tesshu.jpsonic.command;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Date;
 import java.util.List;
 
 import com.tesshu.jpsonic.controller.MusicFolderSettingsController;
@@ -232,7 +233,7 @@ public class MusicFolderSettingsCommand extends SettingsPageCommons {
                 }
                 name = fileName.toString();
             }
-            return new MusicFolder(id, path, name, enabled, new Date());
+            return new MusicFolder(id, path, name, enabled, now());
         }
 
         public boolean isExisting() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/PlayerSettingsCommand.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/PlayerSettingsCommand.java
@@ -21,7 +21,7 @@
 
 package com.tesshu.jpsonic.command;
 
-import java.util.Date;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import com.tesshu.jpsonic.controller.PlayerSettingsController;
@@ -29,6 +29,7 @@ import com.tesshu.jpsonic.domain.Player;
 import com.tesshu.jpsonic.domain.PlayerTechnology;
 import com.tesshu.jpsonic.domain.TranscodeScheme;
 import com.tesshu.jpsonic.domain.Transcoding;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Command used in {@link PlayerSettingsController}.
@@ -57,7 +58,7 @@ public class PlayerSettingsCommand extends SettingsPageCommons {
     private boolean dynamicIp;
     private boolean autoControlEnabled;
     private boolean m3uBomEnabled;
-    private Date lastSeen;
+    private ZonedDateTime lastSeen;
 
     // for view page control
     private boolean useExternalPlayer;
@@ -210,11 +211,11 @@ public class PlayerSettingsCommand extends SettingsPageCommons {
         this.m3uBomEnabled = m3uBomEnabled;
     }
 
-    public Date getLastSeen() {
+    public @Nullable ZonedDateTime getLastSeen() {
         return lastSeen;
     }
 
-    public void setLastSeen(Date lastSeen) {
+    public void setLastSeen(ZonedDateTime lastSeen) {
         this.lastSeen = lastSeen;
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/CoverArtController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/CoverArtController.java
@@ -495,7 +495,7 @@ public class CoverArtController {
 
         @Override
         public long lastModified() {
-            return coverArt == null ? artist.getLastScanned().getTime() : getLastModified(coverArt);
+            return coverArt == null ? artist.getLastScanned().toEpochMilli() : getLastModified(coverArt);
         }
 
         @Override
@@ -525,7 +525,7 @@ public class CoverArtController {
 
         @Override
         public long lastModified() {
-            return coverArt == null ? album.getLastScanned().getTime() : getLastModified(coverArt);
+            return coverArt == null ? album.getLastScanned().toEpochMilli() : getLastModified(coverArt);
         }
 
         @Override
@@ -561,7 +561,7 @@ public class CoverArtController {
 
         @Override
         public long lastModified() {
-            return playlist.getChanged().getTime();
+            return playlist.getChanged().toEpochMilli();
         }
 
         @Override
@@ -670,7 +670,7 @@ public class CoverArtController {
 
         @Override
         public long lastModified() {
-            return coverArt == null ? dir.getChanged().getTime() : getLastModified(coverArt);
+            return coverArt == null ? dir.getChanged().toEpochMilli() : getLastModified(coverArt);
         }
 
         @Override
@@ -717,7 +717,7 @@ public class CoverArtController {
 
         @Override
         public long lastModified() {
-            return mediaFile.getChanged().getTime();
+            return mediaFile.getChanged().toEpochMilli();
         }
 
         @Override

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DLNASettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DLNASettingsController.java
@@ -21,10 +21,10 @@
 
 package com.tesshu.jpsonic.controller;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -196,7 +196,7 @@ public class DLNASettingsController {
         musicFolderService.setMusicFoldersForUser(guestUser.getUsername(), allowedIds);
         UserSettings userSettings = securityService.getUserSettings(guestUser.getUsername());
         userSettings.setTranscodeScheme(command.getTranscodeScheme());
-        userSettings.setChanged(new Date());
+        userSettings.setChanged(now());
         Player guestPlayer = playerService.getGuestPlayer(null);
         transcodingService.setTranscodingsForPlayer(guestPlayer, command.getActiveTranscodingIds());
         if (command.getActiveTranscodingIds().length == 0) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DownloadController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DownloadController.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -107,7 +108,7 @@ public class DownloadController {
             if (mediaFile == null || mediaFile.isDirectory() || mediaFile.getChanged() == null) {
                 return -1;
             }
-            return mediaFile.getChanged().getTime();
+            return mediaFile.getChanged().toEpochMilli();
         } catch (ServletRequestBindingException e) {
             return -1;
         }
@@ -350,7 +351,7 @@ public class DownloadController {
             long lastLimitCheck = 0;
 
             while (true) {
-                long before = System.currentTimeMillis();
+                long before = Instant.now().toEpochMilli();
                 int n = in.read(buf);
                 if (n == -1) {
                     break;
@@ -364,7 +365,7 @@ public class DownloadController {
                 }
 
                 status.addBytesTransfered(n);
-                long after = System.currentTimeMillis();
+                long after = Instant.now().toEpochMilli();
 
                 // Calculate bitrate limit every 5 seconds.
                 if (after - lastLimitCheck > BITRATE_LIMIT_UPDATE_INTERVAL) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/HomeController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/HomeController.java
@@ -24,10 +24,11 @@ package com.tesshu.jpsonic.controller;
 import static org.springframework.web.bind.ServletRequestUtils.getIntParameter;
 import static org.springframework.web.bind.ServletRequestUtils.getStringParameter;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -50,6 +51,8 @@ import com.tesshu.jpsonic.service.SearchService;
 import com.tesshu.jpsonic.service.SecurityService;
 import com.tesshu.jpsonic.service.SettingsService;
 import com.tesshu.jpsonic.util.LegacyMap;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -206,7 +209,9 @@ public class HomeController {
         List<Album> result = new ArrayList<>();
         for (MediaFile mediaFile : mediaFileService.getMostRecentlyPlayedAlbums(offset, count, musicFolders)) {
             Album album = createAlbum(mediaFile);
-            album.setLastPlayed(mediaFile.getLastPlayed());
+            if (mediaFile.getLastPlayed() != null) {
+                album.setLastPlayed(ZonedDateTime.ofInstant(mediaFile.getLastPlayed(), ZoneId.systemDefault()));
+            }
             result.add(album);
         }
         return result;
@@ -216,11 +221,7 @@ public class HomeController {
         List<Album> result = new ArrayList<>();
         for (MediaFile file : mediaFileService.getNewestAlbums(offset, count, musicFolders)) {
             Album album = createAlbum(file);
-            Date created = file.getCreated();
-            if (created == null) {
-                created = file.getChanged();
-            }
-            album.setCreated(created);
+            album.setCreated(ZonedDateTime.ofInstant(file.getCreated(), ZoneId.systemDefault()));
             result.add(album);
         }
         return result;
@@ -295,8 +296,8 @@ public class HomeController {
         private String coverArtPath;
         private String artist;
         private String albumTitle;
-        private Date created;
-        private Date lastPlayed;
+        private ZonedDateTime created;
+        private ZonedDateTime lastPlayed;
         private Integer playCount;
         private Integer rating;
         private int id;
@@ -342,19 +343,19 @@ public class HomeController {
             this.albumTitle = albumTitle;
         }
 
-        public Date getCreated() {
+        public @NonNull ZonedDateTime getCreated() {
             return created;
         }
 
-        public void setCreated(Date created) {
+        public void setCreated(ZonedDateTime created) {
             this.created = created;
         }
 
-        public Date getLastPlayed() {
+        public @Nullable ZonedDateTime getLastPlayed() {
             return lastPlayed;
         }
 
-        public void setLastPlayed(Date lastPlayed) {
+        public void setLastPlayed(ZonedDateTime lastPlayed) {
             this.lastPlayed = lastPlayed;
         }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/InternetRadioSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/InternetRadioSettingsController.java
@@ -21,7 +21,9 @@
 
 package com.tesshu.jpsonic.controller;
 
-import java.util.Date;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
+
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -85,7 +87,7 @@ public class InternetRadioSettingsController {
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops") // (InternetRadio) Not reusable
     private String handleParameters(HttpServletRequest request) {
         List<InternetRadio> radios = internetRadioService.getAllInternetRadios(true);
-        Date current = new Date();
+        Instant current = now();
         for (InternetRadio radio : radios) {
             String msg = updateOrDeleteInternetRadio(request, radio, current);
             if (msg != null) {
@@ -105,14 +107,13 @@ public class InternetRadioSettingsController {
             if (streamUrl == null) {
                 return "internetradiosettings.nourl";
             }
-            internetRadioService
-                    .createInternetRadio(new InternetRadio(name, streamUrl, homepageUrl, enabled, new Date()));
+            internetRadioService.createInternetRadio(new InternetRadio(name, streamUrl, homepageUrl, enabled, now()));
         }
 
         return null;
     }
 
-    private String updateOrDeleteInternetRadio(HttpServletRequest request, InternetRadio radio, Date current) {
+    private String updateOrDeleteInternetRadio(HttpServletRequest request, InternetRadio radio, Instant current) {
         Integer id = radio.getId();
         String streamUrl = getParam4Array(request, Attributes.Request.STREAM_URL.value(), id);
         String homepageUrl = getParam4Array(request, Attributes.Request.HOMEPAGE_URL.value(), id);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/JAXBWriter.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/JAXBWriter.java
@@ -27,8 +27,10 @@ import static org.springframework.web.bind.ServletRequestUtils.getStringParamete
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -181,14 +183,12 @@ public class JAXBWriter {
         writeResponse(request, response, res);
     }
 
-    public XMLGregorianCalendar convertDate(Date date) {
+    public XMLGregorianCalendar convertDate(Instant date) {
         if (date == null) {
             return null;
         }
-
-        GregorianCalendar c = new GregorianCalendar();
-        c.setTime(date);
-        return datatypeFactory.newXMLGregorianCalendar(c).normalize();
+        return datatypeFactory
+                .newXMLGregorianCalendar(GregorianCalendar.from(ZonedDateTime.ofInstant(date, ZoneId.systemDefault())));
     }
 
     public XMLGregorianCalendar convertCalendar(Calendar calendar) {
@@ -196,6 +196,6 @@ public class JAXBWriter {
             return null;
         }
 
-        return datatypeFactory.newXMLGregorianCalendar((GregorianCalendar) calendar).normalize();
+        return datatypeFactory.newXMLGregorianCalendar((GregorianCalendar) calendar);
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MainController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MainController.java
@@ -21,7 +21,11 @@
 
 package com.tesshu.jpsonic.controller;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.FAR_PAST;
+
 import java.io.IOException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +36,6 @@ import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.tesshu.jpsonic.dao.MediaFileDao;
 import com.tesshu.jpsonic.domain.CoverArtScheme;
 import com.tesshu.jpsonic.domain.JpsonicComparators;
 import com.tesshu.jpsonic.domain.MediaFile;
@@ -107,6 +110,7 @@ public class MainController {
         // dir
         mediaFileService.populateStarredDate(dir, username);
         map.put("dir", dir);
+        putLastPlayed(map, dir);
         map.put("ancestors", getAncestors(dir));
         map.put("userRating", getUserRating(username, dir));
         map.put("averageRating", getAverageRating(dir));
@@ -116,7 +120,7 @@ public class MainController {
             map.put("parent", parent);
             map.put("navigateUpAllowed", !mediaFileService.isRoot(parent));
         }
-        map.put("scanForcable", !MediaFileDao.ZERO_DATE.equals(dir.getLastScanned()));
+        map.put("scanForcable", !FAR_PAST.equals(dir.getLastScanned()));
 
         // children
         List<MediaFile> children = mediaFiles.size() == 1 // children
@@ -176,6 +180,12 @@ public class MainController {
         map.put("breadcrumbIndex", userSettings.isBreadcrumbIndex());
 
         return new ModelAndView(getTargetView(dir, children), "model", map);
+    }
+
+    private void putLastPlayed(Map<String, Object> map, MediaFile dir) {
+        if (dir.getLastPlayed() != null) {
+            map.put("lastPlayed", ZonedDateTime.ofInstant(dir.getLastPlayed(), ZoneId.systemDefault()));
+        }
     }
 
     private boolean getThereIsMore(boolean thereIsMoreSiblingAlbums, boolean isShowAll, List<MediaFile> subDirs,

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/OutlineHelpSelector.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/OutlineHelpSelector.java
@@ -19,7 +19,7 @@
 
 package com.tesshu.jpsonic.controller;
 
-import java.util.Date;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -44,7 +44,7 @@ public class OutlineHelpSelector {
                 Attributes.Request.SHOW_OUTLINE_HELP.value(), userSettings.isShowOutlineHelp());
         if (showOutlineHelp != userSettings.isShowOutlineHelp()) {
             userSettings.setShowOutlineHelp(showOutlineHelp);
-            userSettings.setChanged(new Date());
+            userSettings.setChanged(now());
             securityService.updateUserSettings(userSettings);
         }
         return showOutlineHelp;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PersonalSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PersonalSettingsController.java
@@ -21,9 +21,9 @@
 
 package com.tesshu.jpsonic.controller;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -314,7 +314,7 @@ public class PersonalSettingsController {
         settings.setOpenDetailIndex(command.isOpenDetailIndex());
         settings.setOpenDetailSetting(command.isOpenDetailSetting());
         settings.setOpenDetailStar(command.isOpenDetailStar());
-        settings.setChanged(new Date());
+        settings.setChanged(now());
         redirectAttributes.addFlashAttribute(Attributes.Redirect.RELOAD_FLAG.value(), true);
 
         securityService.updateUserSettings(settings);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PlayerSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PlayerSettingsController.java
@@ -21,6 +21,8 @@
 
 package com.tesshu.jpsonic.controller;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -126,7 +128,9 @@ public class PlayerSettingsController {
             command.setDynamicIp(player.isDynamicIp());
             command.setAutoControlEnabled(player.isAutoControlEnabled());
             command.setM3uBomEnabled(player.isM3uBomEnabled());
-            command.setLastSeen(player.getLastSeen());
+            if (player.getLastSeen() != null) {
+                command.setLastSeen(ZonedDateTime.ofInstant(player.getLastSeen(), ZoneId.systemDefault()));
+            }
         }
 
         // for view page control

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PlaylistController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PlaylistController.java
@@ -21,6 +21,9 @@
 
 package com.tesshu.jpsonic.controller;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -78,8 +81,9 @@ public class PlaylistController {
         Player player = playerService.getPlayer(request, response);
 
         return new ModelAndView("playlist", "model",
-                LegacyMap.of("playlist", playlist, "user", user, "visibility", userSettings.getMainVisibility(),
-                        "player", player, "editAllowed",
+                LegacyMap.of("playlist", playlist, "created",
+                        ZonedDateTime.ofInstant(playlist.getCreated(), ZoneId.systemDefault()), "user", user,
+                        "visibility", userSettings.getMainVisibility(), "player", player, "editAllowed",
                         username.equals(playlist.getUsername()) || securityService.isAdmin(username), "coverArtSize",
                         CoverArtScheme.LARGE.getSize(), "partyMode", userSettings.isPartyModeEnabled(), "simpleDisplay",
                         userSettings.isSimpleDisplay()));

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PodcastController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PodcastController.java
@@ -22,8 +22,8 @@
 package com.tesshu.jpsonic.controller;
 
 import java.security.GeneralSecurityException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -55,11 +55,8 @@ public class PodcastController {
     private final SettingsService settingsService;
     private final SecurityService securityService;
     private final PlaylistService playlistService;
-    private final Object dateLock = new Object();
-
-    // Locale is changed by Setting, but restart is required.
-    private DateFormat rssDateFormat;
-    private String lang;
+    private final DateTimeFormatter rssDateFormat = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z")
+            .withZone(ZoneId.systemDefault()).withLocale(Locale.ENGLISH);
 
     public PodcastController(SettingsService settingsService, SecurityService securityService,
             PlaylistService playlistService) {
@@ -67,17 +64,6 @@ public class PodcastController {
         this.playlistService = playlistService;
         this.settingsService = settingsService;
         this.securityService = securityService;
-    }
-
-    private DateFormat getRssDateFormat() {
-        synchronized (dateLock) {
-            if (rssDateFormat == null) {
-                Locale locale = settingsService.getLocale();
-                rssDateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z", locale);
-                lang = locale.getLanguage();
-            }
-            return rssDateFormat;
-        }
     }
 
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops") // (Podcast) Not reusable
@@ -103,7 +89,7 @@ public class PodcastController {
             for (MediaFile song : songs) {
                 length += song.getFileSize();
             }
-            String publishDate = getRssDateFormat().format(playlist.getCreated());
+            String publishDate = rssDateFormat.format(playlist.getCreated());
 
             // Resolve content type.
             String suffix = songs.get(0).getFormat();
@@ -115,7 +101,7 @@ public class PodcastController {
         }
 
         return new ModelAndView("podcast", "model",
-                LegacyMap.of("url", url, "lang", lang, "logo",
+                LegacyMap.of("url", url, "lang", settingsService.getLocale().getLanguage(), "logo",
                         url.replaceAll("podcast/" + ViewName.PODCAST.value() + "$", "") + "/icons/logo.svg", "podcasts",
                         podcasts));
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StatusChartController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StatusChartController.java
@@ -25,8 +25,8 @@ import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Font;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
@@ -100,7 +100,7 @@ public class StatusChartController extends AbstractChartController {
 
         TimeSeries series = new TimeSeries("Kbps");
         TransferStatus.SampleHistory history = status.getHistory();
-        long to = System.currentTimeMillis();
+        long to = Instant.now().toEpochMilli();
         long from = to - status.getHistoryLengthMillis();
 
         if (!history.isEmpty()) {
@@ -114,7 +114,8 @@ public class StatusChartController extends AbstractChartController {
                 long bytesStreamed = Math.max(0L, sample.getBytesTransfered() - previous.getBytesTransfered());
 
                 double kbps = (8.0 * bytesStreamed / 1024.0) / (elapsedTimeMilis / 1000.0);
-                series.addOrUpdate(new Millisecond(new Date(sample.getTimestamp())), kbps);
+                series.addOrUpdate(new Millisecond(java.util.Date.from(Instant.ofEpochMilli(sample.getTimestamp()))),
+                        kbps);
 
                 previous = sample;
             }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SubsonicRESTController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SubsonicRESTController.java
@@ -22,13 +22,14 @@
 package com.tesshu.jpsonic.controller;
 
 import static com.tesshu.jpsonic.security.RESTRequestParameterProcessingFilter.decrypt;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -379,7 +380,7 @@ public class SubsonicRESTController {
                         index.getArtist().add(a);
                         a.setId(String.valueOf(mediaFile.getId()));
                         a.setName(artist.getName());
-                        Date starredDate = mediaFileDao.getMediaFileStarredDate(mediaFile.getId(), username);
+                        Instant starredDate = mediaFileDao.getMediaFileStarredDate(mediaFile.getId(), username);
                         a.setStarred(jaxbWriter.convertDate(starredDate));
 
                         if (mediaFile.isAlbum()) {
@@ -646,7 +647,7 @@ public class SubsonicRESTController {
         org.subsonic.restapi.Artist result = new org.subsonic.restapi.Artist();
         result.setId(String.valueOf(artist.getId()));
         result.setName(artist.getArtist());
-        Date starred = mediaFileDao.getMediaFileStarredDate(artist.getId(), username);
+        Instant starred = mediaFileDao.getMediaFileStarredDate(artist.getId(), username);
         result.setStarred(jaxbWriter.convertDate(starred));
         return result;
     }
@@ -1034,8 +1035,9 @@ public class SubsonicRESTController {
         if (playlistId == null) {
             playlist = new com.tesshu.jpsonic.domain.Playlist();
             playlist.setName(name);
-            playlist.setCreated(new Date());
-            playlist.setChanged(new Date());
+            Instant now = now();
+            playlist.setCreated(now);
+            playlist.setChanged(now);
             playlist.setShared(false);
             playlist.setUsername(username);
             playlistService.createPlaylist(playlist);
@@ -1570,7 +1572,7 @@ public class SubsonicRESTController {
                 }
                 continue;
             }
-            Date time = times.length == 0 ? new Date() : new Date(times[i]);
+            Instant time = times.length == 0 ? now() : Instant.ofEpochMilli(times[i]);
             statusService.addRemotePlay(new PlayStatus(file, player, time));
             mediaFileService.incrementPlayCount(file);
             if (securityService.getUserSettings(player.getUsername()).isLastFmEnabled()) {
@@ -1922,8 +1924,8 @@ public class SubsonicRESTController {
         int mediaFileId = ServletRequestUtils.getRequiredIntParameter(request, Attributes.Request.ID.value());
         long position = ServletRequestUtils.getRequiredLongParameter(request, Attributes.Request.POSITION.value());
         String comment = request.getParameter(Attributes.Request.COMMENT.value());
-        Date now = new Date();
 
+        Instant now = now();
         Bookmark bookmark = new Bookmark(0, mediaFileId, position, username, comment, now, now);
         bookmarkService.createOrUpdateBookmark(bookmark);
         writeEmptyResponse(request, response);
@@ -1986,7 +1988,7 @@ public class SubsonicRESTController {
 
         String username = securityService.getCurrentUsername(request);
         Long position = ServletRequestUtils.getLongParameter(request, Attributes.Request.POSITION.value());
-        Date changed = new Date();
+        Instant changed = now();
         String changedBy = ServletRequestUtils.getRequiredStringParameter(request, Attributes.Request.C.value());
 
         SavedPlayQueue playQueue = new SavedPlayQueue(null, username, mediaFileIds, current, position, changed,
@@ -2037,7 +2039,7 @@ public class SubsonicRESTController {
         share.setDescription(request.getParameter(Attributes.Request.DESCRIPTION.value()));
         long expires = ServletRequestUtils.getLongParameter(request, Attributes.Request.EXPIRES.value(), 0L);
         if (expires != 0) {
-            share.setExpires(new Date(expires));
+            share.setExpires(Instant.ofEpochMilli(expires));
         }
         shareService.updateShare(share);
 
@@ -2104,7 +2106,7 @@ public class SubsonicRESTController {
         String expiresString = request.getParameter(Attributes.Request.EXPIRES.value());
         if (expiresString != null) {
             long expires = Long.parseLong(expiresString);
-            share.setExpires(expires == 0L ? null : new Date(expires));
+            share.setExpires(expires == 0L ? null : Instant.ofEpochMilli(expires));
         }
         shareService.updateShare(share);
         writeEmptyResponse(request, response);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/TopController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/TopController.java
@@ -23,6 +23,7 @@ package com.tesshu.jpsonic.controller;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
@@ -197,7 +198,7 @@ public class TopController {
             return -1L;
         }
 
-        long lastModified = System.currentTimeMillis();
+        long lastModified = Instant.now().toEpochMilli();
         String username = securityService.getCurrentUsernameStrict(request);
 
         // When was settings last changed?
@@ -225,17 +226,17 @@ public class TopController {
 
         // When was music folder table last changed?
         for (MusicFolder musicFolder : allMusicFolders) {
-            lastModified = Math.max(lastModified, musicFolder.getChanged().getTime());
+            lastModified = Math.max(lastModified, musicFolder.getChanged().toEpochMilli());
         }
 
         // When was internet radio table last changed?
         for (InternetRadio internetRadio : internetRadioService.getAllInternetRadios()) {
-            lastModified = Math.max(lastModified, internetRadio.getChanged().getTime());
+            lastModified = Math.max(lastModified, internetRadio.getChanged().toEpochMilli());
         }
 
         // When was user settings last changed?
         UserSettings userSettings = securityService.getUserSettings(username);
-        lastModified = Math.max(lastModified, userSettings.getChanged().getTime());
+        lastModified = Math.max(lastModified, userSettings.getChanged().toEpochMilli());
 
         return lastModified;
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/UploadController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/UploadController.java
@@ -27,6 +27,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.GeneralSecurityException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -334,7 +335,7 @@ public class UploadController {
             this.status = status;
             this.statusService = statusService;
             this.settingsService = settingsService;
-            this.startTime = System.currentTimeMillis();
+            this.startTime = Instant.now().toEpochMilli();
         }
 
         @Override
@@ -348,7 +349,7 @@ public class UploadController {
             // Throttle bitrate.
             long byteCount = status.getBytesTransfered() + bytesRead;
             long bitCount = byteCount * 8L;
-            float elapsedMillis = Math.max(1, System.currentTimeMillis() - startTime);
+            float elapsedMillis = Math.max(1, Instant.now().toEpochMilli() - startTime);
             float elapsedSeconds = elapsedMillis / 1000.0F;
             long maxBitsPerSecond = getBitrateLimit();
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/UserSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/UserSettingsController.java
@@ -21,8 +21,9 @@
 
 package com.tesshu.jpsonic.controller;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
+
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -239,7 +240,7 @@ public class UserSettingsController {
                 }
             }
         }
-        userSettings.setChanged(new Date());
+        userSettings.setChanged(now());
         securityService.updateUserSettings(userSettings);
 
         List<Integer> allowedMusicFolderIds = PlayerUtils.toIntegerList(command.getAllowedMusicFolderIds());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/ViewAsListSelector.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/ViewAsListSelector.java
@@ -19,7 +19,7 @@
 
 package com.tesshu.jpsonic.controller;
 
-import java.util.Date;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -44,7 +44,7 @@ public class ViewAsListSelector {
                 userSettings.isViewAsList());
         if (viewAsList != userSettings.isViewAsList()) {
             userSettings.setViewAsList(viewAsList);
-            userSettings.setChanged(new Date());
+            userSettings.setChanged(now());
             securityService.updateUserSettings(userSettings);
         }
         return viewAsList;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AbstractDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AbstractDao.java
@@ -21,10 +21,12 @@
 
 package com.tesshu.jpsonic.dao;
 
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import com.tesshu.jpsonic.SuppressFBWarnings;
@@ -150,11 +152,11 @@ public class AbstractDao {
         return result;
     }
 
-    protected Date queryForDate(String sql, Date defaultValue, Object... args) {
-        long t = System.nanoTime();
-        List<Date> list = getJdbcTemplate().queryForList(sql, Date.class, args);
-        Date result = list.isEmpty() ? defaultValue : list.get(0) == null ? defaultValue : list.get(0);
-        writeLog(sql, t);
+    protected Instant queryForInstant(String sql, Instant defaultValue, Object... args) {
+        long startTimeNano = System.nanoTime();
+        Instant result = getJdbcTemplate().queryForList(sql, Timestamp.class, args).stream().filter(Objects::nonNull)
+                .findFirst().map(t -> t.toInstant()).orElse(defaultValue);
+        writeLog(sql, startTimeNano);
         return result;
     }
 
@@ -181,4 +183,7 @@ public class AbstractDao {
         daoHelper.checkpoint();
     }
 
+    protected static @Nullable Instant nullableInstantOf(Timestamp timestamp) {
+        return timestamp == null ? null : timestamp.toInstant();
+    }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AlbumDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AlbumDao.java
@@ -21,12 +21,14 @@
 
 package com.tesshu.jpsonic.dao;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -387,7 +389,7 @@ public class AlbumDao extends AbstractDao {
         }
     }
 
-    public void markNonPresent(Date lastScanned) {
+    public void markNonPresent(Instant lastScanned) {
         int minId = queryForInt("select min(id) from album where last_scanned < ? and present", 0, lastScanned);
         int maxId = queryForInt("select max(id) from album where last_scanned < ? and present", 0, lastScanned);
 
@@ -414,15 +416,15 @@ public class AlbumDao extends AbstractDao {
 
     public void starAlbum(int albumId, String username) {
         unstarAlbum(albumId, username);
-        update("insert into starred_album(album_id, username, created) values (?,?,?)", albumId, username, new Date());
+        update("insert into starred_album(album_id, username, created) values (?,?,?)", albumId, username, now());
     }
 
     public void unstarAlbum(int albumId, String username) {
         update("delete from starred_album where album_id=? and username=?", albumId, username);
     }
 
-    public Date getAlbumStarredDate(int albumId, String username) {
-        return queryForDate("select created from starred_album where album_id=? and username=?", null, albumId,
+    public Instant getAlbumStarredDate(int albumId, String username) {
+        return queryForInstant("select created from starred_album where album_id=? and username=?", null, albumId,
                 username);
     }
 
@@ -431,8 +433,9 @@ public class AlbumDao extends AbstractDao {
         public Album mapRow(ResultSet rs, int rowNum) throws SQLException {
             return new Album(rs.getInt(1), rs.getString(2), rs.getString(3), rs.getString(4), rs.getInt(5),
                     rs.getInt(6), rs.getString(7), rs.getInt(8) == 0 ? null : rs.getInt(8), rs.getString(9),
-                    rs.getInt(10), rs.getTimestamp(11), rs.getString(12), rs.getTimestamp(13), rs.getTimestamp(14),
-                    rs.getBoolean(15), rs.getInt(16), rs.getString(17),
+                    rs.getInt(10), nullableInstantOf(rs.getTimestamp(11)), rs.getString(12),
+                    nullableInstantOf(rs.getTimestamp(13)), nullableInstantOf(rs.getTimestamp(14)), rs.getBoolean(15),
+                    rs.getInt(16), rs.getString(17),
                     // JP >>>>
                     rs.getString(18), rs.getString(19), rs.getString(20), rs.getString(21), rs.getInt(22)); // <<<< JP
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AvatarDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AvatarDao.java
@@ -105,8 +105,8 @@ public class AvatarDao extends AbstractDao {
     private static class AvatarRowMapper implements RowMapper<Avatar> {
         @Override
         public Avatar mapRow(ResultSet rs, int rowNum) throws SQLException {
-            return new Avatar(rs.getInt(1), rs.getString(2), rs.getTimestamp(3), rs.getString(4), rs.getInt(5),
-                    rs.getInt(6), rs.getBytes(7));
+            return new Avatar(rs.getInt(1), rs.getString(2), nullableInstantOf(rs.getTimestamp(3)), rs.getString(4),
+                    rs.getInt(5), rs.getInt(6), rs.getBytes(7));
         }
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/BookmarkDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/BookmarkDao.java
@@ -100,7 +100,7 @@ public class BookmarkDao extends AbstractDao {
         @Override
         public Bookmark mapRow(ResultSet rs, int rowNum) throws SQLException {
             return new Bookmark(rs.getInt(1), rs.getInt(2), rs.getLong(3), rs.getString(4), rs.getString(5),
-                    rs.getTimestamp(6), rs.getTimestamp(7));
+                    nullableInstantOf(rs.getTimestamp(6)), nullableInstantOf(rs.getTimestamp(7)));
         }
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/InternetRadioDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/InternetRadioDao.java
@@ -118,7 +118,7 @@ public class InternetRadioDao extends AbstractDao {
         @Override
         public InternetRadio mapRow(ResultSet rs, int rowNum) throws SQLException {
             return new InternetRadio(rs.getInt(1), rs.getString(2), rs.getString(3), rs.getString(4), rs.getBoolean(5),
-                    rs.getTimestamp(6));
+                    nullableInstantOf(rs.getTimestamp(6)));
         }
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/JMediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/JMediaFileDao.java
@@ -26,10 +26,10 @@ import static org.springframework.util.ObjectUtils.isEmpty;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -420,11 +420,11 @@ public class JMediaFileDao extends AbstractDao {
         return result;
     }
 
-    public void markNonPresent(Date lastScanned) {
+    public void markNonPresent(Instant lastScanned) {
         deligate.markNonPresent(lastScanned);
     }
 
-    public void markPresent(String path, Date lastScanned) {
+    public void markPresent(String path, Instant lastScanned) {
         deligate.markPresent(path, lastScanned);
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MusicFolderDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MusicFolderDao.java
@@ -134,7 +134,7 @@ public class MusicFolderDao extends AbstractDao {
         @Override
         public MusicFolder mapRow(ResultSet rs, int rowNum) throws SQLException {
             return new MusicFolder(rs.getInt(1), rs.getString(2), rs.getString(3), rs.getBoolean(4),
-                    rs.getTimestamp(5));
+                    nullableInstantOf(rs.getTimestamp(5)));
         }
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/PlayQueueDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/PlayQueueDao.java
@@ -79,7 +79,7 @@ public class PlayQueueDao extends AbstractDao {
         @Override
         public SavedPlayQueue mapRow(ResultSet rs, int rowNum) throws SQLException {
             return new SavedPlayQueue(rs.getInt(1), rs.getString(2), null, rs.getInt(3), rs.getLong(4),
-                    rs.getTimestamp(5), rs.getString(6));
+                    nullableInstantOf(rs.getTimestamp(5)), rs.getString(6));
         }
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/PlayerDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/PlayerDao.java
@@ -209,7 +209,7 @@ public class PlayerDao extends AbstractDao {
             player.setIpAddress(rs.getString(col++));
             player.setAutoControlEnabled(rs.getBoolean(col++));
             player.setM3uBomEnabled(rs.getBoolean(col++));
-            player.setLastSeen(rs.getTimestamp(col++));
+            player.setLastSeen(nullableInstantOf(rs.getTimestamp(col++)));
             col++; // Ignore cover art scheme.
             player.setTranscodeScheme(TranscodeScheme.of(rs.getString(col++)));
             player.setDynamicIp(rs.getBoolean(col++));

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/PlaylistDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/PlaylistDao.java
@@ -21,10 +21,11 @@
 
 package com.tesshu.jpsonic.dao;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
+
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -111,7 +112,7 @@ public class PlaylistDao extends AbstractDao {
             }
         }
         update("update playlist set file_count=?, duration_seconds=?, changed=? where id=?", files.size(), duration,
-                new Date(), id);
+                now(), id);
     }
 
     public List<String> getPlaylistUsers(int playlistId) {
@@ -135,7 +136,7 @@ public class PlaylistDao extends AbstractDao {
 
     public void updatePlaylist(Playlist playlist) {
         update("update playlist set username=?, is_public=?, name=?, comment=?, changed=?, imported_from=? where id=?",
-                playlist.getUsername(), playlist.isShared(), playlist.getName(), playlist.getComment(), new Date(),
+                playlist.getUsername(), playlist.isShared(), playlist.getName(), playlist.getComment(), now(),
                 playlist.getImportedFrom(), playlist.getId());
     }
 
@@ -143,7 +144,8 @@ public class PlaylistDao extends AbstractDao {
         @Override
         public Playlist mapRow(ResultSet rs, int rowNum) throws SQLException {
             return new Playlist(rs.getInt(1), rs.getString(2), rs.getBoolean(3), rs.getString(4), rs.getString(5),
-                    rs.getInt(6), rs.getInt(7), rs.getTimestamp(8), rs.getTimestamp(9), rs.getString(10));
+                    rs.getInt(6), rs.getInt(7), nullableInstantOf(rs.getTimestamp(8)),
+                    nullableInstantOf(rs.getTimestamp(9)), rs.getString(10));
         }
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/PodcastDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/PodcastDao.java
@@ -214,7 +214,7 @@ public class PodcastDao extends AbstractDao {
         @Override
         public PodcastEpisode mapRow(ResultSet rs, int rowNum) throws SQLException {
             return new PodcastEpisode(rs.getInt(1), rs.getInt(2), rs.getString(3), rs.getString(4), rs.getString(5),
-                    rs.getString(6), rs.getTimestamp(7), rs.getString(8), (Long) rs.getObject(9),
+                    rs.getString(6), nullableInstantOf(rs.getTimestamp(7)), rs.getString(8), (Long) rs.getObject(9),
                     (Long) rs.getObject(10), PodcastStatus.valueOf(rs.getString(11)), rs.getString(12));
         }
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/ShareDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/ShareDao.java
@@ -149,8 +149,9 @@ public class ShareDao extends AbstractDao {
     private static class ShareRowMapper implements RowMapper<Share> {
         @Override
         public Share mapRow(ResultSet rs, int rowNum) throws SQLException {
-            return new Share(rs.getInt(1), rs.getString(2), rs.getString(3), rs.getString(4), rs.getTimestamp(5),
-                    rs.getTimestamp(6), rs.getTimestamp(7), rs.getInt(8));
+            return new Share(rs.getInt(1), rs.getString(2), rs.getString(3), rs.getString(4),
+                    nullableInstantOf(rs.getTimestamp(5)), nullableInstantOf(rs.getTimestamp(6)),
+                    nullableInstantOf(rs.getTimestamp(7)), rs.getInt(8));
         }
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/UserDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/UserDao.java
@@ -429,7 +429,7 @@ public class UserDao extends AbstractDao {
             settings.setNowPlayingAllowed(rs.getBoolean(col++));
             settings.setAvatarScheme(AvatarScheme.valueOf(rs.getString(col++)));
             settings.setSystemAvatarId((Integer) rs.getObject(col++));
-            settings.setChanged(rs.getTimestamp(col++));
+            settings.setChanged(nullableInstantOf(rs.getTimestamp(col++)));
             settings.setShowArtistInfoEnabled(rs.getBoolean(col++));
             settings.setAutoHidePlayQueue(rs.getBoolean(col++));
             settings.setViewAsList(rs.getBoolean(col++));

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Album.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Album.java
@@ -21,7 +21,7 @@
 
 package com.tesshu.jpsonic.domain;
 
-import java.util.Date;
+import java.time.Instant;
 
 public class Album {
 
@@ -35,10 +35,10 @@ public class Album {
     private Integer year;
     private String genre;
     private int playCount;
-    private Date lastPlayed;
+    private Instant lastPlayed;
     private String comment;
-    private Date created;
-    private Date lastScanned;
+    private Instant created;
+    private Instant lastScanned;
     private boolean present;
     private Integer folderId;
     private String musicBrainzReleaseId;
@@ -62,8 +62,8 @@ public class Album {
     }
 
     public Album(int id, String path, String name, String artist, int songCount, int durationSeconds,
-            String coverArtPath, Integer year, String genre, int playCount, Date lastPlayed, String comment,
-            Date created, Date lastScanned, boolean present, Integer folderId, String musicBrainzReleaseId,
+            String coverArtPath, Integer year, String genre, int playCount, Instant lastPlayed, String comment,
+            Instant created, Instant lastScanned, boolean present, Integer folderId, String musicBrainzReleaseId,
             // JP >>>>
             String artistSort, String nameSort, String artistReading, String nameReading, int order // <<<< JP
     ) {
@@ -173,11 +173,11 @@ public class Album {
         this.playCount = playCount;
     }
 
-    public Date getLastPlayed() {
+    public Instant getLastPlayed() {
         return lastPlayed;
     }
 
-    public void setLastPlayed(Date lastPlayed) {
+    public void setLastPlayed(Instant lastPlayed) {
         this.lastPlayed = lastPlayed;
     }
 
@@ -189,19 +189,19 @@ public class Album {
         this.comment = comment;
     }
 
-    public Date getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
-    public void setCreated(Date created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public Date getLastScanned() {
+    public Instant getLastScanned() {
         return lastScanned;
     }
 
-    public void setLastScanned(Date lastScanned) {
+    public void setLastScanned(Instant lastScanned) {
         this.lastScanned = lastScanned;
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Artist.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Artist.java
@@ -21,7 +21,7 @@
 
 package com.tesshu.jpsonic.domain;
 
-import java.util.Date;
+import java.time.Instant;
 
 public class Artist {
 
@@ -29,7 +29,7 @@ public class Artist {
     private String name;
     private String coverArtPath;
     private int albumCount;
-    private Date lastScanned;
+    private Instant lastScanned;
     private boolean present;
     private Integer folderId;
 
@@ -49,7 +49,7 @@ public class Artist {
     public Artist() {
     }
 
-    public Artist(int id, String name, String coverArtPath, int albumCount, Date lastScanned, boolean present,
+    public Artist(int id, String name, String coverArtPath, int albumCount, Instant lastScanned, boolean present,
             Integer folderId,
             // JP >>>>
             String sort, String reading, int order // <<<< JP
@@ -100,11 +100,11 @@ public class Artist {
         this.albumCount = albumCount;
     }
 
-    public Date getLastScanned() {
+    public Instant getLastScanned() {
         return lastScanned;
     }
 
-    public void setLastScanned(Date lastScanned) {
+    public void setLastScanned(Instant lastScanned) {
         this.lastScanned = lastScanned;
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Avatar.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Avatar.java
@@ -21,7 +21,7 @@
 
 package com.tesshu.jpsonic.domain;
 
-import java.util.Date;
+import java.time.Instant;
 
 /**
  * An icon representing a user.
@@ -32,7 +32,7 @@ public class Avatar {
 
     private final int id;
     private final String name;
-    private final Date createdDate;
+    private final Instant createdDate;
     private final String mimeType;
     private final int width;
     private final int height;
@@ -42,7 +42,7 @@ public class Avatar {
     /*
      * False positive. The caller is guaranteed and cloning is a waste of time.
      */
-    public Avatar(int id, String name, Date createdDate, String mimeType, int width, int height, byte[] data) {
+    public Avatar(int id, String name, Instant createdDate, String mimeType, int width, int height, byte[] data) {
         this.id = id;
         this.name = name;
         this.createdDate = createdDate;
@@ -60,7 +60,7 @@ public class Avatar {
         return name;
     }
 
-    public Date getCreatedDate() {
+    public Instant getCreatedDate() {
         return createdDate;
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Bookmark.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Bookmark.java
@@ -21,7 +21,7 @@
 
 package com.tesshu.jpsonic.domain;
 
-import java.util.Date;
+import java.time.Instant;
 
 /**
  * A bookmark within a media file, for a given user.
@@ -35,11 +35,11 @@ public class Bookmark {
     private long positionMillis;
     private String username;
     private String comment;
-    private Date created;
-    private Date changed;
+    private Instant created;
+    private Instant changed;
 
-    public Bookmark(int id, int mediaFileId, long positionMillis, String username, String comment, Date created,
-            Date changed) {
+    public Bookmark(int id, int mediaFileId, long positionMillis, String username, String comment, Instant created,
+            Instant changed) {
         this.id = id;
         this.mediaFileId = mediaFileId;
         this.positionMillis = positionMillis;
@@ -89,19 +89,19 @@ public class Bookmark {
         this.comment = comment;
     }
 
-    public Date getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
-    public void setCreated(Date created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public Date getChanged() {
+    public Instant getChanged() {
         return changed;
     }
 
-    public void setChanged(Date changed) {
+    public void setChanged(Instant changed) {
         this.changed = changed;
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/InternetRadio.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/InternetRadio.java
@@ -21,7 +21,7 @@
 
 package com.tesshu.jpsonic.domain;
 
-import java.util.Date;
+import java.time.Instant;
 
 /**
  * Represents an internet radio station.
@@ -35,7 +35,7 @@ public class InternetRadio {
     private String streamUrl;
     private String homepageUrl;
     private boolean enabled;
-    private Date changed;
+    private Instant changed;
 
     /**
      * Creates a new internet radio station.
@@ -54,7 +54,7 @@ public class InternetRadio {
      *            When the corresponding database entry was last changed.
      */
     public InternetRadio(Integer id, String name, String streamUrl, String homepageUrl, boolean isEnabled,
-            Date changed) {
+            Instant changed) {
         this.id = id;
         this.name = name;
         this.streamUrl = streamUrl;
@@ -77,7 +77,7 @@ public class InternetRadio {
      * @param changed
      *            When the corresponding database entry was last changed.
      */
-    public InternetRadio(String name, String streamUrl, String homepageUrl, boolean isEnabled, Date changed) {
+    public InternetRadio(String name, String streamUrl, String homepageUrl, boolean isEnabled, Instant changed) {
         this(null, name, streamUrl, homepageUrl, isEnabled, changed);
     }
 
@@ -171,7 +171,7 @@ public class InternetRadio {
      *
      * @return When the corresponding database entry was last changed.
      */
-    public Date getChanged() {
+    public Instant getChanged() {
         return changed;
     }
 
@@ -181,7 +181,7 @@ public class InternetRadio {
      * @param changed
      *            When the corresponding database entry was last changed.
      */
-    public void setChanged(Date changed) {
+    public void setChanged(Instant changed) {
         this.changed = changed;
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaFile.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaFile.java
@@ -23,7 +23,7 @@ package com.tesshu.jpsonic.domain;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import com.tesshu.jpsonic.util.StringUtil;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.ObjectUtils;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -63,13 +64,13 @@ public class MediaFile {
     private String coverArtPathString;
     private String parentPathString;
     private int playCount;
-    private Date lastPlayed;
+    private Instant lastPlayed;
     private String comment;
-    private Date created;
-    private Date changed;
-    private Date lastScanned;
-    private Date starredDate;
-    private Date childrenLastUpdated;
+    private Instant created;
+    private Instant changed;
+    private Instant lastScanned;
+    private Instant starredDate;
+    private Instant childrenLastUpdated;
     private boolean present;
     private int version;
     private String musicBrainzReleaseId;
@@ -93,12 +94,12 @@ public class MediaFile {
     public MediaFile(int id, String path, String folder, MediaType mediaType, String format, String title,
             String albumName, String artist, String albumArtist, Integer discNumber, Integer trackNumber, Integer year,
             String genre, Integer bitRate, boolean variableBitRate, Integer durationSeconds, Long fileSize,
-            Integer width, Integer height, String coverArtPath, String parentPath, int playCount, Date lastPlayed,
-            String comment, Date created, Date changed, Date lastScanned, Date childrenLastUpdated, boolean present,
-            int version, String musicBrainzReleaseId, String musicBrainzRecordingId, String composer, String artistSort,
-            String albumSort, String titleSort, String albumArtistSort, String composerSort, String artistReading,
-            String albumReading, String albumArtistReading, String artistSortRaw, String albumSortRaw,
-            String albumArtistSortRaw, String composerSortRaw, int order) {
+            Integer width, Integer height, String coverArtPath, String parentPath, int playCount, Instant lastPlayed,
+            String comment, Instant created, Instant changed, Instant lastScanned, Instant childrenLastUpdated,
+            boolean present, int version, String musicBrainzReleaseId, String musicBrainzRecordingId, String composer,
+            String artistSort, String albumSort, String titleSort, String albumArtistSort, String composerSort,
+            String artistReading, String albumReading, String albumArtistReading, String artistSortRaw,
+            String albumSortRaw, String albumArtistSortRaw, String composerSortRaw, int order) {
         this.id = id;
         this.pathString = path;
         this.folder = folder;
@@ -373,11 +374,11 @@ public class MediaFile {
         this.playCount = playCount;
     }
 
-    public @Nullable Date getLastPlayed() {
+    public @Nullable Instant getLastPlayed() {
         return lastPlayed;
     }
 
-    public void setLastPlayed(Date lastPlayed) {
+    public void setLastPlayed(Instant lastPlayed) {
         this.lastPlayed = lastPlayed;
     }
 
@@ -389,35 +390,35 @@ public class MediaFile {
         this.comment = comment;
     }
 
-    public Date getCreated() {
+    public @NonNull Instant getCreated() {
         return created;
     }
 
-    public void setCreated(Date created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public Date getChanged() {
+    public @NonNull Instant getChanged() {
         return changed;
     }
 
-    public void setChanged(Date changed) {
+    public void setChanged(Instant changed) {
         this.changed = changed;
     }
 
-    public Date getLastScanned() {
+    public Instant getLastScanned() {
         return lastScanned;
     }
 
-    public void setLastScanned(Date lastScanned) {
+    public void setLastScanned(Instant lastScanned) {
         this.lastScanned = lastScanned;
     }
 
-    public Date getStarredDate() {
+    public Instant getStarredDate() {
         return starredDate;
     }
 
-    public void setStarredDate(Date starredDate) {
+    public void setStarredDate(Instant starredDate) {
         this.starredDate = starredDate;
     }
 
@@ -440,11 +441,11 @@ public class MediaFile {
     /**
      * Returns when the children was last updated in the database.
      */
-    public Date getChildrenLastUpdated() {
+    public Instant getChildrenLastUpdated() {
         return childrenLastUpdated;
     }
 
-    public void setChildrenLastUpdated(Date childrenLastUpdated) {
+    public void setChildrenLastUpdated(Instant childrenLastUpdated) {
         this.childrenLastUpdated = childrenLastUpdated;
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaFileWithUrlInfo.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaFileWithUrlInfo.java
@@ -21,7 +21,7 @@
 
 package com.tesshu.jpsonic.domain;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.function.Function;
 
@@ -253,11 +253,11 @@ public class MediaFileWithUrlInfo {
         file.setPlayCount(playCount);
     }
 
-    public Date getLastPlayed() {
+    public Instant getLastPlayed() {
         return file.getLastPlayed();
     }
 
-    public void setLastPlayed(Date lastPlayed) {
+    public void setLastPlayed(Instant lastPlayed) {
         file.setLastPlayed(lastPlayed);
     }
 
@@ -269,43 +269,43 @@ public class MediaFileWithUrlInfo {
         file.setComment(comment);
     }
 
-    public Date getCreated() {
+    public Instant getCreated() {
         return file.getCreated();
     }
 
-    public void setCreated(Date created) {
+    public void setCreated(Instant created) {
         file.setCreated(created);
     }
 
-    public Date getChanged() {
+    public Instant getChanged() {
         return file.getChanged();
     }
 
-    public void setChanged(Date changed) {
+    public void setChanged(Instant changed) {
         file.setChanged(changed);
     }
 
-    public Date getLastScanned() {
+    public Instant getLastScanned() {
         return file.getLastScanned();
     }
 
-    public void setLastScanned(Date lastScanned) {
+    public void setLastScanned(Instant lastScanned) {
         file.setLastScanned(lastScanned);
     }
 
-    public Date getStarredDate() {
+    public Instant getStarredDate() {
         return file.getStarredDate();
     }
 
-    public void setStarredDate(Date starredDate) {
+    public void setStarredDate(Instant starredDate) {
         file.setStarredDate(starredDate);
     }
 
-    public Date getChildrenLastUpdated() {
+    public Instant getChildrenLastUpdated() {
         return file.getChildrenLastUpdated();
     }
 
-    public void setChildrenLastUpdated(Date childrenLastUpdated) {
+    public void setChildrenLastUpdated(Instant childrenLastUpdated) {
         file.setChildrenLastUpdated(childrenLastUpdated);
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaLibraryStatistics.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaLibraryStatistics.java
@@ -21,7 +21,7 @@
 
 package com.tesshu.jpsonic.domain;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.Objects;
 
 import javax.validation.constraints.NotNull;
@@ -44,13 +44,13 @@ public class MediaLibraryStatistics {
     @NotNull
     private Long totalDurationInSeconds;
     @NotNull
-    private Date scanDate;
+    private Instant scanDate;
 
     public MediaLibraryStatistics() {
 
     }
 
-    public MediaLibraryStatistics(Date scanDate) {
+    public MediaLibraryStatistics(Instant scanDate) {
         if (scanDate == null) {
             throw new IllegalArgumentException();
         }
@@ -106,7 +106,7 @@ public class MediaLibraryStatistics {
         return totalDurationInSeconds;
     }
 
-    public Date getScanDate() {
+    public Instant getScanDate() {
         return scanDate;
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicFolder.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicFolder.java
@@ -23,7 +23,7 @@ package com.tesshu.jpsonic.domain;
 
 import java.io.Serializable;
 import java.nio.file.Path;
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -40,9 +40,9 @@ public class MusicFolder implements Serializable {
     private String pathString;
     private String name;
     private boolean enabled;
-    private Date changed;
+    private Instant changed;
 
-    public MusicFolder(Integer id, String pathString, String name, boolean enabled, Date changed) {
+    public MusicFolder(Integer id, String pathString, String name, boolean enabled, Instant changed) {
         this.id = id;
         this.pathString = pathString;
         this.name = name;
@@ -50,7 +50,7 @@ public class MusicFolder implements Serializable {
         this.changed = changed;
     }
 
-    public MusicFolder(String pathString, String name, boolean enabled, Date changed) {
+    public MusicFolder(String pathString, String name, boolean enabled, Instant changed) {
         this(null, pathString, name, enabled, changed);
     }
 
@@ -86,11 +86,11 @@ public class MusicFolder implements Serializable {
         this.enabled = enabled;
     }
 
-    public Date getChanged() {
+    public Instant getChanged() {
         return changed;
     }
 
-    public void setChanged(Date changed) {
+    public void setChanged(Instant changed) {
         this.changed = changed;
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/PlayStatus.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/PlayStatus.java
@@ -21,7 +21,10 @@
 
 package com.tesshu.jpsonic.domain;
 
-import java.util.Date;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 /**
  * Represents the playback of a track, possibly remote (e.g., a cached song on a mobile phone).
@@ -30,13 +33,11 @@ import java.util.Date;
  */
 public class PlayStatus {
 
-    private static final long TTL_MILLIS = 6L * 60L * 60L * 1000L; // 6 hours
-
     private final MediaFile mediaFile;
     private final Player player;
-    private final Date time;
+    private final Instant time;
 
-    public PlayStatus(MediaFile mediaFile, Player player, Date time) {
+    public PlayStatus(MediaFile mediaFile, Player player, Instant time) {
         this.mediaFile = mediaFile;
         this.player = player;
         this.time = time;
@@ -50,15 +51,15 @@ public class PlayStatus {
         return player;
     }
 
-    public Date getTime() {
+    public Instant getTime() {
         return time;
     }
 
     public boolean isExpired() {
-        return System.currentTimeMillis() > time.getTime() + TTL_MILLIS;
+        return now().minus(6, ChronoUnit.HOURS).isBefore(time);
     }
 
     public long getMinutesAgo() {
-        return (System.currentTimeMillis() - time.getTime()) / 1000L / 60L;
+        return Math.abs(ChronoUnit.MINUTES.between(time, now()));
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Player.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Player.java
@@ -21,7 +21,7 @@
 
 package com.tesshu.jpsonic.domain;
 
-import java.util.Date;
+import java.time.Instant;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -43,7 +43,7 @@ public class Player {
     private boolean dynamicIp = true;
     private boolean autoControlEnabled = true;
     private boolean m3uBomEnabled = true;
-    private Date lastSeen;
+    private Instant lastSeen;
     private TranscodeScheme transcodeScheme = TranscodeScheme.OFF;
     private PlayQueue playQueue;
 
@@ -216,7 +216,7 @@ public class Player {
      *
      * @return The time when the player was last seen.
      */
-    public Date getLastSeen() {
+    public Instant getLastSeen() {
         return lastSeen;
     }
 
@@ -226,7 +226,7 @@ public class Player {
      * @param lastSeen
      *            The time when the player was last seen.
      */
-    public void setLastSeen(Date lastSeen) {
+    public void setLastSeen(Instant lastSeen) {
         this.lastSeen = lastSeen;
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Playlist.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Playlist.java
@@ -21,9 +21,10 @@
 
 package com.tesshu.jpsonic.domain;
 
-import java.util.Date;
+import java.time.Instant;
 
 import com.tesshu.jpsonic.util.StringUtil;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class Playlist {
 
@@ -34,8 +35,8 @@ public class Playlist {
     private String comment;
     private int fileCount;
     private int durationSeconds;
-    private Date created;
-    private Date changed;
+    private Instant created;
+    private Instant changed;
     private String importedFrom;
     private transient String reading;
 
@@ -43,7 +44,7 @@ public class Playlist {
     }
 
     public Playlist(int id, String username, boolean shared, String name, String comment, int fileCount,
-            int durationSeconds, Date created, Date changed, String importedFrom) {
+            int durationSeconds, Instant created, Instant changed, String importedFrom) {
         this.id = id;
         this.username = username;
         this.shared = shared;
@@ -116,19 +117,19 @@ public class Playlist {
         return StringUtil.formatDurationMSS(durationSeconds);
     }
 
-    public Date getCreated() {
+    public @NonNull Instant getCreated() {
         return created;
     }
 
-    public void setCreated(Date created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public Date getChanged() {
+    public Instant getChanged() {
         return changed;
     }
 
-    public void setChanged(Date changed) {
+    public void setChanged(Instant changed) {
         this.changed = changed;
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/PodcastEpisode.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/PodcastEpisode.java
@@ -21,7 +21,9 @@
 
 package com.tesshu.jpsonic.domain;
 
-import java.util.Date;
+import java.time.Instant;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A Podcast episode belonging to a channel.
@@ -39,7 +41,7 @@ public class PodcastEpisode {
     private String path;
     private String title;
     private String description;
-    private Date publishDate;
+    private Instant publishDate;
     private String duration;
     private Long bytesTotal;
     private Long bytesDownloaded;
@@ -47,7 +49,7 @@ public class PodcastEpisode {
     private String errorMessage;
 
     public PodcastEpisode(Integer id, Integer channelId, String url, String path, String title, String description,
-            Date publishDate, String duration, Long length, Long bytesDownloaded, PodcastStatus status,
+            Instant publishDate, String duration, Long length, Long bytesDownloaded, PodcastStatus status,
             String errorMessage) {
         this.id = id;
         this.channelId = channelId;
@@ -103,11 +105,11 @@ public class PodcastEpisode {
         this.description = description;
     }
 
-    public Date getPublishDate() {
+    public @Nullable Instant getPublishDate() {
         return publishDate;
     }
 
-    public void setPublishDate(Date publishDate) {
+    public void setPublishDate(Instant publishDate) {
         this.publishDate = publishDate;
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/RandomSearchCriteria.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/RandomSearchCriteria.java
@@ -21,7 +21,7 @@
 
 package com.tesshu.jpsonic.domain;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 
 import com.tesshu.jpsonic.service.SearchService;
@@ -40,8 +40,8 @@ public class RandomSearchCriteria {
     private final Integer fromYear;
     private final Integer toYear;
     private final List<MusicFolder> musicFolders;
-    private final Date minLastPlayedDate;
-    private final Date maxLastPlayedDate;
+    private final Instant minLastPlayedDate;
+    private final Instant maxLastPlayedDate;
     private final Integer minAlbumRating;
     private final Integer maxAlbumRating;
     private final Integer minPlayCount;
@@ -102,9 +102,9 @@ public class RandomSearchCriteria {
      *            Only return songs whose file format is equal to this value. May be <code>null</code>.
      */
     public RandomSearchCriteria(int count, List<String> genres, Integer fromYear, Integer toYear,
-            List<MusicFolder> musicFolders, Date minLastPlayedDate, Date maxLastPlayedDate, Integer minAlbumRating,
-            Integer maxAlbumRating, Integer minPlayCount, Integer maxPlayCount, boolean showStarredSongs,
-            boolean showUnstarredSongs, String format) {
+            List<MusicFolder> musicFolders, Instant minLastPlayedDate, Instant maxLastPlayedDate,
+            Integer minAlbumRating, Integer maxAlbumRating, Integer minPlayCount, Integer maxPlayCount,
+            boolean showStarredSongs, boolean showUnstarredSongs, String format) {
 
         this.count = count;
         this.genres = genres;
@@ -142,11 +142,11 @@ public class RandomSearchCriteria {
         return musicFolders;
     }
 
-    public Date getMinLastPlayedDate() {
+    public Instant getMinLastPlayedDate() {
         return minLastPlayedDate;
     }
 
-    public Date getMaxLastPlayedDate() {
+    public Instant getMaxLastPlayedDate() {
         return maxLastPlayedDate;
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/SavedPlayQueue.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/SavedPlayQueue.java
@@ -21,7 +21,7 @@
 
 package com.tesshu.jpsonic.domain;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -39,11 +39,11 @@ public class SavedPlayQueue {
     private List<Integer> mediaFileIds;
     private Integer currentMediaFileId;
     private Long positionMillis;
-    private Date changed;
+    private Instant changed;
     private String changedBy;
 
     public SavedPlayQueue(Integer id, String username, List<Integer> mediaFileIds, Integer currentMediaFileId,
-            Long positionMillis, Date changed, String changedBy) {
+            Long positionMillis, Instant changed, String changedBy) {
         this.id = id;
         this.username = username;
         this.mediaFileIds = mediaFileIds;
@@ -93,11 +93,11 @@ public class SavedPlayQueue {
         this.positionMillis = positionMillis;
     }
 
-    public Date getChanged() {
+    public Instant getChanged() {
         return changed;
     }
 
-    public void setChanged(Date changed) {
+    public void setChanged(Instant changed) {
         this.changed = changed;
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Share.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Share.java
@@ -21,7 +21,9 @@
 
 package com.tesshu.jpsonic.domain;
 
-import java.util.Date;
+import java.time.Instant;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * A collection of media files that is shared with someone, and accessible via a direct URL.
@@ -34,16 +36,16 @@ public class Share {
     private String name;
     private String description;
     private String username;
-    private Date created;
-    private Date expires;
-    private Date lastVisited;
+    private Instant created;
+    private Instant expires;
+    private Instant lastVisited;
     private int visitCount;
 
     public Share() {
     }
 
-    public Share(int id, String name, String description, String username, Date created, Date expires, Date lastVisited,
-            int visitCount) {
+    public Share(int id, String name, String description, String username, Instant created, Instant expires,
+            Instant lastVisited, int visitCount) {
         this.id = id;
         this.name = name;
         this.description = description;
@@ -86,27 +88,27 @@ public class Share {
         this.username = username;
     }
 
-    public Date getCreated() {
+    public @NonNull Instant getCreated() {
         return created;
     }
 
-    public void setCreated(Date created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public Date getExpires() {
+    public Instant getExpires() {
         return expires;
     }
 
-    public void setExpires(Date expires) {
+    public void setExpires(Instant expires) {
         this.expires = expires;
     }
 
-    public Date getLastVisited() {
+    public Instant getLastVisited() {
         return lastVisited;
     }
 
-    public void setLastVisited(Date lastVisited) {
+    public void setLastVisited(Instant lastVisited) {
         this.lastVisited = lastVisited;
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/TransferStatus.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/TransferStatus.java
@@ -23,6 +23,7 @@ package com.tesshu.jpsonic.domain;
 
 import java.io.Serializable;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.collections4.queue.CircularFifoQueue;
@@ -72,7 +73,7 @@ public class TransferStatus implements Serializable {
     }
 
     private void createSample(long bytesTransfered, boolean force) {
-        long now = System.currentTimeMillis();
+        long now = Instant.now().toEpochMilli();
 
         if (history.isEmpty()) {
             history.add(new Sample(bytesTransfered, now));
@@ -89,7 +90,7 @@ public class TransferStatus implements Serializable {
             if (history.isEmpty()) {
                 return 0L;
             }
-            return System.currentTimeMillis() - history.getLast().getTimestamp();
+            return Instant.now().toEpochMilli() - history.getLast().getTimestamp();
         }
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/UserSettings.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/UserSettings.java
@@ -21,7 +21,9 @@
 
 package com.tesshu.jpsonic.domain;
 
-import java.util.Date;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
+
+import java.time.Instant;
 import java.util.Locale;
 
 /**
@@ -57,7 +59,7 @@ public class UserSettings {
     private boolean nowPlayingAllowed;
     private AvatarScheme avatarScheme;
     private Integer systemAvatarId;
-    private Date changed = new Date();
+    private Instant changed = now();
     private int paginationSize;
 
     // JP >>>>
@@ -379,7 +381,7 @@ public class UserSettings {
      *
      * @return When the corresponding database entry was last changed.
      */
-    public Date getChanged() {
+    public Instant getChanged() {
         return changed;
     }
 
@@ -389,7 +391,7 @@ public class UserSettings {
      * @param changed
      *            When the corresponding database entry was last changed.
      */
-    public void setChanged(Date changed) {
+    public void setChanged(Instant changed) {
         this.changed = changed;
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/AudioScrobblerService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/AudioScrobblerService.java
@@ -21,7 +21,7 @@
 
 package com.tesshu.jpsonic.service;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.concurrent.Executor;
 
 import com.tesshu.jpsonic.domain.MediaFile;
@@ -64,7 +64,7 @@ public class AudioScrobblerService {
      * @param time
      *            Event time, or {@code null} to use current time.
      */
-    public void register(MediaFile mediaFile, String username, boolean submission, Date time) {
+    public void register(MediaFile mediaFile, String username, boolean submission, Instant time) {
         if (mediaFile == null || mediaFile.isVideo()) {
             return;
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/AvatarService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/AvatarService.java
@@ -19,12 +19,13 @@
 
 package com.tesshu.jpsonic.service;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
+
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Date;
 import java.util.List;
 
 import javax.imageio.ImageIO;
@@ -138,7 +139,7 @@ public class AvatarService {
             mimeType = StringUtil.getMimeType("jpeg");
             resized = true;
         }
-        Avatar avatar = new Avatar(0, fileName, new Date(), mimeType, width, height, imageData);
+        Avatar avatar = new Avatar(0, fileName, now(), mimeType, width, height, imageData);
         setCustomAvatar(avatar, username);
         if (LOG.isInfoEnabled()) {
             LOG.info("Created avatar '" + fileName + "' (" + imageData.length + " bytes) for user " + username);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/JWTSecurityService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/JWTSecurityService.java
@@ -21,9 +21,12 @@
 
 package com.tesshu.jpsonic.service;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
+
 import java.math.BigInteger;
 import java.security.SecureRandom;
-import java.util.Date;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
@@ -34,7 +37,6 @@ import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.time.DateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -67,7 +69,7 @@ public class JWTSecurityService {
         return Algorithm.HMAC256(jwtKey);
     }
 
-    static String createToken(String jwtKey, String path, Date expireDate) {
+    static String createToken(String jwtKey, String path, Instant expireDate) {
         UriComponents components = UriComponentsBuilder.fromUriString(path).build();
         String query = components.getQuery();
         String claim = components.getPath() + (StringUtils.isBlank(query) ? "" : "?" + components.getQuery());
@@ -82,10 +84,10 @@ public class JWTSecurityService {
     }
 
     public UriComponentsBuilder addJWTToken(UriComponentsBuilder builder) {
-        return addJWTToken(builder, DateUtils.addDays(new Date(), DEFAULT_DAYS_VALID_FOR));
+        return addJWTToken(builder, now().plus(DEFAULT_DAYS_VALID_FOR, ChronoUnit.DAYS));
     }
 
-    public UriComponentsBuilder addJWTToken(UriComponentsBuilder builder, Date expires) {
+    public UriComponentsBuilder addJWTToken(UriComponentsBuilder builder, Instant expires) {
         String token = JWTSecurityService.createToken(settingsService.getJWTKey(), builder.toUriString(), expires);
         builder.queryParam(JWTSecurityService.JWT_PARAM_NAME, token);
         return builder;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/LastFmCache.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/LastFmCache.java
@@ -29,6 +29,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Properties;
 
 import com.tesshu.jpsonic.util.FileUtil;
@@ -106,7 +107,7 @@ public class LastFmCache extends Cache {
     }
 
     private long getExpirationDate() {
-        return System.currentTimeMillis() + ttl;
+        return Instant.now().toEpochMilli() + ttl;
     }
 
     private void createCache() {
@@ -130,7 +131,7 @@ public class LastFmCache extends Cache {
             Properties p = new Properties();
             p.load(in);
             long expirationDate = Long.parseLong(p.getProperty("expiration-date"));
-            return expirationDate < System.currentTimeMillis();
+            return expirationDate < Instant.now().toEpochMilli();
         } catch (IOException e) {
             return false;
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
@@ -21,7 +21,8 @@
 
 package com.tesshu.jpsonic.service;
 
-import static com.tesshu.jpsonic.dao.MediaFileDao.ZERO_DATE;
+import static com.tesshu.jpsonic.util.PlayerUtils.FAR_PAST;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -29,10 +30,10 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -199,7 +200,7 @@ public class MediaFileService {
                 throw new UncheckedIOException(e);
             }
         }
-        return statistics[0].getScanDate().getTime();
+        return statistics[0].getScanDate().toEpochMilli();
     }
 
     MediaFile checkLastModified(final MediaFile mediaFile, boolean useFastCache, MediaLibraryStatistics... statistics) {
@@ -213,15 +214,15 @@ public class MediaFileService {
             switch (scheme) {
             case LAST_MODIFIED:
                 if (!settingsService.isIgnoreFileTimestamps()
-                        && mediaFile.getChanged().getTime() >= getLastModified(mediaFile.toPath(), statistics)
-                        && !ZERO_DATE.equals(mediaFile.getLastScanned())) {
+                        && mediaFile.getChanged().toEpochMilli() >= getLastModified(mediaFile.toPath(), statistics)
+                        && !FAR_PAST.equals(mediaFile.getLastScanned())) {
                     return mediaFile;
-                } else if (settingsService.isIgnoreFileTimestamps() && !ZERO_DATE.equals(mediaFile.getLastScanned())) {
+                } else if (settingsService.isIgnoreFileTimestamps() && !FAR_PAST.equals(mediaFile.getLastScanned())) {
                     return mediaFile;
                 }
                 break;
             case LAST_SCANNED:
-                if (!ZERO_DATE.equals(mediaFile.getLastScanned())) {
+                if (!FAR_PAST.equals(mediaFile.getLastScanned())) {
                     return mediaFile;
                 }
                 break;
@@ -286,10 +287,10 @@ public class MediaFileService {
     void updateChildren(MediaFile parent, MediaLibraryStatistics... statistics) {
 
         if (isSchemeLastModified() //
-                && parent.getChildrenLastUpdated().getTime() >= parent.getChanged().getTime()) {
+                && parent.getChildrenLastUpdated().toEpochMilli() >= parent.getChanged().toEpochMilli()) {
             return;
         } else if (isSchemeLastScaned() //
-                && parent.getMediaType() == MediaType.ALBUM && !ZERO_DATE.equals(parent.getChildrenLastUpdated())) {
+                && parent.getMediaType() == MediaType.ALBUM && !FAR_PAST.equals(parent.getChildrenLastUpdated())) {
             return;
         }
 
@@ -384,12 +385,12 @@ public class MediaFileService {
         MediaFile mediaFile = new MediaFile();
 
         // Variable initial value
-        Date lastModified = new Date(getLastModified(path, statistics));
+        Instant lastModified = Instant.ofEpochMilli(getLastModified(path, statistics));
         mediaFile.setChanged(lastModified);
         mediaFile.setCreated(lastModified);
 
-        mediaFile.setLastScanned(existingFile == null ? ZERO_DATE : existingFile.getLastScanned());
-        mediaFile.setChildrenLastUpdated(ZERO_DATE);
+        mediaFile.setLastScanned(existingFile == null ? FAR_PAST : existingFile.getLastScanned());
+        mediaFile.setChildrenLastUpdated(FAR_PAST);
 
         mediaFile.setPathString(path.toString());
         mediaFile.setFolder(securityService.getRootFolderForFile(path));
@@ -443,7 +444,7 @@ public class MediaFileService {
             to.setComposerSort(metaData.getComposerSort());
             to.setComposerSortRaw(metaData.getComposerSort());
             utils.analyze(to);
-            to.setLastScanned(statistics.length == 0 ? new Date() : statistics[0].getScanDate());
+            to.setLastScanned(statistics.length == 0 ? now() : statistics[0].getScanDate());
         }
         String format = StringUtils.trimToNull(StringUtils.lowerCase(FilenameUtils.getExtension(to.getPathString())));
         to.setFormat(format);
@@ -572,7 +573,7 @@ public class MediaFileService {
     }
 
     public void incrementPlayCount(MediaFile file) {
-        Date now = new Date();
+        Instant now = now();
         file.setLastPlayed(now);
         file.setPlayCount(file.getPlayCount() + 1);
         updateMediaFile(file);
@@ -637,7 +638,7 @@ public class MediaFileService {
         files.removeIf(MediaFile::isVideo);
     }
 
-    public Date getMediaFileStarredDate(int id, String username) {
+    public Instant getMediaFileStarredDate(int id, String username) {
         return mediaFileDao.getMediaFileStarredDate(id, username);
     }
 
@@ -648,7 +649,7 @@ public class MediaFileService {
     }
 
     public void populateStarredDate(MediaFile mediaFile, String username) {
-        Date starredDate = mediaFileDao.getMediaFileStarredDate(mediaFile.getId(), username);
+        Instant starredDate = mediaFileDao.getMediaFileStarredDate(mediaFile.getId(), username);
         mediaFile.setStarredDate(starredDate);
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaScannerService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaScannerService.java
@@ -21,13 +21,13 @@
 
 package com.tesshu.jpsonic.service;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.apache.commons.lang.ObjectUtils.defaultIfNull;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Calendar;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -50,7 +50,6 @@ import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.service.search.IndexManager;
 import com.tesshu.jpsonic.util.concurrent.ConcurrentUtils;
 import net.sf.ehcache.Ehcache;
-import org.apache.commons.lang3.time.DateUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -174,7 +173,7 @@ public class MediaScannerService {
 
         LOG.info("Starting to scan media library.");
 
-        MediaLibraryStatistics statistics = new MediaLibraryStatistics(DateUtils.truncate(new Date(), Calendar.SECOND));
+        MediaLibraryStatistics statistics = new MediaLibraryStatistics(now());
         if (LOG.isDebugEnabled()) {
             LOG.debug("New last scan date is " + statistics.getScanDate());
         }
@@ -342,7 +341,7 @@ public class MediaScannerService {
         }
     }
 
-    void updateAlbum(@NonNull MediaFile file, @NonNull MusicFolder musicFolder, @NonNull Date lastScanned,
+    void updateAlbum(@NonNull MediaFile file, @NonNull MusicFolder musicFolder, @NonNull Instant lastScanned,
             @NonNull Map<String, Integer> albumCount) {
 
         if (isNotAlbumUpdatable(file)) {
@@ -427,7 +426,7 @@ public class MediaScannerService {
         return album;
     }
 
-    void updateArtist(MediaFile file, MusicFolder musicFolder, Date lastScanned, Map<String, Integer> albumCount) {
+    void updateArtist(MediaFile file, MusicFolder musicFolder, Instant lastScanned, Map<String, Integer> albumCount) {
         if (file.getAlbumArtist() == null || !file.isAudio()) {
             return;
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PlayerService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PlayerService.java
@@ -21,10 +21,11 @@
 
 package com.tesshu.jpsonic.service;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.springframework.web.bind.ServletRequestUtils.getIntParameter;
 
-import java.util.Calendar;
-import java.util.Date;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -45,6 +46,7 @@ import com.tesshu.jpsonic.domain.UserSettings;
 import com.tesshu.jpsonic.security.JWTAuthenticationToken;
 import com.tesshu.jpsonic.util.StringUtil;
 import org.apache.commons.lang3.StringUtils;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -209,7 +211,7 @@ public class PlayerService {
         }
     }
 
-    private boolean isToBeUpdate(HttpServletRequest request, boolean isStreamRequest, Player player) {
+    boolean isToBeUpdate(HttpServletRequest request, boolean isStreamRequest, @NonNull Player player) {
         boolean isToBeUpdate = false;
         String username = securityService.getCurrentUsername(request);
         if (username != null && player.getUsername() == null) {
@@ -224,7 +226,7 @@ public class PlayerService {
         String userAgent = request.getHeader("user-agent");
         if (isStreamRequest) {
             player.setType(userAgent);
-            player.setLastSeen(new Date());
+            player.setLastSeen(now());
             isToBeUpdate = true;
         }
         return isToBeUpdate;
@@ -423,7 +425,7 @@ public class PlayerService {
     public Player getGuestPlayer(HttpServletRequest request) {
 
         User user = securityService.getGuestUser();
-        Date now = new Date();
+        Instant now = now();
 
         // Look for existing player.
         List<Player> players = getPlayersForUserAndClientId(user.getUsername(), null);
@@ -437,9 +439,7 @@ public class PlayerService {
         if (oldPlayer.isPresent()) {
             // Update date only if more than 24 hours have passed
             Player player = oldPlayer.get();
-            Calendar lastSeen = Calendar.getInstance();
-            lastSeen.setTime(player.getLastSeen());
-            if (now.getTime() - player.getLastSeen().getTime() > 1000 * 60 * 60 * 24) {
+            if (player.getLastSeen().plus(1, ChronoUnit.DAYS).isBefore(now)) {
                 player.setLastSeen(now);
                 playerDao.updatePlayer(player);
             }
@@ -453,7 +453,7 @@ public class PlayerService {
         }
         player.setUsername(user.getUsername());
         player.setType(GUEST_PLAYER_TYPE);
-        player.setLastSeen(new Date());
+        player.setLastSeen(now());
         createPlayer(player, false);
 
         return player;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PlaylistService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PlaylistService.java
@@ -21,6 +21,8 @@
 
 package com.tesshu.jpsonic.service;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -28,8 +30,8 @@ import java.io.UncheckedIOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -225,7 +227,7 @@ public class PlaylistService {
             throw new ExecutionException(new IOException("No songs in the playlist were found."));
         }
 
-        Date now = new Date();
+        Instant now = now();
         Playlist playlist;
         if (existingPlaylist == null) {
             playlist = new Playlist();
@@ -326,7 +328,7 @@ public class PlaylistService {
             if (fileName.toString().equals(playlist.getImportedFrom())) {
                 existingPlaylist = playlist;
                 try {
-                    if (Files.getLastModifiedTime(file).toMillis() <= playlist.getChanged().getTime()) {
+                    if (Files.getLastModifiedTime(file).toMillis() <= playlist.getChanged().toEpochMilli()) {
                         // Already imported and not changed since.
                         return;
                     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PodcastService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PodcastService.java
@@ -682,6 +682,9 @@ public class PodcastService {
 
     private void updateTags(Path path, PodcastEpisode episode) {
         MediaFile mediaFile = mediaFileService.getMediaFile(path, false);
+        if (mediaFile == null) {
+            return;
+        }
         if (StringUtils.isNotBlank(episode.getTitle())) {
             MetaDataParser parser = metaDataParserFactory.getParser(path);
             if (parser == null || !parser.isEditingSupported(path)) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/RecoverService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/RecoverService.java
@@ -19,7 +19,8 @@
 
 package com.tesshu.jpsonic.service;
 
-import java.util.Date;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
+
 import java.util.Properties;
 
 import javax.mail.Message;
@@ -103,7 +104,7 @@ public class RecoverService {
                     + "You have requested to reset your Jpsonic password.  Please find your new login details below.\n\n"
                     + "Username: " + username + "\n" + "Password: " + password + "\n\n" + "--\n"
                     + "Your Jpsonic server\n" + "tesshu.com/");
-            message.setSentDate(new Date());
+            message.setSentDate(java.util.Date.from(now()));
 
             try (Transport trans = session.getTransport(prot)) {
                 if (props.get(SESSION_KEY_MAIL_PREF + prot + ".auth") != null

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
@@ -21,12 +21,12 @@
 
 package com.tesshu.jpsonic.service;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Pattern;
@@ -110,7 +110,7 @@ public class SecurityService implements UserDetailsService {
     private @NonNull UserSettings createDefaultUserSettings(String username) {
 
         UserSettings settings = new UserSettings(username);
-        settings.setChanged(new Date());
+        settings.setChanged(now());
         settings.setFinalVersionNotificationEnabled(true);
 
         // settings for desktop PC

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SettingsService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SettingsService.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -279,7 +280,7 @@ public class SettingsService {
     public void save(boolean updateSettingsChanged) {
         if (updateSettingsChanged) {
             removeObsoleteProperties();
-            setProperty(SettingsConstants.SETTINGS_CHANGED, System.currentTimeMillis());
+            setProperty(SettingsConstants.SETTINGS_CHANGED, Instant.now().toEpochMilli());
         }
         configurationService.save();
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/ShareService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/ShareService.java
@@ -21,9 +21,10 @@
 
 package com.tesshu.jpsonic.service;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
+
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -109,13 +110,9 @@ public class ShareService {
 
         Share share = new Share();
         share.setName(RandomStringUtils.random(5, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"));
-        share.setCreated(new Date());
+        share.setCreated(now());
         share.setUsername(securityService.getCurrentUsername(request));
-
-        Calendar expires = Calendar.getInstance();
-        expires.add(Calendar.YEAR, 1);
-        share.setExpires(expires.getTime());
-
+        share.setExpires(now().plus(365, ChronoUnit.DAYS));
         shareDao.createShare(share);
         for (MediaFile file : files) {
             shareDao.createSharedFiles(share.getId(), file.getPathString());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/StatusService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/StatusService.java
@@ -24,8 +24,8 @@ package com.tesshu.jpsonic.service;
 import static java.util.Collections.unmodifiableList;
 
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -211,7 +211,8 @@ public class StatusService {
                     if (player == null || mediaFile == null) {
                         continue;
                     }
-                    Date time = new Date(System.currentTimeMillis() - streamStatus.getMillisSinceLastUpdate());
+                    Instant time = Instant
+                            .ofEpochMilli(Instant.now().toEpochMilli() - streamStatus.getMillisSinceLastUpdate());
                     result.put(player.getId(), new PlayStatus(mediaFile, player, time));
                 }
                 return unmodifiableList(new ArrayList<>(result.values()));

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/VersionService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/VersionService.java
@@ -29,14 +29,13 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -54,6 +53,7 @@ import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -68,8 +68,8 @@ import org.springframework.stereotype.Service;
 public class VersionService {
 
     private static final Logger LOG = LoggerFactory.getLogger(VersionService.class);
-    private static final ThreadLocal<DateFormat> DATE_FORMAT = ThreadLocal
-            .withInitial(() -> new SimpleDateFormat("yyyyMMdd", Locale.US));
+    private static final ThreadLocal<DateTimeFormatter> DATE_FORMAT = ThreadLocal
+            .withInitial(() -> DateTimeFormatter.ofPattern("yyyyMMdd"));
     private static final Pattern VERSION_REGEX = Pattern.compile("^v(.*)");
     private static final String VERSION_URL = "https://api.github.com/repos/jpsonic/jpsonic/releases";
 
@@ -88,7 +88,7 @@ public class VersionService {
     private Version latestFinalVersion;
     private Version latestBetaVersion;
     private Version localVersion;
-    private Date localBuildDate;
+    private LocalDate localBuildDate;
     private String localBuildNumber;
 
     /**
@@ -146,21 +146,28 @@ public class VersionService {
      * @return The build date for the locally installed Jpsonic version, or <code>null</code> if the build date can't be
      *         resolved.
      */
-    public Date getLocalBuildDate() {
+    public LocalDate getLocalBuildDate() {
         synchronized (localBuildDateLock) {
             if (localBuildDate == null) {
                 try {
                     String date = readLineFromResource("/build_date.txt");
                     synchronized (DATE_FORMAT) {
-                        localBuildDate = DATE_FORMAT.get().parse(date);
+                        localBuildDate = parseLocalBuildDate(date);
                     }
-                } catch (ParseException e) {
+                } catch (DateTimeParseException e) {
                     if (LOG.isWarnEnabled()) {
                         LOG.warn("Failed to resolve local Jpsonic build date.", e);
                     }
                 }
             }
             return localBuildDate;
+        }
+    }
+
+    @Nullable
+    LocalDate parseLocalBuildDate(String date) {
+        synchronized (DATE_FORMAT) {
+            return LocalDate.parse(date, DATE_FORMAT.get());
         }
     }
 
@@ -235,7 +242,7 @@ public class VersionService {
      * Refreshes the latest final and beta versions.
      */
     private void refreshLatestVersion() {
-        long now = System.currentTimeMillis();
+        long now = Instant.now().toEpochMilli();
         boolean isOutdated = now - lastVersionFetched > LAST_VERSION_FETCH_INTERVAL;
 
         if (isOutdated) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/VersionService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/VersionService.java
@@ -21,6 +21,8 @@
 
 package com.tesshu.jpsonic.service;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.OBJECT_MAPPER;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -42,7 +44,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tesshu.jpsonic.domain.Version;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.ResponseHandler;
@@ -275,7 +276,7 @@ public class VersionService {
             }
 
             List<String> unsortedTags = new ArrayList<>();
-            for (JsonNode item : new ObjectMapper().readTree(content)) {
+            for (JsonNode item : OBJECT_MAPPER.readTree(content)) {
                 String tagName = item.path("tag_name").asText();
                 if (!StringUtils.isEmpty(tagName)) {
                     unsortedTags.add(tagName);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/FFprobe.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/FFprobe.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -46,6 +47,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
+@SuppressWarnings("PMD.TooManyStaticImports")
 public class FFprobe {
 
     private static final Logger LOG = LoggerFactory.getLogger(FFprobe.class);
@@ -158,7 +160,7 @@ public class FFprobe {
         long start;
         JsonNode node;
         try {
-            start = System.currentTimeMillis();
+            start = Instant.now().toEpochMilli();
             Process process = pb.start();
             try (InputStream is = process.getInputStream(); OutputStream os = process.getOutputStream();
                     InputStream es = process.getErrorStream(); BufferedInputStream bis = new BufferedInputStream(is);) {
@@ -182,7 +184,7 @@ public class FFprobe {
     MetaData parse(@NonNull MediaFile mediaFile, @Nullable Map<String, MP4ParseStatistics> statistics) {
         return parse(mediaFile.toPath(), (start) -> {
             if (!isEmpty(statistics) && statistics.containsKey(ParserUtils.getFolder(mediaFile))) {
-                long readtime = System.currentTimeMillis() - start;
+                long readtime = Instant.now().toEpochMilli() - start;
                 statistics.get(ParserUtils.getFolder(mediaFile)).addCmdLeadTime(readtime);
             }
         });

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/FFprobe.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/FFprobe.java
@@ -20,6 +20,7 @@
 package com.tesshu.jpsonic.service.metadata;
 
 import static com.tesshu.jpsonic.util.FileUtil.getShortPath;
+import static com.tesshu.jpsonic.util.PlayerUtils.OBJECT_MAPPER;
 import static org.apache.commons.lang.StringUtils.trimToNull;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
@@ -35,7 +36,6 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.service.TranscodingService;
 import com.tesshu.jpsonic.util.PlayerUtils;
@@ -54,8 +54,6 @@ public class FFprobe {
             "json" };
 
     private static final String CODEC_TYPE_VIDEO = "video";
-
-    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private final TranscodingService transcodingService;
 
@@ -164,7 +162,7 @@ public class FFprobe {
             Process process = pb.start();
             try (InputStream is = process.getInputStream(); OutputStream os = process.getOutputStream();
                     InputStream es = process.getErrorStream(); BufferedInputStream bis = new BufferedInputStream(is);) {
-                node = MAPPER.readTree(bis);
+                node = OBJECT_MAPPER.readTree(bis);
             } finally {
                 process.destroy();
             }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MP4Parser.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MP4Parser.java
@@ -27,6 +27,7 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 
@@ -84,7 +85,7 @@ public class MP4Parser {
         ParseContext ps = new ParseContext();
         try (InputStream is = Files.newInputStream(mediaFile.toPath());
                 BufferedInputStream bid = new BufferedInputStream(is, 1_000_000);) {
-            current = System.currentTimeMillis();
+            current = Instant.now().toEpochMilli();
             tikaParser.parse(bid, handler, metadata, ps);
         } catch (IOException | SAXException | TikaException e) {
             if (LOG.isWarnEnabled()) {
@@ -93,7 +94,7 @@ public class MP4Parser {
             return result;
         }
 
-        long readtime = System.currentTimeMillis() - current;
+        long readtime = Instant.now().toEpochMilli() - current;
         statistics.get(ParserUtils.getFolder(mediaFile)).addTikaLeadTime(mediaFile.getFileSize(), readtime);
 
         getField(metadata, TIFF.IMAGE_LENGTH.getName()).ifPresent(s -> result.setHeight(ParserUtils.parseInt(s)));

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scrobbler/ListenBrainzScrobbler.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scrobbler/ListenBrainzScrobbler.java
@@ -21,9 +21,12 @@
 
 package com.tesshu.jpsonic.service.scrobbler;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.OBJECT_MAPPER;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
+
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -31,7 +34,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.util.LegacyMap;
 import com.tesshu.jpsonic.util.concurrent.ConcurrentUtils;
@@ -80,7 +82,7 @@ public class ListenBrainzScrobbler {
      * @param time
      *            Event time, or {@code null} to use current time.
      */
-    public void register(MediaFile mediaFile, String token, boolean submission, Date time, Executor executor) {
+    public void register(MediaFile mediaFile, String token, boolean submission, Instant time, Executor executor) {
 
         synchronized (registrationLock) {
 
@@ -154,7 +156,7 @@ public class ListenBrainzScrobbler {
         Map<String, Object> content = LegacyMap.of();
 
         if (registrationData.submission) {
-            payload.put("listened_at", registrationData.getTime().getTime() / 1000L);
+            payload.put("listened_at", registrationData.getTime().getEpochSecond());
             content.put("listen_type", "single");
         } else {
             content.put("listen_type", "playing_now");
@@ -164,10 +166,9 @@ public class ListenBrainzScrobbler {
         payloads.add(payload);
         content.put("payload", payloads);
 
-        ObjectMapper mapper = new ObjectMapper();
         String json;
         try {
-            json = mapper.writeValueAsString(content);
+            json = OBJECT_MAPPER.writeValueAsString(content);
         } catch (JsonProcessingException e) {
             throw new ExecutionException("Error when writing Json", e);
         }
@@ -285,10 +286,10 @@ public class ListenBrainzScrobbler {
         private final String musicBrainzRecordingId;
         private final Integer trackNumber;
         // private int duration;
-        private final Date time;
+        private final Instant time;
         public boolean submission;
 
-        public RegistrationData(MediaFile mediaFile, String token, boolean submission, Date time) {
+        public RegistrationData(MediaFile mediaFile, String token, boolean submission, Instant time) {
             super();
             this.token = token;
             this.artist = mediaFile.getArtist();
@@ -298,7 +299,7 @@ public class ListenBrainzScrobbler {
             this.musicBrainzRecordingId = mediaFile.getMusicBrainzRecordingId();
             this.trackNumber = mediaFile.getTrackNumber();
             // reg.duration = mediaFile.getDurationSeconds() == null ? 0 : mediaFile.getDurationSeconds();
-            this.time = time == null ? new Date() : time;
+            this.time = time == null ? now() : time;
             this.submission = submission;
         }
 
@@ -310,7 +311,7 @@ public class ListenBrainzScrobbler {
             return token;
         }
 
-        public Date getTime() {
+        public Instant getTime() {
             return time;
         }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/SearchServiceUtilities.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/SearchServiceUtilities.java
@@ -25,6 +25,7 @@ import static org.springframework.util.ObjectUtils.isEmpty;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -146,7 +147,7 @@ public class SearchServiceUtilities {
                     LOG.info("SHA1PRNG is used to create a random list of songs.");
                 }
             } catch (NoSuchAlgorithmException e1) {
-                random = new Random(System.currentTimeMillis());
+                random = new Random(Instant.now().toEpochMilli());
                 if (settingsService.isVerboseLogStart() && LOG.isInfoEnabled()) {
                     LOG.info("NativePRNG and SHA1PRNG cannot be used on this platform.");
                 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/PodcastUpnpProcessor.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/PodcastUpnpProcessor.java
@@ -22,13 +22,10 @@ package com.tesshu.jpsonic.service.upnp.processor;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
 import java.net.URI;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 
 import javax.annotation.PostConstruct;
@@ -58,8 +55,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Service
 public class PodcastUpnpProcessor extends UpnpContentProcessor<PodcastChannel, PodcastEpisode> {
 
-    private static final ThreadLocal<DateFormat> DATE_FORMAT = ThreadLocal
-            .withInitial(() -> new SimpleDateFormat("yyyy-MM-dd", Locale.US));
+    private static final ThreadLocal<DateTimeFormatter> DATE_FORMAT = ThreadLocal
+            .withInitial(() -> DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault()));
     private final UpnpProcessorUtil util;
     private final MediaFileService mediaFileService;
     private final PodcastService podcastService;
@@ -119,13 +116,9 @@ public class PodcastUpnpProcessor extends UpnpContentProcessor<PodcastChannel, P
             item.addProperty(new ALBUM_ART_URI(createPodcastChannelURI(channel)));
         }
 
-        Date publishDate = episode.getPublishDate();
-        if (isEmpty(publishDate)) {
-            Calendar.getInstance();
-            Calendar c = Calendar.getInstance();
-            c.setTime(publishDate);
+        if (!isEmpty(episode.getPublishDate())) {
             synchronized (DATE_FORMAT) {
-                item.setDate(DATE_FORMAT.get().format(c.getTime()));
+                item.setDate(DATE_FORMAT.get().format(episode.getPublishDate()));
             }
         }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/UpnpContentProcessor.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/UpnpContentProcessor.java
@@ -32,7 +32,7 @@ import org.fourthline.cling.support.model.SortCriterion;
 import org.fourthline.cling.support.model.container.Container;
 import org.fourthline.cling.support.model.container.StorageFolder;
 
-public abstract class UpnpContentProcessor<T extends Object, U extends Object> {
+public abstract class UpnpContentProcessor<T, U> {
 
     private final UpnpProcessDispatcher dispatcher;
     private final UpnpProcessorUtil util;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/PlayerUtils.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/PlayerUtils.java
@@ -21,6 +21,8 @@
 
 package com.tesshu.jpsonic.util;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -58,10 +60,22 @@ public final class PlayerUtils {
     private static final String URL_SENSITIVE_REPLACEMENT_STRING = "<hidden>";
     private static final Validator VALIDATOR = Validation.buildDefaultValidatorFactory().getValidator();
 
+    /*
+     * Represents a "far past timestamp". A flag value that may be used as an initial value or when forcibly scanning.
+     * To avoid ArithmeticException, Instant.MIN is not used. https://bugs.openjdk.org/browse/JDK-8169532
+     */
+    public static final Instant FAR_PAST = Instant.EPOCH;
+
     /**
      * Disallow external instantiation.
      */
     private PlayerUtils() {
+    }
+
+    public static Instant now() {
+        // Date precision uses milliseconds.
+        // (hsqldb timestamp precision is milliseconds)
+        return Instant.now().truncatedTo(ChronoUnit.MILLIS);
     }
 
     public static String getDefaultMusicFolder() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/PlayerUtils.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/PlayerUtils.java
@@ -51,14 +51,12 @@ import org.springframework.web.util.UriComponentsBuilder;
  */
 public final class PlayerUtils {
 
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).findAndRegisterModules();
+
     private static final Logger LOG = LoggerFactory.getLogger(PlayerUtils.class);
     private static final String URL_SENSITIVE_REPLACEMENT_STRING = "<hidden>";
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final Validator VALIDATOR;
-
-    static {
-        VALIDATOR = Validation.buildDefaultValidatorFactory().getValidator();
-    }
+    private static final Validator VALIDATOR = Validation.buildDefaultValidatorFactory().getValidator();
 
     /**
      * Disallow external instantiation.
@@ -127,10 +125,6 @@ public final class PlayerUtils {
             result[i] = values.get(i);
         }
         return result;
-    }
-
-    static {
-        OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
     public static String debugObject(Object object) {

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/albumMain.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/albumMain.jsp
@@ -283,10 +283,12 @@ function toggleComment() {
 
     <c:if test="${model.showLastPlay}">
         <div><fmt:message key="main.playcount"><fmt:param value="${model.dir.playCount}"/></fmt:message></div>
-        <c:if test="${not empty model.dir.lastPlayed}">
+        <c:if test="${not empty model.lastPlayed}">
             <div>
+                <fmt:parseDate value="${model.lastPlayed}" type="both" pattern="yyyy-MM-dd'T'HH:mm:ss" var="parsedDate" />
+                <fmt:formatDate value="${parsedDate}" pattern="yyyy-MM-dd HH:mm:ss" var="formatedDate" />
                 <fmt:message key="main.lastplayed">
-                    <fmt:param><fmt:formatDate type="date" dateStyle="long" value="${model.dir.lastPlayed}"/></fmt:param>
+                    <fmt:param>${formatedDate}</fmt:param>
                 </fmt:message>
             </div>
         </c:if>

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/help.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/help.jsp
@@ -19,7 +19,8 @@
         <fmt:message key="common.unknown" var="buildDateString"/>
     </c:when>
     <c:otherwise>
-        <fmt:formatDate value="${model.buildDate}" dateStyle="long" var="buildDateString"/>
+        <fmt:parseDate value="${model.buildDate}" type="date" pattern="yyyy-MM-dd" var="parsedDate" />
+        <fmt:formatDate value="${parsedDate}" pattern="yyyy-MM-dd" type="date" var="buildDateString" />
     </c:otherwise>
 </c:choose>
 

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/home.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/home.jsp
@@ -34,10 +34,10 @@ $(document).ready(function(){
     <ul class="breadcrumb">
         <c:choose>
             <c:when test="${not empty model.musicFolder}">
-		        <li>${fn:escapeXml(model.musicFolder.name)}</li>
+                <li>${fn:escapeXml(model.musicFolder.name)}</li>
             </c:when>
             <c:otherwise>
-		        <li><fmt:message key='left.allfolders'/></li>
+                <li><fmt:message key='left.allfolders'/></li>
             </c:otherwise>
         </c:choose>
     </ul>
@@ -95,11 +95,11 @@ $(document).ready(function(){
 </section>
 
 <div class="actions">
-	<ul class="controls">
-		<li><a href="javascript:refresh()" title="<fmt:message key='common.refresh'/>" class="control refresh"><fmt:message key="common.refresh"/></a></li>
-		<li><a href="javascript:playShuffle()" title="<fmt:message key='home.shuffle'/>" class="control shuffle"><fmt:message key="home.shuffle"/></a></li>
-	</ul>
-	<c:set var="isFootPager" value="false" />
+    <ul class="controls">
+        <li><a href="javascript:refresh()" title="<fmt:message key='common.refresh'/>" class="control refresh"><fmt:message key="common.refresh"/></a></li>
+        <li><a href="javascript:playShuffle()" title="<fmt:message key='home.shuffle'/>" class="control shuffle"><fmt:message key="home.shuffle"/></a></li>
+    </ul>
+    <c:set var="isFootPager" value="false" />
     <%@ include file="homePager.jsp" %>
 </div>
 
@@ -131,12 +131,14 @@ $(document).ready(function(){
             <c:set var="captionCount" value="3"/>
         </c:if>
         <c:if test="${not empty album.lastPlayed}">
-            <fmt:formatDate value="${album.lastPlayed}" dateStyle="short" var="lastPlayedDate"/>
+            <fmt:parseDate value="${album.lastPlayed}" type="both" pattern="yyyy-MM-dd" var="parsedDate" />
+            <fmt:formatDate value="${parsedDate}" pattern="yyyy-MM-dd" var="lastPlayedDate" />
             <c:set var="caption3"><fmt:message key="home.lastplayed"><fmt:param value="${lastPlayedDate}"/></fmt:message></c:set>
             <c:set var="captionCount" value="3"/>
         </c:if>
         <c:if test="${not empty album.created}">
-            <fmt:formatDate value="${album.created}" dateStyle="short" var="creationDate"/>
+            <fmt:parseDate value="${album.created}" type="both" pattern="yyyy-MM-dd" var="parsedDate" />
+            <fmt:formatDate value="${parsedDate}" pattern="yyyy-MM-dd" var="creationDate" />
             <c:set var="caption3"><fmt:message key="home.created"><fmt:param value="${creationDate}"/></fmt:message></c:set>
             <c:set var="captionCount" value="3"/>
         </c:if>

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/playerSettings.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/playerSettings.jsp
@@ -167,7 +167,12 @@
                         </dd>
                     </c:if>
                     <dt><fmt:message key="playersettings.lastseen"/></dt>
-                    <dd><fmt:formatDate value="${command.lastSeen}" type="both" dateStyle="long" timeStyle="medium"/></dd>
+                    <dd>
+                        <c:if test="${not empty command.lastSeen}">
+                            <fmt:parseDate value="${command.lastSeen}" type="both" pattern="yyyy-MM-dd'T'HH:mm:ss" var="parsedDate" />
+                            <fmt:formatDate value="${parsedDate}" pattern="yyyy-MM-dd HH:mm:ss" />
+                        </c:if>
+                    </dd>
                 </dl>
             </details>
     

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/playlist.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/playlist.jsp
@@ -220,7 +220,10 @@ function onDeletePlaylist() {
         <dt><span class="icon duration"><fmt:message key="playlist2.duration"/></span></dt>
         <dd><span id="songCount"></span><fmt:message key="playlist2.songs"/> &ndash; <span id="duration"></span></dd>
         <dt><span class="icon date"><fmt:message key="playlist2.created"/></span></dt>
-        <dd><fmt:formatDate type="date" dateStyle="long" value="${model.playlist.created}"/></dd>
+        <dd>
+            <fmt:parseDate value="${model.created}" type="both" pattern="yyyy-MM-dd'T'HH:mm:ss" var="parsedDate" />
+            <fmt:formatDate value="${parsedDate}" pattern="yyyy-MM-dd HH:mm:ss" />
+        </dd>
         <dt><span class="icon person"><fmt:message key="playlist2.author"/></span></dt>
         <dd>${fn:escapeXml(model.playlist.username)}</dd>
         <dt><span class="icon visibility"><fmt:message key="playlist2.visibility"/></span></dt>

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/playlists.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/playlists.jsp
@@ -10,7 +10,7 @@
 </head>
 <script>
 $(document).ready(function(){
-    initTruncate(".mainframe", ".tabular.playlists", 2, ["name", "created", "comment"]);
+    initTruncate(".mainframe", ".tabular.playlists", 2, ["name", "comment"]);
 });
 </script>
 <body class="mainframe playlists">
@@ -65,7 +65,12 @@ $(document).ready(function(){
                             <td class="name"><span><a href="${targetUrl}" title="${fn:escapeXml(playlist.name)}">${fn:escapeXml(playlist.name)}</a></span></td>
                             <td class="numberofsongs">${playlist.fileCount} <fmt:message key="playlist2.songs"/></td>
                             <td class="duration">${playlist.durationAsString}</td>
-                            <td class="created"><span><fmt:formatDate type="date" dateStyle="long" value="${playlist.created}"/></span></td>
+                            <td class="created">
+                                <span>
+                                    <fmt:parseDate value="${playlist.createdDateTime}" type="both" pattern="yyyy-MM-dd'T'HH:mm:ss" var="parsedDate" />
+                                    <fmt:formatDate value="${parsedDate}" pattern="yyyy-MM-dd HH:mm:ss" />
+                                </span>
+                            </td>
                             <td class="author">${fn:escapeXml(playlist.username)}</td>
                             <td class="visibility">
                                 <c:choose>

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/podcastChannel.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/podcastChannel.jsp
@@ -180,7 +180,12 @@ function getSelectedEpisodes() {
                                 </c:choose>
                             </td>
                             <td class="duration">${episode.duration}</td>
-                            <td class="date"><fmt:formatDate value="${episode.publishDate}" dateStyle="medium"/></td>
+                            <td class="date">
+                                <c:if test="${not empty episode.publishDateWithZone}">
+                                    <fmt:parseDate value="${episode.publishDateWithZone}" type="both" pattern="yyyy-MM-dd'T'HH:mm" var="parsedDate" />
+                                    <fmt:formatDate value="${parsedDate}" pattern="yyyy-MM-dd HH:mm" />
+                                </c:if>
+                            </td>
                         </tr>
                     </c:forEach>
                 </tbody>        

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/podcastChannels.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/podcastChannels.jsp
@@ -152,7 +152,12 @@ $(document).ready(function(){
                     <c:set var="channelTitle" value="${model.channelMap[episode.channelId].title}"/>
                     <td class="channelTitle"><span><a href="podcastChannel.view?id=${episode.channelId}">${channelTitle}</a></span></td>
                     <td class="duration">${episode.duration}</td>
-                    <td class="date"><fmt:formatDate value="${episode.publishDate}" dateStyle="medium"/></td>
+                    <td class="date">
+                        <c:if test="${not empty episode.publishDateWithZone}">
+                            <fmt:parseDate value="${episode.publishDateWithZone}" type="both" pattern="yyyy-MM-dd'T'HH:mm" var="parsedDate" />
+                            <fmt:formatDate value="${parsedDate}" pattern="yyyy-MM-dd HH:mm" />
+                        </c:if>
+                    </td>
                 </tr>
             </c:forEach>
         </tbody>

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/shareSettings.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/shareSettings.jsp
@@ -46,13 +46,19 @@
 	                                <dt><fmt:message key="sharesettings.description" /></dt>
 	                                <dd><input type="text" name="description[${share.id}]" value="${share.description}" /></dd>
 	                                <dt><fmt:message key="sharesettings.lastvisited" /></dt>
-	                                <dd><fmt:formatDate value="${share.lastVisited}" type="date" dateStyle="medium" /></dd>
-	                                <dt><fmt:message key="sharesettings.visits" /></dt>
-	                                <dd>${share.visitCount}</dd>
-	                                <dt><fmt:message key="sharesettings.files" /></dt>
-	                                <dd><a href="${albumUrl}" title="${shareInfo.dir.name}"><str:truncateNicely upper="30">${fn:escapeXml(shareInfo.dir.name)}</str:truncateNicely></a></dd>
-	                                <dt><fmt:message key="sharesettings.expires" /></dt>
-	                                <dd><fmt:formatDate value="${share.expires}" type="date" dateStyle="medium" /></dd>
+                                    <dd>
+                                        <fmt:parseDate value="${share.lastVisitedWithZone}" type="date" pattern="yyyy-MM-dd'T'HH:mm:ss" var="parsedDate" />
+                                        <fmt:formatDate value="${parsedDate}" pattern="yyyy-MM-dd HH:mm:ss" />
+                                    </dd>
+                                    <dt><fmt:message key="sharesettings.visits" /></dt>
+                                    <dd>${share.visitCount}</dd>
+                                    <dt><fmt:message key="sharesettings.files" /></dt>
+                                    <dd><a href="${albumUrl}" title="${shareInfo.dir.name}"><str:truncateNicely upper="30">${fn:escapeXml(shareInfo.dir.name)}</str:truncateNicely></a></dd>
+                                    <dt><fmt:message key="sharesettings.expires" /></dt>
+                                    <dd>
+                                        <fmt:parseDate value="${share.expiresWithZone}" type="date" pattern="yyyy-MM-dd'T'HH:mm:ss" var="parsedDate" />
+                                        <fmt:formatDate value="${parsedDate}" pattern="yyyy-MM-dd HH:mm:ss" />
+                                    </dd>
 	                                <dt><fmt:message key="sharesettings.expirein" /></dt>
 	                                <dd>
 	                                    

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/MusicFolderTestDataUtils.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/MusicFolderTestDataUtils.java
@@ -21,10 +21,11 @@
 
 package com.tesshu.jpsonic;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
+
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 
 import com.tesshu.jpsonic.domain.MusicFolder;
@@ -59,7 +60,7 @@ public final class MusicFolderTestDataUtils {
 
     public static List<MusicFolder> getTestMusicFolders() {
         return Arrays.asList(
-                new MusicFolder(1, MusicFolderTestDataUtils.resolveMusicFolderPath(), "Music", true, new Date()),
-                new MusicFolder(2, MusicFolderTestDataUtils.resolveMusic2FolderPath(), "Music2", true, new Date()));
+                new MusicFolder(1, MusicFolderTestDataUtils.resolveMusicFolderPath(), "Music", true, now()),
+                new MusicFolder(2, MusicFolderTestDataUtils.resolveMusic2FolderPath(), "Music2", true, now()));
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/CoverArtServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/CoverArtServiceTest.java
@@ -19,6 +19,7 @@
 
 package com.tesshu.jpsonic.ajax;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -29,7 +30,6 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 
 import com.tesshu.jpsonic.AbstractNeedsScan;
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 
+@SuppressWarnings("PMD.TooManyStaticImports")
 class CoverArtServiceTest extends AbstractNeedsScan {
 
     private static final String TEST_IMAGE_URL = "https://avatars.githubusercontent.com/u/44695789?s=200&v=4";
@@ -62,7 +63,7 @@ class CoverArtServiceTest extends AbstractNeedsScan {
     @Override
     public List<MusicFolder> getMusicFolders() {
         if (isEmpty(musicFolders)) {
-            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, new Date()));
+            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now()));
         }
         return musicFolders;
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/MultiServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/MultiServiceTest.java
@@ -19,13 +19,13 @@
 
 package com.tesshu.jpsonic.ajax;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 
 import com.tesshu.jpsonic.AbstractNeedsScan;
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
 
+@SuppressWarnings("PMD.TooManyStaticImports")
 class MultiServiceTest extends AbstractNeedsScan {
 
     private static final String ADMIN_NAME = "admin";
@@ -64,7 +65,7 @@ class MultiServiceTest extends AbstractNeedsScan {
     @Override
     public List<MusicFolder> getMusicFolders() {
         if (isEmpty(musicFolders)) {
-            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, new Date()));
+            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now()));
         }
         return musicFolders;
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/NowPlayingServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/NowPlayingServiceTest.java
@@ -20,10 +20,10 @@
 package com.tesshu.jpsonic.ajax;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.Arrays;
-import java.util.Date;
 
 import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.domain.PlayStatus;
@@ -50,7 +50,7 @@ class NowPlayingServiceTest {
         file.setId(0);
         Player player = new Player();
         player.setUsername(ServiceMockUtils.ADMIN_NAME);
-        PlayStatus playStatus = new PlayStatus(file, player, new Date());
+        PlayStatus playStatus = new PlayStatus(file, player, now());
         Mockito.when(statusService.getPlayStatuses()).thenReturn(Arrays.asList(playStatus));
 
         nowPlayingService = new NowPlayingService(mock(SecurityService.class), mock(PlayerService.class), statusService,

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/PlaylistServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/PlaylistServiceTest.java
@@ -20,9 +20,17 @@
 package com.tesshu.jpsonic.ajax;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import java.util.regex.Pattern;
+
 import com.tesshu.jpsonic.dao.MediaFileDao;
+import com.tesshu.jpsonic.domain.PlayQueue;
+import com.tesshu.jpsonic.domain.Player;
+import com.tesshu.jpsonic.domain.Playlist;
 import com.tesshu.jpsonic.i18n.AirsonicLocaleResolver;
 import com.tesshu.jpsonic.service.MediaFileService;
 import com.tesshu.jpsonic.service.MusicFolderService;
@@ -31,18 +39,65 @@ import com.tesshu.jpsonic.service.SecurityService;
 import com.tesshu.jpsonic.service.ServiceMockUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.web.bind.ServletRequestBindingException;
 
+@SuppressWarnings("PMD.TooManyStaticImports")
 class PlaylistServiceTest {
 
     private PlaylistService playlistService;
+    private com.tesshu.jpsonic.service.PlaylistService deligate;
+    private PlayerService playerService;
 
     @BeforeEach
     public void setup() {
+        deligate = mock(com.tesshu.jpsonic.service.PlaylistService.class);
+        playerService = mock(PlayerService.class);
         playlistService = new PlaylistService(mock(MusicFolderService.class), mock(SecurityService.class),
-                mock(MediaFileService.class), mock(com.tesshu.jpsonic.service.PlaylistService.class),
-                mock(MediaFileDao.class), mock(PlayerService.class), mock(AirsonicLocaleResolver.class),
-                AjaxMockUtils.mock(AjaxHelper.class));
+                mock(MediaFileService.class), deligate, mock(MediaFileDao.class), playerService,
+                mock(AirsonicLocaleResolver.class), AjaxMockUtils.mock(AjaxHelper.class));
+    }
+
+    @Test
+    @WithMockUser(username = ServiceMockUtils.ADMIN_NAME)
+    void testGetPlaylist() {
+        int id = 99;
+        Playlist playlist = new Playlist();
+        playlist.setCreated(now());
+        playlist.setChanged(now());
+        Mockito.when(deligate.getPlaylist(id)).thenReturn(playlist);
+
+        PlaylistInfo playlistInfo = playlistService.getPlaylist(id);
+        assertNull(playlistInfo.getPlaylist().getCreated());
+        assertNull(playlistInfo.getPlaylist().getChanged());
+    }
+
+    @Test
+    void testCreateEmptyPlaylist() {
+        ArgumentCaptor<Playlist> captor = ArgumentCaptor.forClass(Playlist.class);
+        Mockito.doNothing().when(deligate).createPlaylist(captor.capture());
+
+        playlistService.createEmptyPlaylist();
+        // yyyy-MM-dd HH:mm
+        assertTrue(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}$")
+                .matcher(captor.getValue().getName()).matches());
+    }
+
+    @Test
+    @WithMockUser(username = ServiceMockUtils.ADMIN_NAME)
+    void testCreatePlaylistForPlayQueue() throws ServletRequestBindingException {
+        ArgumentCaptor<Playlist> captor = ArgumentCaptor.forClass(Playlist.class);
+        Mockito.doNothing().when(deligate).createPlaylist(captor.capture());
+        Player player = new Player();
+        player.setPlayQueue(new PlayQueue());
+        Mockito.when(playerService.getPlayer(Mockito.any(), Mockito.any())).thenReturn(player);
+
+        playlistService.createPlaylistForPlayQueue();
+        // yyyy-MM-dd HH:mm
+        assertTrue(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}$")
+                .matcher(captor.getValue().getName()).matches());
     }
 
     @Test

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/ChangeCoverArtControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/ChangeCoverArtControllerTest.java
@@ -19,10 +19,10 @@
 
 package com.tesshu.jpsonic.controller;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -50,7 +50,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 class ChangeCoverArtControllerTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, new Date()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now()));
 
     @Autowired
     private MediaFileDao mediaFileDao;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/CoverArtControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/CoverArtControllerTest.java
@@ -20,6 +20,7 @@
 package com.tesshu.jpsonic.controller;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -34,7 +35,7 @@ import java.io.OutputStream;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Date;
+import java.time.Instant;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -396,11 +397,11 @@ class CoverArtControllerTest {
         void testLastModified() throws URISyntaxException, IOException {
 
             Artist artist = new Artist();
-            Date lastScanned = new Date();
+            Instant lastScanned = now();
             artist.setLastScanned(lastScanned);
 
             ArtistCoverArtRequest request = new ArtistCoverArtRequest(controller, fontLoader, logic, artist);
-            assertEquals(lastScanned.getTime(), request.lastModified());
+            assertEquals(lastScanned.toEpochMilli(), request.lastModified());
 
             Path path = createPath("/MEDIAS/Metadata/coverart/album.gif");
             artist.setCoverArtPath(path.toString());
@@ -416,11 +417,11 @@ class CoverArtControllerTest {
         void testLastModified() throws URISyntaxException, IOException {
 
             Album album = new Album();
-            Date lastScanned = new Date();
+            Instant lastScanned = now();
             album.setLastScanned(lastScanned);
 
             AlbumCoverArtRequest request = new AlbumCoverArtRequest(controller, fontLoader, logic, album);
-            assertEquals(lastScanned.getTime(), request.lastModified());
+            assertEquals(lastScanned.toEpochMilli(), request.lastModified());
 
             Path path = createPath("/MEDIAS/Metadata/coverart/album.gif");
             album.setCoverArtPath(path.toString());
@@ -436,12 +437,12 @@ class CoverArtControllerTest {
         void testLastModified() throws URISyntaxException, IOException {
 
             Playlist playlist = new Playlist();
-            Date changed = new Date();
+            Instant changed = now();
             playlist.setChanged(changed);
 
             PlaylistCoverArtRequest request = new PlaylistCoverArtRequest(controller, fontLoader, logic,
                     mediaFileService, playlistService, playlist);
-            assertEquals(changed.getTime(), request.lastModified());
+            assertEquals(changed.toEpochMilli(), request.lastModified());
         }
     }
 
@@ -464,11 +465,11 @@ class CoverArtControllerTest {
             MediaFile album = new MediaFile();
             album.setMediaType(MediaType.ALBUM);
             assertTrue(album.isDirectory());
-            Date changed = new Date();
+            Instant changed = now();
             album.setChanged(changed);
             MediaFileCoverArtRequest request = new MediaFileCoverArtRequest(controller, fontLoader, logic,
                     mediaFileService, album);
-            assertEquals(changed.getTime(), request.lastModified());
+            assertEquals(changed.toEpochMilli(), request.lastModified());
 
             MediaFile song = new MediaFile();
             song.setMediaType(MediaType.MUSIC);
@@ -487,10 +488,10 @@ class CoverArtControllerTest {
             MediaFile video = new MediaFile();
             video.setMediaType(MediaType.ALBUM);
             assertTrue(video.isDirectory());
-            Date changed = new Date();
+            Instant changed = now();
             video.setChanged(changed);
             VideoCoverArtRequest request = new VideoCoverArtRequest(controller, fontLoader, logic, video, 0);
-            assertEquals(changed.getTime(), request.lastModified());
+            assertEquals(changed.toEpochMilli(), request.lastModified());
         }
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DownloadControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DownloadControllerTest.java
@@ -19,13 +19,13 @@
 
 package com.tesshu.jpsonic.controller;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -70,7 +70,7 @@ class DownloadControllerTest extends AbstractNeedsScan {
     @Override
     public List<MusicFolder> getMusicFolders() {
         if (isEmpty(musicFolders)) {
-            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, new Date()));
+            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now()));
         }
         return musicFolders;
     }
@@ -116,8 +116,8 @@ class DownloadControllerTest extends AbstractNeedsScan {
         Playlist playlist = new Playlist();
         playlist.setName("download test");
         playlist.setId(10);
-        playlist.setCreated(new Date());
-        playlist.setChanged(new Date());
+        playlist.setCreated(now());
+        playlist.setChanged(now());
         playlist.setShared(false);
         playlist.setUsername("admin");
         playlistService.createPlaylist(playlist);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/EditTagsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/EditTagsControllerTest.java
@@ -19,10 +19,10 @@
 
 package com.tesshu.jpsonic.controller;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -46,7 +46,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 class EditTagsControllerTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, new Date()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now()));
 
     private MockMvc mockMvc;
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/ExternalPlayerControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/ExternalPlayerControllerTest.java
@@ -23,10 +23,10 @@ import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.nio.file.Path;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -72,9 +72,9 @@ class ExternalPlayerControllerTest {
         Share share = new Share();
         share.setId(shareId);
         LocalDateTime localDateTime = LocalDateTime.now();
-        Date current = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        Instant current = localDateTime.atZone(ZoneId.systemDefault()).toInstant();
         share.setCreated(current);
-        Date expires = Date.from(localDateTime.plusDays(10).atZone(ZoneId.systemDefault()).toInstant());
+        Instant expires = localDateTime.plusDays(10).atZone(ZoneId.systemDefault()).toInstant();
         share.setExpires(expires);
         Mockito.when(shareService.getShareByName(Mockito.anyString())).thenReturn(share);
 
@@ -93,9 +93,8 @@ class ExternalPlayerControllerTest {
         UriComponentsBuilder builder = mock(UriComponentsBuilder.class);
         UriComponents components = mock(UriComponents.class);
         Mockito.when(builder.build()).thenReturn(components);
-        Mockito.when(
-                jwtSecurityService.addJWTToken(Mockito.any(UriComponentsBuilder.class), Mockito.nullable(Date.class)))
-                .thenReturn(builder);
+        Mockito.when(jwtSecurityService.addJWTToken(Mockito.any(UriComponentsBuilder.class),
+                Mockito.nullable(Instant.class))).thenReturn(builder);
 
         MvcResult result = mockMvc
                 .perform(MockMvcRequestBuilders.get("/ext/share/AAaaA")

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/HomeControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/HomeControllerTest.java
@@ -20,6 +20,7 @@
 package com.tesshu.jpsonic.controller;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -29,7 +30,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -211,7 +211,7 @@ class HomeControllerTest {
             MockHttpServletRequest req = mock(MockHttpServletRequest.class);
             Mockito.when(req.getParameter(Attributes.Request.LIST_TYPE.value()))
                     .thenReturn(AlbumListType.INDEX.getId());
-            List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, "", "name", false, new Date()));
+            List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, "", "name", false, now()));
             Mockito.when(musicFolderService.getMusicFoldersForUser(anyString(), Mockito.nullable(Integer.class)))
                     .thenReturn(musicFolders);
             Mockito.when(musicIndexService.getMusicFolderContent(musicFolders, false))

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/HomeControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/HomeControllerTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.ExecutionException;
 
 import com.tesshu.jpsonic.domain.AlbumListType;
 import com.tesshu.jpsonic.domain.Genre;
+import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.domain.MusicFolderContent;
 import com.tesshu.jpsonic.service.MediaFileService;
@@ -141,6 +142,20 @@ class HomeControllerTest {
             MockHttpServletRequest req = mock(MockHttpServletRequest.class);
             Mockito.when(req.getParameter(Attributes.Request.LIST_TYPE.value()))
                     .thenReturn(AlbumListType.RECENT.getId());
+
+            MediaFile album = new MediaFile();
+            album.setId(1);
+            Mockito.when(mediaFileService.getMostRecentlyPlayedAlbums(anyInt(), anyInt(), anyList()))
+                    .thenReturn(Arrays.asList(album));
+
+            controller.handleRequestInternal(req);
+            Mockito.verify(mediaFileService, Mockito.times(1)).getMostRecentlyPlayedAlbums(anyInt(), anyInt(),
+                    anyList());
+            Mockito.clearInvocations(mediaFileService);
+
+            album.setLastPlayed(now());
+            Mockito.when(mediaFileService.getMostRecentlyPlayedAlbums(anyInt(), anyInt(), anyList()))
+                    .thenReturn(Arrays.asList(album));
             controller.handleRequestInternal(req);
             Mockito.verify(mediaFileService, Mockito.times(1)).getMostRecentlyPlayedAlbums(anyInt(), anyInt(),
                     anyList());
@@ -151,6 +166,13 @@ class HomeControllerTest {
             MockHttpServletRequest req = mock(MockHttpServletRequest.class);
             Mockito.when(req.getParameter(Attributes.Request.LIST_TYPE.value()))
                     .thenReturn(AlbumListType.NEWEST.getId());
+
+            MediaFile album = new MediaFile();
+            album.setId(1);
+            album.setCreated(now());
+            Mockito.when(mediaFileService.getNewestAlbums(anyInt(), anyInt(), anyList()))
+                    .thenReturn(Arrays.asList(album));
+
             controller.handleRequestInternal(req);
             Mockito.verify(mediaFileService, Mockito.times(1)).getNewestAlbums(anyInt(), anyInt(), anyList());
         }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/InternetRadioSettingsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/InternetRadioSettingsControllerTest.java
@@ -20,6 +20,7 @@
 package com.tesshu.jpsonic.controller;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -27,7 +28,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.lang.annotation.Documented;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.concurrent.ExecutionException;
 
 import javax.servlet.http.HttpServletRequest;
@@ -49,7 +49,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({ "PMD.AvoidDuplicateLiterals", "PMD.TooManyStaticImports" })
 class InternetRadioSettingsControllerTest {
 
     private InternetRadioDao internetRadioDao;
@@ -58,7 +58,7 @@ class InternetRadioSettingsControllerTest {
 
     @BeforeEach
     public void setup() throws ExecutionException {
-        InternetRadio radio = new InternetRadio(0, "*name*", "*streamUrl*", "*homepageUrl*", false, new Date());
+        InternetRadio radio = new InternetRadio(0, "*name*", "*streamUrl*", "*homepageUrl*", false, now());
         internetRadioDao = mock(InternetRadioDao.class);
         Mockito.when(internetRadioDao.getAllInternetRadios()).thenReturn(Arrays.asList(radio));
         InternetRadioService internetRadioService = new InternetRadioService(internetRadioDao);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/JAXBWriterTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/JAXBWriterTest.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2022 tesshucom
+ */
+
+package com.tesshu.jpsonic.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.ExecutionException;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import com.tesshu.jpsonic.util.PlayerUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.test.context.support.WithMockUser;
+
+class JAXBWriterTest {
+
+    private JAXBWriter writer;
+
+    @BeforeEach
+    public void setup() throws ExecutionException {
+        writer = new JAXBWriter();
+    }
+
+    @Test
+    @WithMockUser(username = "admin")
+    void testConvertDate() throws Exception {
+
+        Instant dateInDB = ZonedDateTime.of(2001, 12, 31, 23, 59, 59, 999, ZoneOffset.UTC)
+                .truncatedTo(ChronoUnit.MILLIS).toInstant();
+        XMLGregorianCalendar converted = writer.convertDate(dateInDB);
+
+        assertEquals(dateInDB.toEpochMilli(), converted.toGregorianCalendar().getTimeInMillis());
+
+        // The results below will vary depending on your system's default timezone
+        // (No normalization required. To ensure readability and allow client apps to decide how to display the date.)
+
+        // Below is a sample for JST(+9)
+
+        // assertEquals(converted.getYear(), 2002);
+        // assertEquals(converted.getMonth(), 1);
+        // assertEquals(converted.getDay(), 1);
+        // assertEquals(converted.getHour(), 8);
+        // assertEquals(converted.getMinute(), 59);
+        // assertEquals(converted.getSecond(), 59);
+        // assertEquals(converted.getMillisecond(), 0);
+        // assertEquals("2001-12-31T23:59:59.000+09:00", converted.toXMLFormat());
+        // assertEquals("2001-12-31T23:59:59.000+09:00", converted.toString());
+
+        // With modern Jackson parsers, it doesn't really matter whether the intermediate format is normalized or not.
+        XMLGregorianCalendar parsedLocal = PlayerUtils.OBJECT_MAPPER.convertValue(converted.toXMLFormat(),
+                XMLGregorianCalendar.class);
+
+        // The format is different. Simply because Jackson defaults to nanoseconds.
+        assertNotEquals(dateInDB, parsedLocal); // 2001-12-31T23:59:59Z 2001-12-31T23:59:59.000Z
+
+        // Most are treated in milliseconds, so they are effectively equivalent
+        assertEquals(dateInDB.toEpochMilli(), parsedLocal.toGregorianCalendar().getTime().getTime());
+
+        assertEquals("2001-12-31 23:59:59", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneOffset.UTC)
+                .format(parsedLocal.toGregorianCalendar().toInstant()));
+        assertEquals("2002-01-01 08:59:59", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+                .withZone(ZoneId.of("Japan")).format(parsedLocal.toGregorianCalendar().toInstant()));
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MoreControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MoreControllerTest.java
@@ -20,6 +20,7 @@
 package com.tesshu.jpsonic.controller;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -27,7 +28,6 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -63,9 +63,8 @@ class MoreControllerTest {
                 .build();
         Mockito.when(searchService.getGenres(false)).thenReturn(Collections.emptyList());
         Mockito.when(playerService.getPlayer(Mockito.any(), Mockito.any())).thenReturn(new Player());
-        List<MusicFolder> musicFolders = Arrays
-                .asList(new MusicFolder(1, Path.of(MoreControllerTest.class.getResource("/MEDIAS").toURI()).toString(),
-                        "MEDIAS", true, new Date()));
+        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
+                Path.of(MoreControllerTest.class.getResource("/MEDIAS").toURI()).toString(), "MEDIAS", true, now()));
         Mockito.when(musicFolderService.getMusicFoldersForUser(ServiceMockUtils.ADMIN_NAME)).thenReturn(musicFolders);
     }
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MusicFolderSettingsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MusicFolderSettingsControllerTest.java
@@ -20,12 +20,12 @@
 package com.tesshu.jpsonic.controller;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Arrays;
-import java.util.Date;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 
@@ -57,6 +57,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+@SuppressWarnings("PMD.TooManyStaticImports")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class MusicFolderSettingsControllerTest {
 
@@ -175,7 +176,7 @@ class MusicFolderSettingsControllerTest {
         assertNotNull(command);
 
         MusicFolder musicFolder = new MusicFolder(MusicFolderTestDataUtils.resolveMusicFolderPath(), "Music", true,
-                new Date());
+                now());
         MusicFolderInfo musicFolderInfo = new MusicFolderInfo(musicFolder);
         command.setNewMusicFolder(musicFolderInfo);
 
@@ -202,21 +203,21 @@ class MusicFolderSettingsControllerTest {
         assertNotNull(command);
 
         MusicFolder musicFolder1 = new MusicFolder(99, MusicFolderTestDataUtils.resolveMusicFolderPath(), "Music", true,
-                new Date());
+                now());
         MusicFolderInfo musicFolderInfo1 = new MusicFolderInfo(musicFolder1);
         musicFolderInfo1.setDelete(true);
         MusicFolder musicFolder2 = new MusicFolder(MusicFolderTestDataUtils.resolveMusic2FolderPath(), null, true,
-                new Date());
+                now());
         MusicFolderInfo musicFolderInfo2 = new MusicFolderInfo(musicFolder2);
         command.setMusicFolders(Arrays.asList(musicFolderInfo1, musicFolderInfo2));
 
         // Case where the registered path is deleted on the web page
         MusicFolder musicFolder3 = new MusicFolder(MusicFolderTestDataUtils.resolveMusic3FolderPath(), null, true,
-                new Date());
+                now());
         MusicFolderInfo musicFolderInfo3 = new MusicFolderInfo(musicFolder3);
         musicFolderInfo3.setPath(null);
         // Cases that do not (already) exist. Update will be executed but will be ignored in Dao.
-        MusicFolder musicFolder4 = new MusicFolder("/Unknown", null, true, new Date());
+        MusicFolder musicFolder4 = new MusicFolder("/Unknown", null, true, now());
         MusicFolderInfo musicFolderInfo4 = new MusicFolderInfo(musicFolder4);
 
         command.setMusicFolders(Arrays.asList(musicFolderInfo1, musicFolderInfo2, musicFolderInfo3, musicFolderInfo4));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/PlaylistControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/PlaylistControllerTest.java
@@ -20,6 +20,7 @@
 package com.tesshu.jpsonic.controller;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -50,7 +51,9 @@ class PlaylistControllerTest {
     @BeforeEach
     public void setup() throws ExecutionException {
         PlaylistService playlistService = mock(PlaylistService.class);
-        Mockito.when(playlistService.getPlaylist(PLAYLIST_ID)).thenReturn(new Playlist());
+        Playlist playlist = new Playlist();
+        playlist.setCreated(now());
+        Mockito.when(playlistService.getPlaylist(PLAYLIST_ID)).thenReturn(playlist);
         mockMvc = MockMvcBuilders
                 .standaloneSetup(
                         new PlaylistController(mock(SecurityService.class), playlistService, mock(PlayerService.class)))

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/PodcastChannelsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/PodcastChannelsControllerTest.java
@@ -20,17 +20,27 @@
 package com.tesshu.jpsonic.controller;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
+import com.tesshu.jpsonic.domain.PodcastEpisode;
 import com.tesshu.jpsonic.service.MediaScannerService;
 import com.tesshu.jpsonic.service.PodcastService;
 import com.tesshu.jpsonic.service.SecurityService;
 import com.tesshu.jpsonic.service.ServiceMockUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -39,16 +49,25 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.ModelAndView;
 
+@SuppressWarnings("PMD.TooManyStaticImports")
 class PodcastChannelsControllerTest {
 
+    private PodcastService podcastService;
     private MockMvc mockMvc;
 
     @BeforeEach
     public void setup() throws ExecutionException {
+        podcastService = mock(PodcastService.class);
+
+        PodcastEpisode episode = new PodcastEpisode(null, null, null, null, null, null, null, null, null, null, null,
+                null);
+        Mockito.when(podcastService.getNewestEpisodes(10)).thenReturn(Arrays.asList(episode));
+
         mockMvc = MockMvcBuilders.standaloneSetup(new PodcastChannelsController(mock(SecurityService.class),
-                mock(PodcastService.class), mock(MediaScannerService.class), mock(ViewAsListSelector.class))).build();
+                podcastService, mock(MediaScannerService.class), mock(ViewAsListSelector.class))).build();
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     @WithMockUser(username = ServiceMockUtils.ADMIN_NAME)
     void testGet() throws Exception {
@@ -58,5 +77,25 @@ class PodcastChannelsControllerTest {
 
         ModelAndView modelAndView = result.getModelAndView();
         assertEquals("podcastChannels", modelAndView.getViewName());
+        Map<String, Object> model = (Map<String, Object>) modelAndView.getModel().get("model");
+        List<PodcastChannelsController.PodcastEpisode> episodes = (List<PodcastChannelsController.PodcastEpisode>) model
+                .get("newestEpisodes");
+        assertEquals(1, episodes.size());
+        assertNull(episodes.get(0).getPublishDate());
+        assertNull(episodes.get(0).getPublishDateWithZone());
+        Mockito.clearInvocations(podcastService);
+
+        Instant now = now();
+        PodcastEpisode episode = new PodcastEpisode(null, null, null, null, null, null, null, null, null, null, null,
+                null);
+        episode.setPublishDate(now);
+        Mockito.when(podcastService.getNewestEpisodes(10)).thenReturn(Arrays.asList(episode));
+        result = mockMvc.perform(MockMvcRequestBuilders.get("/" + ViewName.PODCAST_CHANNELS.value()))
+                .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
+        model = (Map<String, Object>) result.getModelAndView().getModel().get("model");
+        episodes = (List<PodcastChannelsController.PodcastEpisode>) model.get("newestEpisodes");
+        assertEquals(1, episodes.size());
+        assertEquals(now, episodes.get(0).getPublishDate());
+        assertEquals(ZonedDateTime.ofInstant(now, ZoneId.systemDefault()), episodes.get(0).getPublishDateWithZone());
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/PodcastControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/PodcastControllerTest.java
@@ -23,8 +23,19 @@ import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
+import com.tesshu.jpsonic.domain.MediaFile;
+import com.tesshu.jpsonic.domain.Playlist;
 import com.tesshu.jpsonic.service.PlaylistService;
 import com.tesshu.jpsonic.service.SecurityService;
 import com.tesshu.jpsonic.service.SettingsService;
@@ -41,25 +52,52 @@ import org.springframework.web.servlet.ModelAndView;
 
 class PodcastControllerTest {
 
+    private SettingsService settingsService;
+    private PlaylistService playlistService;
     private MockMvc mockMvc;
+    private final Instant created = ZonedDateTime.of(2022, 10, 20, 3, 4, 5, 6, ZoneOffset.UTC).toInstant();
 
     @BeforeEach
     public void setup() throws ExecutionException {
-        SettingsService settingsService = mock(SettingsService.class);
+        settingsService = mock(SettingsService.class);
+        playlistService = mock(PlaylistService.class);
         Mockito.when(settingsService.isPublishPodcast()).thenReturn(true);
-        mockMvc = MockMvcBuilders.standaloneSetup(
-                new PodcastController(settingsService, mock(SecurityService.class), mock(PlaylistService.class)))
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new PodcastController(settingsService, mock(SecurityService.class), playlistService))
                 .build();
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     @WithMockUser(username = "admin")
     void testGet() throws Exception {
+
+        Mockito.when(settingsService.getLocale()).thenReturn(Locale.JAPAN);
+
+        Playlist playlist = new Playlist();
+        playlist.setCreated(created);
+        Mockito.when(playlistService.getReadablePlaylistsForUser(Mockito.nullable(String.class)))
+                .thenReturn(Arrays.asList(playlist));
+        MediaFile song = new MediaFile();
+        song.setFileSize(20L);
+        Mockito.when(playlistService.getFilesInPlaylist(playlist.getId())).thenReturn(Arrays.asList(song));
+
         MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/" + ViewName.PODCAST.value()))
                 .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
         assertNotNull(result);
 
         ModelAndView modelAndView = result.getModelAndView();
         assertEquals("podcast", modelAndView.getViewName());
+        Map<String, Object> model = (Map<String, Object>) modelAndView.getModel().get("model");
+
+        // lang depends on SettingsService
+        assertEquals("ja", model.get("lang"));
+
+        List<PodcastController.Podcast> podcasts = (List<PodcastController.Podcast>) model.get("podcasts");
+        assertEquals(1, podcasts.size());
+
+        // date format must be English
+        assertEquals(DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z").withZone(ZoneId.systemDefault())
+                .withLocale(Locale.ENGLISH).format(created), podcasts.get(0).getPublishDate());
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/RandomPlayQueueControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/RandomPlayQueueControllerTest.java
@@ -20,6 +20,7 @@
 package com.tesshu.jpsonic.controller;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -45,8 +46,10 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.ModelAndView;
 
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class RandomPlayQueueControllerTest {
 
+    private RandomPlayQueueController controller;
     private MockMvc mockMvc;
 
     @BeforeEach
@@ -56,9 +59,9 @@ class RandomPlayQueueControllerTest {
         player.setUsername(ServiceMockUtils.ADMIN_NAME);
         player.setPlayQueue(new PlayQueue());
         Mockito.when(playerService.getPlayer(Mockito.any(), Mockito.any())).thenReturn(player);
-        mockMvc = MockMvcBuilders.standaloneSetup(new RandomPlayQueueController(mock(MusicFolderService.class),
-                mock(SecurityService.class), playerService, mock(MediaFileService.class), mock(IndexManager.class)))
-                .build();
+        controller = new RandomPlayQueueController(mock(MusicFolderService.class), mock(SecurityService.class),
+                playerService, mock(MediaFileService.class), mock(IndexManager.class));
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
     }
 
     @Test
@@ -69,6 +72,7 @@ class RandomPlayQueueControllerTest {
                         .param(Attributes.Request.SIZE.value(), Integer.toString(24))
                         .param(Attributes.Request.MUSIC_FOLDER_ID.value(), Integer.toString(0))
                         .param(Attributes.Request.NameConstants.LAST_PLAYED_VALUE, "any")
+                        .param(Attributes.Request.NameConstants.LAST_PLAYED_COMP, "lt")
                         .param(Attributes.Request.NameConstants.YEAR, "any"))
                 .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
         assertNotNull(result);
@@ -79,5 +83,43 @@ class RandomPlayQueueControllerTest {
         @SuppressWarnings("unchecked")
         Map<String, Object> model = (Map<String, Object>) modelAndView.getModel().get("model");
         assertNotNull(model);
+    }
+
+    @Test
+    void testGetLastPlayed() {
+        assertNull(controller.getLastPlayed("any", "lt").getMinLastPlayedDate());
+        assertNull(controller.getLastPlayed("any", "lt").getMaxLastPlayedDate());
+        assertNull(controller.getLastPlayed("any", "gt").getMinLastPlayedDate());
+        assertNull(controller.getLastPlayed("any", "gt").getMaxLastPlayedDate());
+
+        assertNull(controller.getLastPlayed("1day", "lt").getMinLastPlayedDate());
+        assertNotNull(controller.getLastPlayed("1day", "lt").getMaxLastPlayedDate());
+        assertNotNull(controller.getLastPlayed("1day", "gt").getMinLastPlayedDate());
+        assertNull(controller.getLastPlayed("1day", "gt").getMaxLastPlayedDate());
+
+        assertNull(controller.getLastPlayed("1week", "lt").getMinLastPlayedDate());
+        assertNotNull(controller.getLastPlayed("1week", "lt").getMaxLastPlayedDate());
+        assertNotNull(controller.getLastPlayed("1week", "gt").getMinLastPlayedDate());
+        assertNull(controller.getLastPlayed("1week", "gt").getMaxLastPlayedDate());
+
+        assertNull(controller.getLastPlayed("1month", "lt").getMinLastPlayedDate());
+        assertNotNull(controller.getLastPlayed("1month", "lt").getMaxLastPlayedDate());
+        assertNotNull(controller.getLastPlayed("1month", "gt").getMinLastPlayedDate());
+        assertNull(controller.getLastPlayed("1month", "gt").getMaxLastPlayedDate());
+
+        assertNull(controller.getLastPlayed("3months", "lt").getMinLastPlayedDate());
+        assertNotNull(controller.getLastPlayed("3months", "lt").getMaxLastPlayedDate());
+        assertNotNull(controller.getLastPlayed("3months", "gt").getMinLastPlayedDate());
+        assertNull(controller.getLastPlayed("3months", "gt").getMaxLastPlayedDate());
+
+        assertNull(controller.getLastPlayed("6months", "lt").getMinLastPlayedDate());
+        assertNotNull(controller.getLastPlayed("6months", "lt").getMaxLastPlayedDate());
+        assertNotNull(controller.getLastPlayed("6months", "gt").getMinLastPlayedDate());
+        assertNull(controller.getLastPlayed("6months", "gt").getMaxLastPlayedDate());
+
+        assertNull(controller.getLastPlayed("1year", "lt").getMinLastPlayedDate());
+        assertNotNull(controller.getLastPlayed("1year", "lt").getMaxLastPlayedDate());
+        assertNotNull(controller.getLastPlayed("1year", "gt").getMinLastPlayedDate());
+        assertNull(controller.getLastPlayed("1year", "gt").getMaxLastPlayedDate());
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/ShareSettingsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/ShareSettingsControllerTest.java
@@ -20,12 +20,24 @@
 package com.tesshu.jpsonic.controller;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
+import com.tesshu.jpsonic.controller.ShareSettingsController.ShareInfo;
+import com.tesshu.jpsonic.domain.MediaFile;
+import com.tesshu.jpsonic.domain.Share;
+import com.tesshu.jpsonic.domain.User;
 import com.tesshu.jpsonic.service.MediaFileService;
 import com.tesshu.jpsonic.service.MusicFolderService;
 import com.tesshu.jpsonic.service.SecurityService;
@@ -34,6 +46,7 @@ import com.tesshu.jpsonic.service.SettingsService;
 import com.tesshu.jpsonic.service.ShareService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -42,22 +55,33 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.ModelAndView;
 
+@SuppressWarnings("PMD.TooManyStaticImports")
 class ShareSettingsControllerTest {
 
+    private ShareService shareService;
     private MockMvc mockMvc;
 
     @BeforeEach
     public void setup() throws ExecutionException {
-        mockMvc = MockMvcBuilders
-                .standaloneSetup(
-                        new ShareSettingsController(mock(SettingsService.class), mock(MusicFolderService.class),
-                                mock(SecurityService.class), mock(ShareService.class), mock(MediaFileService.class)))
+        shareService = mock(ShareService.class);
+        mockMvc = MockMvcBuilders.standaloneSetup(
+                new ShareSettingsController(mock(SettingsService.class), mock(MusicFolderService.class),
+                        mock(SecurityService.class), shareService, mock(MediaFileService.class)))
                 .build();
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     @WithMockUser(username = ServiceMockUtils.ADMIN_NAME)
     void testDoGet() throws Exception {
+
+        Instant now = now();
+        Share share = new Share();
+        share.setCreated(now);
+        Mockito.when(shareService.getSharesForUser(Mockito.any(User.class))).thenReturn(Arrays.asList(share));
+        Mockito.when(shareService.getSharedFiles(Mockito.anyInt(), Mockito.anyList()))
+                .thenReturn(Arrays.asList(new MediaFile()));
+
         MvcResult result = mockMvc
                 .perform(MockMvcRequestBuilders.get("/" + ViewName.SHARE_SETTINGS.value())
                         .param(Attributes.Request.DELETE.value(), "false"))
@@ -66,9 +90,34 @@ class ShareSettingsControllerTest {
         ModelAndView modelAndView = result.getModelAndView();
         assertEquals("shareSettings", modelAndView.getViewName());
 
-        @SuppressWarnings("unchecked")
         Map<String, Object> model = (Map<String, Object>) modelAndView.getModel().get("model");
         assertNotNull(model);
+        List<ShareInfo> shareInfos = (List<ShareInfo>) model.get("shareInfos");
+        assertEquals(1, shareInfos.size());
+        assertEquals(ZonedDateTime.ofInstant(now, ZoneId.systemDefault()),
+                shareInfos.get(0).getShare().getCreatedWithZone());
+        assertNull(shareInfos.get(0).getShare().getExpiresWithZone());
+        assertNull(shareInfos.get(0).getShare().getLastVisitedWithZone());
+        Mockito.clearInvocations(shareService);
+
+        Instant expires = now.plus(2, ChronoUnit.DAYS);
+        share.setExpires(expires);
+        Instant lastVisited = now.plus(1, ChronoUnit.DAYS);
+        share.setLastVisited(lastVisited);
+        Mockito.when(shareService.getSharesForUser(Mockito.any(User.class))).thenReturn(Arrays.asList(share));
+        result = mockMvc
+                .perform(MockMvcRequestBuilders.get("/" + ViewName.SHARE_SETTINGS.value())
+                        .param(Attributes.Request.DELETE.value(), "false"))
+                .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
+        model = (Map<String, Object>) result.getModelAndView().getModel().get("model");
+        shareInfos = (List<ShareInfo>) model.get("shareInfos");
+        assertEquals(ZonedDateTime.ofInstant(now, ZoneId.systemDefault()),
+                shareInfos.get(0).getShare().getCreatedWithZone());
+        assertEquals(ZonedDateTime.ofInstant(expires, ZoneId.systemDefault()),
+                shareInfos.get(0).getShare().getExpiresWithZone());
+        assertEquals(ZonedDateTime.ofInstant(lastVisited, ZoneId.systemDefault()),
+                shareInfos.get(0).getShare().getLastVisitedWithZone());
+        Mockito.clearInvocations(shareService);
     }
 
     @Test

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/SubsonicRESTControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/SubsonicRESTControllerTest.java
@@ -22,6 +22,7 @@
 package com.tesshu.jpsonic.controller;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -30,7 +31,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -238,7 +238,7 @@ class SubsonicRESTControllerTest {
     class IntegreationTest extends AbstractNeedsScan {
 
         private final List<MusicFolder> musicFolders = Arrays
-                .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, new Date()));
+                .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now()));
 
         @Autowired
         private MockMvc mvc;
@@ -895,8 +895,8 @@ class SubsonicRESTControllerTest {
         void testGetPlaylist() throws ExecutionException {
             try {
 
-                Playlist playlist = new Playlist(0, ServiceMockUtils.ADMIN_NAME, false, "name", "comment", 0, 0,
-                        new Date(), new Date(), null);
+                Playlist playlist = new Playlist(0, ServiceMockUtils.ADMIN_NAME, false, "name", "comment", 0, 0, now(),
+                        now(), null);
                 playlistService.createPlaylist(playlist);
 
                 mvc.perform(MockMvcRequestBuilders.get("/rest/getPlaylist")
@@ -971,7 +971,7 @@ class SubsonicRESTControllerTest {
 
                 String playlistName = "UpdatePlaylist";
                 Playlist playlist = new Playlist(0, ServiceMockUtils.ADMIN_NAME, false, playlistName, "comment", 0, 0,
-                        new Date(), new Date(), null);
+                        now(), now(), null);
                 playlistService.createPlaylist(playlist);
                 playlist = playlistService.getAllPlaylists().stream().filter(p -> playlistName.equals(p.getName()))
                         .findFirst().get();
@@ -1013,7 +1013,7 @@ class SubsonicRESTControllerTest {
 
                 String playlistName = "DeletePlaylist";
                 Playlist playlist = new Playlist(0, ServiceMockUtils.ADMIN_NAME, false, playlistName, "comment", 0, 0,
-                        new Date(), new Date(), null);
+                        now(), now(), null);
                 playlistService.createPlaylist(playlist);
                 playlist = playlistService.getAllPlaylists().stream().filter(p -> playlistName.equals(p.getName()))
                         .findFirst().get();

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/SubsonicRESTControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/SubsonicRESTControllerTest.java
@@ -1415,6 +1415,7 @@ class SubsonicRESTControllerTest {
         }
 
         @Test
+        @WithMockUser(username = ServiceMockUtils.ADMIN_NAME)
         void testScrobble() throws ExecutionException {
             RandomSearchCriteria criteria = new RandomSearchCriteria(1, null, null, null, musicFolders);
             MediaFile song = mediaFileDao.getRandomSongs(criteria, ServiceMockUtils.ADMIN_NAME).get(0);
@@ -1435,7 +1436,7 @@ class SubsonicRESTControllerTest {
                         .param(Attributes.Request.U.value(), ServiceMockUtils.ADMIN_NAME)
                         .param(Attributes.Request.P.value(), ADMIN_PASS)
                         .param(Attributes.Request.F.value(), EXPECTED_FORMAT)
-                        .param(Attributes.Request.ID.value(), Integer.toString(song.getId())).param("time", "0")
+                        .param(Attributes.Request.ID.value(), Integer.toString(song.getId()))
                         .contentType(MediaType.APPLICATION_JSON)).andExpect(MockMvcResultMatchers.status().isOk())
                         .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_STATUS).value(JSON_VALUE_OK))
                         .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_VERSION).value(apiVerion));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/TopControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/TopControllerTest.java
@@ -20,6 +20,7 @@
 package com.tesshu.jpsonic.controller;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -31,7 +32,6 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -236,7 +236,7 @@ class TopControllerTest {
         void testWithoutSelectedMusicFolders() throws ServletRequestBindingException, URISyntaxException {
             List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
                     Path.of(TopControllerTest.class.getResource("/MEDIAS/Sort/Pagination/Artists").toURI()).toString(),
-                    "MEDIAS", true, new Date()));
+                    "MEDIAS", true, now()));
             Mockito.when(musicFolderService.getMusicFoldersForUser(Mockito.anyString())).thenReturn(musicFolders);
 
             MockHttpServletRequest request = mock(MockHttpServletRequest.class);
@@ -248,7 +248,7 @@ class TopControllerTest {
         void testWithSelectedMusicFolders() throws ServletRequestBindingException, URISyntaxException {
             List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
                     Path.of(TopControllerTest.class.getResource("/MEDIAS/Sort/Pagination/Artists").toURI()).toString(),
-                    "MEDIAS", true, new Date()));
+                    "MEDIAS", true, now()));
             Mockito.when(musicFolderService.getMusicFoldersForUser(Mockito.anyString())).thenReturn(musicFolders);
             Mockito.when(securityService.getSelectedMusicFolder(Mockito.anyString())).thenReturn(musicFolders.get(0));
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/UploadControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/UploadControllerTest.java
@@ -20,13 +20,13 @@
 package com.tesshu.jpsonic.controller;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -87,8 +87,7 @@ class UploadControllerTest {
     @WithMockUser(username = "admin")
     void testHandleRequestInternalWithFile(@TempDir Path tempDirPath) throws Exception {
 
-        MusicFolder musicFolder = new MusicFolder(Integer.valueOf(0), tempDirPath.toString(), "Incoming1", true,
-                new Date());
+        MusicFolder musicFolder = new MusicFolder(Integer.valueOf(0), tempDirPath.toString(), "Incoming1", true, now());
         musicFolderDao.createMusicFolder(musicFolder);
 
         URL url = UploadController.class.getResource(FILE_PATH);
@@ -116,8 +115,7 @@ class UploadControllerTest {
     @WithMockUser(username = "admin")
     void testHandleRequestInternalWithZip(@TempDir Path tempDirPath) throws Exception {
 
-        MusicFolder musicFolder = new MusicFolder(Integer.valueOf(1), tempDirPath.toString(), "Incoming2", true,
-                new Date());
+        MusicFolder musicFolder = new MusicFolder(Integer.valueOf(1), tempDirPath.toString(), "Incoming2", true, now());
         musicFolderDao.createMusicFolder(musicFolder);
 
         URL url = UploadController.class.getResource(ZIP_PATH);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/UploadEntryControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/UploadEntryControllerTest.java
@@ -20,13 +20,13 @@
 package com.tesshu.jpsonic.controller;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -55,7 +55,7 @@ class UploadEntryControllerTest {
     public void setup() throws ExecutionException, URISyntaxException {
         List<MusicFolder> musicFolders = Arrays.asList(
                 new MusicFolder(1, Path.of(UploadEntryControllerTest.class.getResource("/MEDIAS").toURI()).toString(),
-                        "MEDIAS", true, new Date()));
+                        "MEDIAS", true, now()));
         MusicFolderService musicFolderService = mock(MusicFolderService.class);
         Mockito.when(musicFolderService.getMusicFoldersForUser(ServiceMockUtils.ADMIN_NAME)).thenReturn(musicFolders);
         mockMvc = MockMvcBuilders.standaloneSetup(new UploadEntryController(musicFolderService,

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/InternetRadioDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/InternetRadioDaoTest.java
@@ -21,9 +21,10 @@
 
 package com.tesshu.jpsonic.dao;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Date;
+import java.time.temporal.ChronoUnit;
 
 import com.tesshu.jpsonic.NeedsHome;
 import com.tesshu.jpsonic.domain.InternetRadio;
@@ -60,16 +61,16 @@ class InternetRadioDaoTest {
 
     @Test
     void testCreateInternetRadio() {
-        InternetRadio radio = new InternetRadio("name", "streamUrl", "homePageUrl", true, new Date());
+        InternetRadio radio = new InternetRadio("name", "streamUrl", "homePageUrl", true, now());
         internetRadioDao.createInternetRadio(radio);
 
-        InternetRadio newRadio = internetRadioDao.getAllInternetRadios().get(0);
-        assertInternetRadioEquals(radio, newRadio);
+        InternetRadio insertedRadio = internetRadioDao.getAllInternetRadios().get(0);
+        assertInternetRadioEquals(radio, insertedRadio);
     }
 
     @Test
     void testUpdateInternetRadio() {
-        InternetRadio radio = new InternetRadio("name", "streamUrl", "homePageUrl", true, new Date());
+        InternetRadio radio = new InternetRadio("name", "streamUrl", "homePageUrl", true, now());
         internetRadioDao.createInternetRadio(radio);
         radio = internetRadioDao.getAllInternetRadios().get(0);
 
@@ -77,7 +78,7 @@ class InternetRadioDaoTest {
         radio.setStreamUrl("newStreamUrl");
         radio.setHomepageUrl("newHomePageUrl");
         radio.setEnabled(false);
-        radio.setChanged(new Date(234_234L));
+        radio.setChanged(radio.getChanged().minus(1, ChronoUnit.DAYS));
         internetRadioDao.updateInternetRadio(radio);
 
         InternetRadio newRadio = internetRadioDao.getAllInternetRadios().get(0);
@@ -87,9 +88,9 @@ class InternetRadioDaoTest {
     @Test
     void testDeleteInternetRadio() {
         assertEquals(0, internetRadioDao.getAllInternetRadios().size(), "Wrong number of radios.");
-        internetRadioDao.createInternetRadio(new InternetRadio("name", "streamUrl", "homePageUrl", true, new Date()));
+        internetRadioDao.createInternetRadio(new InternetRadio("name", "streamUrl", "homePageUrl", true, now()));
         assertEquals(1, internetRadioDao.getAllInternetRadios().size(), "Wrong number of radios.");
-        internetRadioDao.createInternetRadio(new InternetRadio("name", "streamUrl", "homePageUrl", true, new Date()));
+        internetRadioDao.createInternetRadio(new InternetRadio("name", "streamUrl", "homePageUrl", true, now()));
         assertEquals(2, internetRadioDao.getAllInternetRadios().size(), "Wrong number of radios.");
         internetRadioDao.deleteInternetRadio(internetRadioDao.getAllInternetRadios().get(0).getId());
         assertEquals(1, internetRadioDao.getAllInternetRadios().size(), "Wrong number of radios.");

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/JAlbumDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/JAlbumDaoTest.java
@@ -19,10 +19,10 @@
 
 package com.tesshu.jpsonic.dao;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -37,7 +37,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class JAlbumDaoTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Compare"), "Albums", true, new Date()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Compare"), "Albums", true, now()));
 
     @Autowired
     private AlbumDao albumDao;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/JArtistDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/JArtistDaoTest.java
@@ -19,10 +19,10 @@
 
 package com.tesshu.jpsonic.dao;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -37,7 +37,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class JArtistDaoTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Compare"), "Artists", true, new Date()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Compare"), "Artists", true, now()));
 
     @Autowired
     private JArtistDao artistDao;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/JMediaFileDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/JMediaFileDaoTest.java
@@ -19,14 +19,15 @@
 
 package com.tesshu.jpsonic.dao;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.lang.annotation.Documented;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -47,7 +48,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class JMediaFileDaoTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays.asList(
-            new MusicFolder(1, resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Merge"), "Duplicate", true, new Date()));
+            new MusicFolder(1, resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Merge"), "Duplicate", true, now()));
 
     @Autowired
     private JMediaFileDao mediaFileDao;
@@ -294,7 +295,7 @@ class JMediaFileDaoTest extends AbstractNeedsScan {
 
     @BeforeEach
     public void setup() {
-        Date now = new Date();
+        Instant now = now();
 
         mediaScannerService.setJpsonicCleansingProcess(false);
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MediaFileDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MediaFileDaoTest.java
@@ -19,6 +19,7 @@
 
 package com.tesshu.jpsonic.dao;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -26,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("PMD.AvoidDuplicateLiterals") // In the testing class, it may be less readable.
+@SuppressWarnings({ "PMD.AvoidDuplicateLiterals", "PMD.TooManyStaticImports" })
 class MediaFileDaoTest {
 
     @Nested
@@ -237,8 +237,8 @@ class MediaFileDaoTest {
             Optional<String> op = builder.getMinLastPlayedDateCondition();
             assertFalse(op.isPresent());
 
-            criteria = new RandomSearchCriteria(0, null, null, null, null, new Date(), null, null, null, null, null,
-                    false, false, null);
+            criteria = new RandomSearchCriteria(0, null, null, null, null, now(), null, null, null, null, null, false,
+                    false, null);
             Assertions.assertNotNull(criteria.getMinLastPlayedDate());
             builder = new RandomSongsQueryBuilder(criteria);
             op = builder.getMinLastPlayedDateCondition();
@@ -259,16 +259,16 @@ class MediaFileDaoTest {
             Optional<String> op = builder.getMaxLastPlayedDateCondition();
             assertFalse(op.isPresent());
 
-            criteria = new RandomSearchCriteria(0, null, null, null, null, new Date(), new Date(), null, null, null,
-                    null, false, false, null);
+            criteria = new RandomSearchCriteria(0, null, null, null, null, now(), now(), null, null, null, null, false,
+                    false, null);
             Assertions.assertNotNull(criteria.getMinLastPlayedDate());
             Assertions.assertNotNull(criteria.getMaxLastPlayedDate());
             builder = new RandomSongsQueryBuilder(criteria);
             op = builder.getMaxLastPlayedDateCondition();
             assertEquals(condition1, op.get());
 
-            criteria = new RandomSearchCriteria(0, null, null, null, null, null, new Date(), null, null, null, null,
-                    false, false, null);
+            criteria = new RandomSearchCriteria(0, null, null, null, null, null, now(), null, null, null, null, false,
+                    false, null);
             assertNull(criteria.getMinLastPlayedDate());
             Assertions.assertNotNull(criteria.getMaxLastPlayedDate());
             builder = new RandomSongsQueryBuilder(criteria);
@@ -510,15 +510,15 @@ class MediaFileDaoTest {
             assertTrue(assertWithCondition.apply(query));
 
             // minLastPlayedDateCondition
-            criteria = new RandomSearchCriteria(0, null, null, null, Collections.emptyList(), new Date(), null, null,
-                    null, null, null, false, false, null);
+            criteria = new RandomSearchCriteria(0, null, null, null, Collections.emptyList(), now(), null, null, null,
+                    null, null, false, false, null);
             builder = new RandomSongsQueryBuilder(criteria);
             query = builder.build();
             assertTrue(assertWithCondition.apply(query));
 
             // maxLastPlayedDateCondition
-            criteria = new RandomSearchCriteria(0, null, null, null, Collections.emptyList(), null, new Date(), null,
-                    null, null, null, false, false, null);
+            criteria = new RandomSearchCriteria(0, null, null, null, Collections.emptyList(), null, now(), null, null,
+                    null, null, false, false, null);
             builder = new RandomSongsQueryBuilder(criteria);
             query = builder.build();
             assertTrue(assertWithCondition.apply(query));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MusicFolderDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MusicFolderDaoTest.java
@@ -21,9 +21,10 @@
 
 package com.tesshu.jpsonic.dao;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Date;
+import java.time.temporal.ChronoUnit;
 
 import com.tesshu.jpsonic.NeedsHome;
 import com.tesshu.jpsonic.domain.MusicFolder;
@@ -56,7 +57,7 @@ class MusicFolderDaoTest {
 
     @Test
     void testCreateMusicFolder() {
-        MusicFolder musicFolder = new MusicFolder("path", "name", true, new Date());
+        MusicFolder musicFolder = new MusicFolder("path", "name", true, now());
         musicFolderDao.createMusicFolder(musicFolder);
 
         MusicFolder newMusicFolder = musicFolderDao.getAllMusicFolders().get(0);
@@ -65,13 +66,13 @@ class MusicFolderDaoTest {
 
     @Test
     void testUpdateMusicFolder() {
-        MusicFolder musicFolder = new MusicFolder("path", "name", true, new Date());
+        MusicFolder musicFolder = new MusicFolder("path", "name", true, now());
         musicFolderDao.createMusicFolder(musicFolder);
         musicFolder = musicFolderDao.getAllMusicFolders().get(0);
 
         musicFolder.setName("newName");
         musicFolder.setEnabled(false);
-        musicFolder.setChanged(new Date(234_234L));
+        musicFolder.setChanged(now().minus(1, ChronoUnit.DAYS));
         musicFolderDao.updateMusicFolder(musicFolder);
 
         MusicFolder newMusicFolder = musicFolderDao.getAllMusicFolders().get(0);
@@ -82,10 +83,10 @@ class MusicFolderDaoTest {
     void testDeleteMusicFolder() {
         assertEquals(0, musicFolderDao.getAllMusicFolders().size(), "Wrong number of music folders.");
 
-        musicFolderDao.createMusicFolder(new MusicFolder("path", "name", true, new Date()));
+        musicFolderDao.createMusicFolder(new MusicFolder("path", "name", true, now()));
         assertEquals(1, musicFolderDao.getAllMusicFolders().size(), "Wrong number of music folders.");
 
-        musicFolderDao.createMusicFolder(new MusicFolder("path", "name", true, new Date()));
+        musicFolderDao.createMusicFolder(new MusicFolder("path", "name", true, now()));
         assertEquals(2, musicFolderDao.getAllMusicFolders().size(), "Wrong number of music folders.");
 
         musicFolderDao.deleteMusicFolder(musicFolderDao.getAllMusicFolders().get(0).getId());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/PlayerDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/PlayerDaoTest.java
@@ -21,12 +21,12 @@
 
 package com.tesshu.jpsonic.dao;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Date;
 import java.util.List;
 
 import com.tesshu.jpsonic.NeedsHome;
@@ -49,7 +49,7 @@ import org.springframework.boot.test.context.SpringBootTest;
  */
 @SpringBootTest
 @ExtendWith(NeedsHome.class)
-@SuppressWarnings("PMD.AvoidDuplicateLiterals") // In the testing class, it may be less readable.
+@SuppressWarnings({ "PMD.AvoidDuplicateLiterals", "PMD.TooManyStaticImports" })
 class PlayerDaoTest {
 
     @Autowired
@@ -74,7 +74,7 @@ class PlayerDaoTest {
         player.setAutoControlEnabled(false);
         player.setTechnology(PlayerTechnology.EXTERNAL_WITH_PLAYLIST);
         player.setClientId("android");
-        player.setLastSeen(new Date());
+        player.setLastSeen(now());
         player.setTranscodeScheme(TranscodeScheme.MAX_256);
 
         playerDao.createPlayer(player);
@@ -172,7 +172,7 @@ class PlayerDaoTest {
         player.setIpAddress("ipaddress");
         player.setDynamicIp(true);
         player.setAutoControlEnabled(false);
-        player.setLastSeen(new Date());
+        player.setLastSeen(now());
         player.setTranscodeScheme(TranscodeScheme.MAX_256);
 
         playerDao.updatePlayer(player);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/PodcastDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/PodcastDaoTest.java
@@ -21,12 +21,13 @@
 
 package com.tesshu.jpsonic.dao;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-import java.util.Date;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import com.tesshu.jpsonic.NeedsHome;
@@ -46,7 +47,7 @@ import org.springframework.boot.test.context.SpringBootTest;
  */
 @SpringBootTest
 @ExtendWith(NeedsHome.class)
-@SuppressWarnings("PMD.AvoidDuplicateLiterals") // In the testing class, it may be less readable.
+@SuppressWarnings({ "PMD.AvoidDuplicateLiterals", "PMD.TooManyStaticImports" })
 class PodcastDaoTest {
 
     @Autowired
@@ -132,7 +133,7 @@ class PodcastDaoTest {
     void testCreateEpisode() {
         int channelId = createChannel();
         PodcastEpisode episode = new PodcastEpisode(null, channelId, "http://bar", "path", "title", "description",
-                new Date(), "12:34", null, null, PodcastStatus.NEW, null);
+                now(), "12:34", null, null, PodcastStatus.NEW, null);
         podcastDao.createEpisode(episode);
 
         PodcastEpisode newEpisode = podcastDao.getEpisodes(channelId).get(0);
@@ -146,7 +147,7 @@ class PodcastDaoTest {
 
         int channelId = createChannel();
         PodcastEpisode episode = new PodcastEpisode(null, channelId, "http://bar", "path", "title", "description",
-                new Date(), "12:34", 3_276_213L, 2_341_234L, PodcastStatus.NEW, "error");
+                now(), "12:34", 3_276_213L, 2_341_234L, PodcastStatus.NEW, "error");
         podcastDao.createEpisode(episode);
 
         int episodeId = podcastDao.getEpisodes(channelId).get(0).getId();
@@ -157,12 +158,12 @@ class PodcastDaoTest {
     @Test
     void testGetEpisodes() {
         int channelId = createChannel();
-        PodcastEpisode a = new PodcastEpisode(null, channelId, "a", null, null, null, new Date(3000), null, null, null,
-                PodcastStatus.NEW, null);
-        PodcastEpisode b = new PodcastEpisode(null, channelId, "b", null, null, null, new Date(1000), null, null, null,
-                PodcastStatus.NEW, "error");
-        PodcastEpisode c = new PodcastEpisode(null, channelId, "c", null, null, null, new Date(2000), null, null, null,
-                PodcastStatus.NEW, null);
+        PodcastEpisode a = new PodcastEpisode(null, channelId, "a", null, null, null, now().plus(3, ChronoUnit.DAYS),
+                null, null, null, PodcastStatus.NEW, null);
+        PodcastEpisode b = new PodcastEpisode(null, channelId, "b", null, null, null, now().plus(1, ChronoUnit.DAYS),
+                null, null, null, PodcastStatus.NEW, "error");
+        PodcastEpisode c = new PodcastEpisode(null, channelId, "c", null, null, null, now().plus(2, ChronoUnit.DAYS),
+                null, null, null, PodcastStatus.NEW, null);
         PodcastEpisode d = new PodcastEpisode(null, channelId, "c", null, null, null, null, null, null, null,
                 PodcastStatus.NEW, "");
         podcastDao.createEpisode(a);
@@ -190,7 +191,7 @@ class PodcastDaoTest {
         episode.setPath("c:/tmp");
         episode.setTitle("Title");
         episode.setDescription("Description");
-        episode.setPublishDate(new Date());
+        episode.setPublishDate(now());
         episode.setDuration("1:20");
         episode.setBytesTotal(87_628_374_612L);
         episode.setBytesDownloaded(9086L);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/UserDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/UserDaoTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 
@@ -256,7 +256,7 @@ class UserDaoTest {
         settings.setNowPlayingAllowed(true);
         settings.setAvatarScheme(AvatarScheme.SYSTEM);
         settings.setSystemAvatarId(102);
-        settings.setChanged(new Date(9412L));
+        settings.setChanged(Instant.ofEpochMilli(9412L));
         settings.setKeyboardShortcutsEnabled(true);
         settings.setPaginationSize(120);
 
@@ -291,7 +291,7 @@ class UserDaoTest {
         assertTrue(userSettings.isNowPlayingAllowed(), "Error in getUserSettings().");
         Assertions.assertSame(AvatarScheme.SYSTEM, userSettings.getAvatarScheme(), "Error in getUserSettings().");
         assertEquals(102, userSettings.getSystemAvatarId().intValue(), "Error in getUserSettings().");
-        assertEquals(new Date(9412L), userSettings.getChanged(), "Error in getUserSettings().");
+        assertEquals(Instant.ofEpochMilli(9412L), userSettings.getChanged(), "Error in getUserSettings().");
         assertTrue(userSettings.isKeyboardShortcutsEnabled(), "Error in getUserSettings().");
         assertEquals(120, userSettings.getPaginationSize(), "Error in getUserSettings().");
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JpsonicComparatorsTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JpsonicComparatorsTest.java
@@ -20,17 +20,18 @@
 package com.tesshu.jpsonic.domain;
 
 import static com.tesshu.jpsonic.domain.JpsonicComparators.OrderBy.ARTIST;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.lang.annotation.Documented;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.function.Function;
@@ -65,13 +66,13 @@ import org.springframework.context.annotation.ComponentScan;
 @SpringBootTest
 @SpringBootConfiguration
 @ComponentScan(basePackages = "com.tesshu.jpsonic")
-@SuppressWarnings("PMD.AvoidDuplicateLiterals") // In the testing class, it may be less readable.
+@SuppressWarnings({ "PMD.AvoidDuplicateLiterals", "PMD.TooManyStaticImports" })
 class JpsonicComparatorsTest extends AbstractNeedsScan {
 
     protected static final Logger LOG = LoggerFactory.getLogger(JpsonicComparatorsTest.class);
 
-    protected static final List<MusicFolder> MUSIC_FOLDERS = Arrays.asList(
-            new MusicFolder(1, resolveBaseMediaPath("Sort/Compare"), "test date for sorting", true, new Date()));
+    protected static final List<MusicFolder> MUSIC_FOLDERS = Arrays
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Compare"), "test date for sorting", true, now()));
 
     protected static final List<String> INDEX_LIST = Collections.unmodifiableList(Arrays.asList("abcde", "abcいうえおあ", // Turn
                                                                                                                      // over
@@ -1221,7 +1222,7 @@ class JpsonicComparatorsTest extends AbstractNeedsScan {
             settingsService.setDlnaGuestPublish(false);
 
             Function<String, Playlist> toPlaylist = (title) -> {
-                Date now = new Date();
+                Instant now = now();
                 Playlist playlist = new Playlist();
                 playlist.setName(title);
                 playlist.setUsername("admin");

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/PlayStatusTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/PlayStatusTest.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2022 tesshucom
+ */
+
+package com.tesshu.jpsonic.domain;
+
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.time.temporal.ChronoUnit;
+
+import org.junit.jupiter.api.Test;
+
+class PlayStatusTest {
+
+    @Test
+    void testIsExpired() {
+        PlayStatus withinBoundaries = new PlayStatus(null, null,
+                now().minus(5, ChronoUnit.HOURS).minus(59, ChronoUnit.MINUTES));
+        assertTrue(withinBoundaries.isExpired());
+
+        PlayStatus outOfBoundaries = new PlayStatus(null, null, now().minus(6, ChronoUnit.HOURS));
+        assertFalse(outOfBoundaries.isExpired());
+    }
+
+    @Test
+    void testGetMinutesAgo() {
+        assertEquals(5L, new PlayStatus(null, null, now().plus(5, ChronoUnit.MINUTES)).getMinutesAgo());
+        assertEquals(60L, new PlayStatus(null, null, now().plus(1, ChronoUnit.HOURS)).getMinutesAgo());
+        assertEquals(1440L, new PlayStatus(null, null, now().plus(1, ChronoUnit.DAYS)).getMinutesAgo());
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/InternetRadioServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/InternetRadioServiceTest.java
@@ -21,6 +21,7 @@
 
 package com.tesshu.jpsonic.service;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
@@ -32,7 +33,6 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -45,6 +45,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("PMD.TooManyStaticImports")
 class InternetRadioServiceTest {
 
     private static final String TEST_RADIO_NAME = "Test Radio";
@@ -79,15 +80,13 @@ class InternetRadioServiceTest {
         internetRadioService = Mockito.spy(new InternetRadioService(null));
 
         // Prepare a mock InternetRadio object
-        radio1 = new InternetRadio(1, TEST_RADIO_NAME, TEST_PLAYLIST_URL_1, TEST_RADIO_HOMEPAGE, true, new Date());
-        radioMove = new InternetRadio(3, TEST_RADIO_NAME, TEST_PLAYLIST_URL_MOVE, TEST_RADIO_HOMEPAGE, true,
-                new Date());
+        radio1 = new InternetRadio(1, TEST_RADIO_NAME, TEST_PLAYLIST_URL_1, TEST_RADIO_HOMEPAGE, true, now());
+        radioMove = new InternetRadio(3, TEST_RADIO_NAME, TEST_PLAYLIST_URL_MOVE, TEST_RADIO_HOMEPAGE, true, now());
         radioMoveLoop = new InternetRadio(3, TEST_RADIO_NAME, TEST_PLAYLIST_URL_MOVE_LOOP, TEST_RADIO_HOMEPAGE, true,
-                new Date());
-        radioLarge = new InternetRadio(4, TEST_RADIO_NAME, TEST_PLAYLIST_URL_LARGE, TEST_RADIO_HOMEPAGE, true,
-                new Date());
+                now());
+        radioLarge = new InternetRadio(4, TEST_RADIO_NAME, TEST_PLAYLIST_URL_LARGE, TEST_RADIO_HOMEPAGE, true, now());
         radioLarge2 = new InternetRadio(5, TEST_RADIO_NAME, TEST_PLAYLIST_URL_LARGE_2, TEST_RADIO_HOMEPAGE, true,
-                new Date());
+                now());
 
         // Prepare the mocked URL connection for the simple playlist
         HttpURLConnection mockURLConnection1 = Mockito.mock(HttpURLConnection.class);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceTest.java
@@ -22,6 +22,8 @@
 package com.tesshu.jpsonic.service;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.FAR_PAST;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,10 +36,10 @@ import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -72,7 +74,6 @@ import com.tesshu.jpsonic.service.search.SearchCriteriaDirector;
 import com.tesshu.jpsonic.util.FileUtil;
 import net.sf.ehcache.Ehcache;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.time.DateUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -186,11 +187,11 @@ class MediaScannerServiceTest {
                 Path file = createPath("/MEDIAS/Music2/_DIR_ chrome hoof - 2004/10 telegraph hill.mp3");
                 assertFalse(Files.isDirectory(file));
                 MediaFile child = mediaFileService.createMediaFile(file);
-                child.setLastScanned(MediaFileDao.ZERO_DATE);
+                child.setLastScanned(FAR_PAST);
 
                 MusicFolder musicFolder = new MusicFolder(
-                        MusicFolderTestDataUtils.resolveBaseMediaPath().concat("Music2"), "name", false, new Date());
-                Date scanStart = DateUtils.truncate(new Date(), Calendar.SECOND);
+                        MusicFolderTestDataUtils.resolveBaseMediaPath().concat("Music2"), "name", false, now());
+                Instant scanStart = now();
                 MediaLibraryStatistics statistics = new MediaLibraryStatistics(scanStart);
                 Map<String, Integer> albumCount = new ConcurrentHashMap<>();
                 Genres genres = new Genres();
@@ -214,16 +215,16 @@ class MediaScannerServiceTest {
                 song.setArtist("artist");
 
                 // nullable
-                song.setLastScanned(new Date());
+                song.setLastScanned(now().minus(1, ChronoUnit.SECONDS));
                 return song;
             }
 
             private MediaLibraryStatistics createStatistics() {
-                return new MediaLibraryStatistics(DateUtils.truncate(new Date(), Calendar.SECOND));
+                return new MediaLibraryStatistics(now());
             }
 
             private MusicFolder createMusicFolder() {
-                return new MusicFolder(Integer.valueOf(1), "", "", true, new Date());
+                return new MusicFolder(Integer.valueOf(1), "", "", true, now());
             }
 
             @Test
@@ -456,16 +457,16 @@ class MediaScannerServiceTest {
                 song.setAlbumArtist("albumArtist");
 
                 // nullable
-                // song.setLastScanned(new Date());
+                // song.setLastScanned(now());
                 return song;
             }
 
             private MediaLibraryStatistics createStatistics() {
-                return new MediaLibraryStatistics(DateUtils.truncate(new Date(), Calendar.SECOND));
+                return new MediaLibraryStatistics(now());
             }
 
             private MusicFolder createMusicFolder() {
-                return new MusicFolder(Integer.valueOf(1), "", "", true, new Date());
+                return new MusicFolder(Integer.valueOf(1), "", "", true, now());
             }
 
             @Test
@@ -546,10 +547,10 @@ class MediaScannerServiceTest {
         public List<MusicFolder> getMusicFolders() {
             if (ObjectUtils.isEmpty(musicFolders)) {
                 musicFolders = Arrays.asList(
-                        new MusicFolder(1, resolveBaseMediaPath("Scan/Id3LIFO"), "alphaBeticalProps", true, new Date()),
-                        new MusicFolder(2, resolveBaseMediaPath("Scan/Null"), "noTagFirstChild", true, new Date()),
+                        new MusicFolder(1, resolveBaseMediaPath("Scan/Id3LIFO"), "alphaBeticalProps", true, now()),
+                        new MusicFolder(2, resolveBaseMediaPath("Scan/Null"), "noTagFirstChild", true, now()),
                         new MusicFolder(3, resolveBaseMediaPath("Scan/Reverse"), "fileAndPropsNameInReverse", true,
-                                new Date()));
+                                now()));
             }
             return musicFolders;
         }
@@ -805,7 +806,7 @@ class MediaScannerServiceTest {
             assertNotNull(FileUtil.createDirectories(artist));
             this.album = Path.of(artist.toString(), "ALBUM");
             assertNotNull(FileUtil.createDirectories(album));
-            this.musicFolders = Arrays.asList(new MusicFolder(1, tempDir.toString(), "musicFolder", true, new Date()));
+            this.musicFolders = Arrays.asList(new MusicFolder(1, tempDir.toString(), "musicFolder", true, now()));
 
             // Copy the song file from the test resource. No tags are registered in this file.
             Path sample = Path.of(MediaScannerServiceTest.class
@@ -1093,7 +1094,7 @@ class MediaScannerServiceTest {
                 IOUtils.copy(resource, Files.newOutputStream(musicPath));
             }
 
-            MusicFolder musicFolder = new MusicFolder(1, tempDirPath.toString(), "Music", true, new Date());
+            MusicFolder musicFolder = new MusicFolder(1, tempDirPath.toString(), "Music", true, now());
             musicFolderDao.createMusicFolder(musicFolder);
             musicFolderService.clearMusicFolderCache();
             TestCaseUtils.execScan(mediaScannerService);
@@ -1112,7 +1113,7 @@ class MediaScannerServiceTest {
 
             // Add the "Music3" folder to the database
             Path musicFolderPath = Path.of(MusicFolderTestDataUtils.resolveMusic3FolderPath());
-            MusicFolder musicFolder = new MusicFolder(1, musicFolderPath.toString(), "Music3", true, new Date());
+            MusicFolder musicFolder = new MusicFolder(1, musicFolderPath.toString(), "Music3", true, now());
             musicFolderDao.createMusicFolder(musicFolder);
             musicFolderService.clearMusicFolderCache();
             TestCaseUtils.execScan(mediaScannerService);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceUtilsTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MediaScannerServiceUtilsTest.java
@@ -19,12 +19,13 @@
 
 package com.tesshu.jpsonic.service;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -63,7 +64,7 @@ class MediaScannerServiceUtilsTest {
     class CompensateSortOfArtistTest extends AbstractNeedsScan {
 
         private final List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
-                resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Compensation"), "Duplicate", true, new Date()));
+                resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Compensation"), "Duplicate", true, now()));
 
         @Autowired
         private JMediaFileDao mediaFileDao;
@@ -347,8 +348,8 @@ class MediaScannerServiceUtilsTest {
     @Order(2)
     class CopySortOfArtistTest extends AbstractNeedsScan {
 
-        private final List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
-                resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Copy"), "Duplicate", true, new Date()));
+        private final List<MusicFolder> musicFolders = Arrays.asList(
+                new MusicFolder(1, resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Copy"), "Duplicate", true, now()));
 
         @Autowired
         private JMediaFileDao mediaFileDao;
@@ -488,8 +489,8 @@ class MediaScannerServiceUtilsTest {
     // Windows 10 Home and Windows Server 2022 results are same
     class MergeSortOfArtistTest extends AbstractNeedsScan {
 
-        private final List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
-                resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Merge"), "Duplicate", true, new Date()));
+        private final List<MusicFolder> musicFolders = Arrays.asList(
+                new MusicFolder(1, resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Merge"), "Duplicate", true, now()));
 
         @Autowired
         private JMediaFileDao mediaFileDao;
@@ -518,7 +519,7 @@ class MediaScannerServiceUtilsTest {
             assertEquals(0, mediaFileDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, false, musicFolders).size());
             assertEquals(0, artistDao.getAlphabetialArtists(0, Integer.MAX_VALUE, musicFolders).size());
 
-            Date now = new Date();
+            Instant now = now();
             populateDatabase(null, () -> {
                 List<MediaFile> albums = mediaFileDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, false, musicFolders);
                 albums.forEach(a -> {
@@ -1304,8 +1305,8 @@ class MediaScannerServiceUtilsTest {
     // Windows 10 Home and Ubuntu results are same
     class UpdateSortOfAlbumTest extends AbstractNeedsScan {
 
-        private final List<MusicFolder> musicFolders = Arrays.asList(
-                new MusicFolder(1, resolveBaseMediaPath("Sort/Cleansing/AlbumSort"), "Duplicate", true, new Date()));
+        private final List<MusicFolder> musicFolders = Arrays
+                .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Cleansing/AlbumSort"), "Duplicate", true, now()));
 
         @Autowired
         private JMediaFileDao mediaFileDao;
@@ -1335,7 +1336,7 @@ class MediaScannerServiceUtilsTest {
 
             populateDatabase(null, () -> {
                 List<MediaFile> albums = mediaFileDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, false, musicFolders);
-                Date now = new Date();
+                Instant now = now();
                 albums.forEach(a -> {
                     List<MediaFile> songs = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, a.getPathString(), false);
                     songs.forEach(m -> {

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MusicIndexServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MusicIndexServiceTest.java
@@ -22,12 +22,12 @@
 package com.tesshu.jpsonic.service;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -94,7 +94,7 @@ class MusicIndexServiceTest {
         List<MediaFile> children = Arrays.asList(child1, child2);
         Mockito.when(mediaFileService.getChildrenOf(Mockito.any(MediaFile.class), Mockito.anyBoolean(),
                 Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean())).thenReturn(children);
-        MusicFolder folder = new MusicFolder(0, "path", "name", true, new Date());
+        MusicFolder folder = new MusicFolder(0, "path", "name", true, now());
 
         SortedMap<MusicIndex, List<MusicIndex.SortableArtistWithMediaFiles>> indexedArtists = musicIndexService
                 .getIndexedArtists(Arrays.asList(folder), false);
@@ -146,8 +146,8 @@ class MusicIndexServiceTest {
 
     @Test
     void testGetIndexedArtistsListOfArtist() {
-        Artist artist1 = new Artist(0, "The Flipper's Guitar", null, 0, new Date(), false, 0, null, null, -1);
-        Artist artist2 = new Artist(0, "abcde", null, 0, new Date(), false, 0, null, null, -1);
+        Artist artist1 = new Artist(0, "The Flipper's Guitar", null, 0, now(), false, 0, null, null, -1);
+        Artist artist2 = new Artist(0, "abcde", null, 0, now(), false, 0, null, null, -1);
         List<Artist> artists = Arrays.asList(artist1, artist2);
 
         SortedMap<MusicIndex, List<MusicIndex.SortableArtistWithArtist>> indexedArtists = musicIndexService
@@ -182,7 +182,7 @@ class MusicIndexServiceTest {
                 .thenReturn(songs).thenThrow(new RuntimeException("Fail"));
         Mockito.when(mediaFileService.getMediaFile(Mockito.any(Path.class), Mockito.anyBoolean()))
                 .thenReturn(new MediaFile());
-        MusicFolder folder = new MusicFolder(0, "path", "name", true, new Date());
+        MusicFolder folder = new MusicFolder(0, "path", "name", true, now());
 
         MusicFolderContent content = musicIndexService.getMusicFolderContent(Arrays.asList(folder), false);
         assertEquals(2, content.getIndexedArtists().size());
@@ -227,8 +227,7 @@ class MusicIndexServiceTest {
         song.setPathString("path");
         Mockito.when(mediaFileService.getMediaFile(Mockito.any(Path.class), Mockito.anyBoolean())).thenReturn(song);
         MusicFolder folder = new MusicFolder(
-                Path.of(MusicIndexServiceTest.class.getResource("/MEDIAS").toURI()).toString(), "Music", true,
-                new Date());
+                Path.of(MusicIndexServiceTest.class.getResource("/MEDIAS").toURI()).toString(), "Music", true, now());
 
         List<MediaFile> shortcuts = musicIndexService.getShortcuts(Arrays.asList(folder));
         assertEquals(1, shortcuts.size());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PlayerServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PlayerServiceTest.java
@@ -20,6 +20,7 @@
 package com.tesshu.jpsonic.service;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -168,13 +169,13 @@ class PlayerServiceTest {
         void c01() {
 
             Calendar today = Calendar.getInstance();
-            today.setTime(new Date());
+            today.setTime(Date.from(now()));
 
             Mockito.clearInvocations(playerDao);
             Player player = playerService.getGuestPlayer(null);
             assertNotNull(player.getLastSeen());
             Calendar lastSeen = Calendar.getInstance();
-            lastSeen.setTime(player.getLastSeen());
+            lastSeen.setTime(Date.from(player.getLastSeen()));
             assertEquals(today.get(Calendar.YEAR), lastSeen.get(Calendar.YEAR));
             assertEquals(today.get(Calendar.MONTH), lastSeen.get(Calendar.MONTH));
             assertEquals(today.get(Calendar.DATE), lastSeen.get(Calendar.DATE));
@@ -192,11 +193,11 @@ class PlayerServiceTest {
         void c02() {
 
             Calendar today = Calendar.getInstance();
-            today.setTime(new Date());
+            today.setTime(Date.from(now()));
             Player dummy = playerService.getGuestPlayer(null);
             Player playerWithIp = new Player();
             playerWithIp.setIpAddress(PLAYER_IP);
-            playerWithIp.setLastSeen(new Date());
+            playerWithIp.setLastSeen(now());
             Mockito.when(playerDao.getPlayersForUserAndClientId(Mockito.nullable(String.class),
                     Mockito.nullable(String.class))).thenReturn(Arrays.asList(playerWithIp, dummy));
 
@@ -204,7 +205,7 @@ class PlayerServiceTest {
             Player player = playerService.getGuestPlayer(null);
             assertNotNull(player.getLastSeen());
             Calendar lastSeen = Calendar.getInstance();
-            lastSeen.setTime(player.getLastSeen());
+            lastSeen.setTime(Date.from(player.getLastSeen()));
             assertEquals(today.get(Calendar.YEAR), lastSeen.get(Calendar.YEAR));
             assertEquals(today.get(Calendar.MONTH), lastSeen.get(Calendar.MONTH));
             assertEquals(today.get(Calendar.DATE), lastSeen.get(Calendar.DATE));
@@ -223,9 +224,9 @@ class PlayerServiceTest {
 
             Player dummy = playerService.getGuestPlayer(null);
             Calendar old = Calendar.getInstance();
-            old.setTime(dummy.getLastSeen());
+            old.setTime(Date.from(dummy.getLastSeen()));
             old.add(Calendar.DATE, -2);
-            dummy.setLastSeen(old.getTime());
+            dummy.setLastSeen(old.getTime().toInstant());
             Mockito.when(playerDao.getPlayersForUserAndClientId(Mockito.nullable(String.class),
                     Mockito.nullable(String.class))).thenReturn(Arrays.asList(dummy));
 
@@ -233,9 +234,9 @@ class PlayerServiceTest {
             Player player = playerService.getGuestPlayer(null);
             assertNotNull(player.getLastSeen());
             Calendar lastSeen = Calendar.getInstance();
-            lastSeen.setTime(player.getLastSeen());
+            lastSeen.setTime(Date.from(player.getLastSeen()));
             Calendar today = Calendar.getInstance();
-            today.setTime(new Date());
+            today.setTime(Date.from(now()));
             assertEquals(today.get(Calendar.YEAR), lastSeen.get(Calendar.YEAR));
             assertEquals(today.get(Calendar.MONTH), lastSeen.get(Calendar.MONTH));
             assertEquals(today.get(Calendar.DATE), lastSeen.get(Calendar.DATE));
@@ -253,7 +254,7 @@ class PlayerServiceTest {
         void c04() {
 
             Calendar today = Calendar.getInstance();
-            today.setTime(new Date());
+            today.setTime(Date.from(now()));
 
             Mockito.when(playerDao.getPlayersForUserAndClientId(Mockito.nullable(String.class),
                     Mockito.nullable(String.class))).thenReturn(Collections.emptyList());
@@ -266,7 +267,7 @@ class PlayerServiceTest {
             assertEquals(PLAYER_IP, player.getIpAddress());
             assertNotNull(player.getLastSeen());
             Calendar lastSeen = Calendar.getInstance();
-            lastSeen.setTime(player.getLastSeen());
+            lastSeen.setTime(Date.from(player.getLastSeen()));
             assertEquals(today.get(Calendar.YEAR), lastSeen.get(Calendar.YEAR));
             assertEquals(today.get(Calendar.MONTH), lastSeen.get(Calendar.MONTH));
             assertEquals(today.get(Calendar.DATE), lastSeen.get(Calendar.DATE));
@@ -284,12 +285,12 @@ class PlayerServiceTest {
         void c05() {
 
             Calendar today = Calendar.getInstance();
-            today.setTime(new Date());
+            today.setTime(Date.from(now()));
 
             Player dummy = playerService.getGuestPlayer(null);
             Player playerWithIp = new Player();
             playerWithIp.setIpAddress(PLAYER_IP);
-            playerWithIp.setLastSeen(new Date());
+            playerWithIp.setLastSeen(now());
             Mockito.when(playerDao.getPlayersForUserAndClientId(Mockito.nullable(String.class),
                     Mockito.nullable(String.class))).thenReturn(Arrays.asList(dummy, playerWithIp));
 
@@ -301,7 +302,7 @@ class PlayerServiceTest {
             assertEquals(PLAYER_IP, player.getIpAddress());
             assertNotNull(player.getLastSeen());
             Calendar lastSeen = Calendar.getInstance();
-            lastSeen.setTime(player.getLastSeen());
+            lastSeen.setTime(Date.from(player.getLastSeen()));
             assertEquals(today.get(Calendar.YEAR), lastSeen.get(Calendar.YEAR));
             assertEquals(today.get(Calendar.MONTH), lastSeen.get(Calendar.MONTH));
             assertEquals(today.get(Calendar.DATE), lastSeen.get(Calendar.DATE));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PlayerServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PlayerServiceTest.java
@@ -312,6 +312,7 @@ class PlayerServiceTest {
             Mockito.verify(transcodingService, Mockito.never()).setTranscodingsForPlayer(Mockito.any(Player.class),
                     Mockito.anyList());
         }
+
     }
 
     @Nested
@@ -398,5 +399,14 @@ class PlayerServiceTest {
             assertEquals(TranscodeScheme.MAX_128, createdPlayer.getTranscodeScheme());
             assertEquals(transcodingDao.getAllTranscodings(), transcodingsCaptor.getValue());
         }
+    }
+
+    @Test
+    void testIsToBeUpdate() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        Player player = new Player();
+        assertNull(player.getLastSeen());
+        assertTrue(playerService.isToBeUpdate(req, true, player));
+        assertNotNull(player.getLastSeen());
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PlaylistServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PlaylistServiceTest.java
@@ -1,6 +1,7 @@
 package com.tesshu.jpsonic.service;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
@@ -11,10 +12,10 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 
 import com.tesshu.jpsonic.dao.DaoHelper;
@@ -42,7 +43,7 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({ "PMD.AvoidDuplicateLiterals", "PMD.TooManyStaticImports" })
 class PlaylistServiceTest {
 
     @Nested
@@ -305,7 +306,7 @@ class PlaylistServiceTest {
         @Test
         void testImportPlaylists(@TempDir Path tempDir) throws IOException {
 
-            final Date current = new Date();
+            final Instant current = now();
 
             Mockito.when(settingsService.getPlaylistFolder()).thenReturn(tempDir.toString());
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PodcastScheduleConfigurationTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PodcastScheduleConfigurationTest.java
@@ -20,6 +20,7 @@
 package com.tesshu.jpsonic.service;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -29,7 +30,6 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
-import java.util.Date;
 
 import ch.qos.logback.classic.Level;
 import com.tesshu.jpsonic.TestCaseUtils;
@@ -44,6 +44,7 @@ import org.springframework.scheduling.TriggerContext;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.springframework.scheduling.config.TriggerTask;
 
+@SuppressWarnings("PMD.TooManyStaticImports")
 class PodcastScheduleConfigurationTest {
 
     private SettingsService settingsService;
@@ -68,9 +69,10 @@ class PodcastScheduleConfigurationTest {
 
     @Test
     void testCreateFirstTime() {
-        LocalDateTime firstTimeExpected = LocalDateTime.now().plus(5, ChronoUnit.MINUTES);
-        LocalDateTime firstTime = PodcastScheduleConfiguration.createFirstTime().toInstant()
-                .atZone(ZoneId.systemDefault()).toLocalDateTime();
+        LocalDateTime firstTimeExpected = now().plus(5, ChronoUnit.MINUTES).atZone(ZoneId.systemDefault())
+                .toLocalDateTime();
+        LocalDateTime firstTime = PodcastScheduleConfiguration.createFirstTime().atZone(ZoneId.systemDefault())
+                .toLocalDateTime();
         assertEquals(firstTimeExpected.getDayOfMonth(), firstTime.getDayOfMonth());
         assertEquals(firstTimeExpected.getHour(), firstTime.getHour());
         assertEquals(firstTimeExpected.getMinute(), firstTime.getMinute());
@@ -112,15 +114,14 @@ class PodcastScheduleConfigurationTest {
             // Operation check at the first startup
             LocalDateTime firstTimeExpected = LocalDateTime.now().plus(5, ChronoUnit.MINUTES);
 
-            Date firstTime = trigger.nextExecutionTime(triggerContext);
-            LocalDateTime firstDateTime = Instant.ofEpochMilli(firstTime.getTime()).atZone(ZoneId.systemDefault())
-                    .toLocalDateTime();
+            Instant firstTime = trigger.nextExecutionTime(triggerContext).toInstant();
+            LocalDateTime firstDateTime = firstTime.atZone(ZoneId.systemDefault()).toLocalDateTime();
             assertEquals(firstTimeExpected.getDayOfMonth(), firstDateTime.getDayOfMonth());
             assertEquals(firstTimeExpected.getHour(), firstDateTime.getHour());
             assertEquals(firstTimeExpected.getMinute(), firstDateTime.getMinute());
 
             // Operation check at the second and subsequent startups
-            Mockito.when(triggerContext.lastCompletionTime()).thenReturn(firstTime);
+            Mockito.when(triggerContext.lastCompletionTime()).thenReturn(java.util.Date.from(firstTime));
             LocalDateTime secondDateTime = Instant.ofEpochMilli(trigger.nextExecutionTime(triggerContext).getTime())
                     .atZone(ZoneId.systemDefault()).toLocalDateTime();
             LocalDateTime secondExpected = firstTimeExpected.plus(hourOfweek, ChronoUnit.HOURS);
@@ -171,15 +172,14 @@ class PodcastScheduleConfigurationTest {
             // Operation check at the first startup
             LocalDateTime firstTimeExpected = LocalDateTime.now().plus(5, ChronoUnit.MINUTES);
 
-            Date firstTime = trigger.nextExecutionTime(triggerContext);
-            LocalDateTime firstDateTime = Instant.ofEpochMilli(firstTime.getTime()).atZone(ZoneId.systemDefault())
-                    .toLocalDateTime();
+            Instant firstTime = trigger.nextExecutionTime(triggerContext).toInstant();
+            LocalDateTime firstDateTime = firstTime.atZone(ZoneId.systemDefault()).toLocalDateTime();
             assertEquals(firstTimeExpected.getDayOfMonth(), firstDateTime.getDayOfMonth());
             assertEquals(firstTimeExpected.getHour(), firstDateTime.getHour());
             assertEquals(firstTimeExpected.getMinute(), firstDateTime.getMinute());
 
             // Operation check at the second and subsequent startups
-            Mockito.when(triggerContext.lastCompletionTime()).thenReturn(firstTime);
+            Mockito.when(triggerContext.lastCompletionTime()).thenReturn(java.util.Date.from(firstTime));
             LocalDateTime secondDateTime = Instant.ofEpochMilli(trigger.nextExecutionTime(triggerContext).getTime())
                     .atZone(ZoneId.systemDefault()).toLocalDateTime();
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PodcastServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PodcastServiceTest.java
@@ -48,16 +48,15 @@ class PodcastServiceTest {
     @Test
     void testParseDate() {
 
-        assertNull(podcastService.parseDate(null));
-        assertNull(podcastService.parseDate("Fri, 09 Sep 2022 08:49:03"));
+        assertNull(podcastService.parseDate(null)); // null
+        assertNull(podcastService.parseDate("09 Sep 2022 08:44:00 +0000")); // no days of the week
+        assertNull(podcastService.parseDate("Fri, 09 Sep 2022 08:49:03")); // no zone
+        assertNull(podcastService.parseDate("Fri, 09 Sep 2022 08:45 +0000")); // no seconds
 
         DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
         assertEquals("2022-09-09 17:41:00", fmt.format(toJST("Fri, 09 Sep 2022 08:41:00 +0000")));
         assertEquals("2022-09-09 16:42:00", fmt.format(toJST("Fri, 09 Sep 2022 08:42:00 +0100")));
         assertEquals("2022-09-09 15:43:00", fmt.format(toJST("Fri, 09 Sep 2022 08:43:00 +0200")));
-        assertEquals("2022-09-09 17:44:00", fmt.format(toJST("09 Sep 2022 08:44:00 +0000")));
-        assertEquals("2022-09-09 17:45:00", fmt.format(toJST("Fri, 09 Sep 2022 08:45 +0000")));
         assertEquals("2022-09-09 08:46:00", fmt.format(toJST("Fri, 09 Sep 2022 08:46:00 JST")));
         assertEquals("2022-09-09 08:47:01", fmt.format(toJST("Fri, 09 Sep 2022 08:47:01 ROK")));
         assertEquals("2022-09-09 22:48:02", fmt.format(toJST("Fri, 09 Sep 2022 08:48:02 CDT")));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PodcastServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PodcastServiceTest.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2021 tesshucom
+ */
+
+package com.tesshu.jpsonic.service;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PodcastServiceTest {
+
+    private PodcastService podcastService;
+
+    @BeforeEach
+    public void setup() throws ExecutionException {
+        podcastService = new PodcastService(null, null, null, null, null, null, null);
+    }
+
+    private ZonedDateTime toJST(String date) {
+        // Parse and return in Japan Standard Time
+        // "Japan" is a value for testing, actually systemDefault is used in Jpsonic.
+        return ZonedDateTime.ofInstant(podcastService.parseDate(date), ZoneId.of("Japan"));
+    }
+
+    @Test
+    void testParseDate() {
+
+        assertNull(podcastService.parseDate(null));
+        assertNull(podcastService.parseDate("Fri, 09 Sep 2022 08:49:03"));
+
+        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+        assertEquals("2022-09-09 17:41:00", fmt.format(toJST("Fri, 09 Sep 2022 08:41:00 +0000")));
+        assertEquals("2022-09-09 16:42:00", fmt.format(toJST("Fri, 09 Sep 2022 08:42:00 +0100")));
+        assertEquals("2022-09-09 15:43:00", fmt.format(toJST("Fri, 09 Sep 2022 08:43:00 +0200")));
+        assertEquals("2022-09-09 17:44:00", fmt.format(toJST("09 Sep 2022 08:44:00 +0000")));
+        assertEquals("2022-09-09 17:45:00", fmt.format(toJST("Fri, 09 Sep 2022 08:45 +0000")));
+        assertEquals("2022-09-09 08:46:00", fmt.format(toJST("Fri, 09 Sep 2022 08:46:00 JST")));
+        assertEquals("2022-09-09 08:47:01", fmt.format(toJST("Fri, 09 Sep 2022 08:47:01 ROK")));
+        assertEquals("2022-09-09 22:48:02", fmt.format(toJST("Fri, 09 Sep 2022 08:48:02 CDT")));
+        assertEquals("2022-09-09 21:49:03", fmt.format(toJST("Fri, 09 Sep 2022 08:49:03 EST")));
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/RatingServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/RatingServiceTest.java
@@ -20,13 +20,13 @@
 package com.tesshu.jpsonic.service;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 
 import com.tesshu.jpsonic.dao.RatingDao;
@@ -61,7 +61,7 @@ class RatingServiceTest {
         album.setPathString(albumPath.toString());
         Mockito.when(mediaFileService.getMediaFile(albumPath)).thenReturn(album);
 
-        MusicFolder musicFolder = new MusicFolder(0, "path", "Music", true, new Date());
+        MusicFolder musicFolder = new MusicFolder(0, "path", "Music", true, now());
         List<MusicFolder> musicFolders = Arrays.asList(musicFolder);
         List<MediaFile> highestRatedAlbums = ratingService.getHighestRatedAlbums(0, 0, musicFolders);
         assertEquals(1, highestRatedAlbums.size());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/VersionServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/VersionServiceTest.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2022 tesshucom
+ */
+
+package com.tesshu.jpsonic.service;
+
+import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class VersionServiceTest {
+
+    private VersionService versionService;
+
+    @BeforeEach
+    public void setup() {
+        versionService = new VersionService(mock(SettingsService.class));
+    }
+
+    @Test
+    void testParseLocalBuildDate() {
+        /*
+         * Zoned is used for most of the date and time on web pages or outbounds ... upnp, podcast. BuildDate is also
+         * used outside of the app (such as CI), so the text input value is used as is without region conversion.
+         */
+        LocalDate localDate = versionService.parseLocalBuildDate("20010203");
+        assertEquals(2001, localDate.getYear());
+        assertEquals(2, localDate.getMonthValue());
+        assertEquals(3, localDate.getDayOfMonth());
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/DocumentFactoryTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/DocumentFactoryTest.java
@@ -22,12 +22,12 @@
 package com.tesshu.jpsonic.service.search;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.annotation.Documented;
-import java.util.Date;
 
 import com.tesshu.jpsonic.dao.MusicFolderTestDataUtils;
 import com.tesshu.jpsonic.domain.Album;
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-@SuppressWarnings("PMD.AvoidDuplicateLiterals") // In the testing class, it may be less readable.
+@SuppressWarnings({ "PMD.AvoidDuplicateLiterals", "PMD.TooManyStaticImports" })
 class DocumentFactoryTest {
 
     private SettingsService settingsService;
@@ -155,7 +155,7 @@ class DocumentFactoryTest {
         artist.setSort("sort");
         artist.setFolderId(10);
         MusicFolder musicFolder = new MusicFolder(100, MusicFolderTestDataUtils.resolveMusicFolderPath(), "Music", true,
-                new Date());
+                now());
         Document document = documentFactory.createArtistId3Document(artist, musicFolder);
         assertEquals(6, document.getFields().size(), "fields.size");
         assertEquals("1", document.get(FieldNamesConstants.ID));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
@@ -21,6 +21,7 @@
 
 package com.tesshu.jpsonic.service.search;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -29,7 +30,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -78,7 +78,7 @@ class IndexManagerTest extends AbstractNeedsScan {
     @Override
     public List<MusicFolder> getMusicFolders() {
         if (ObjectUtils.isEmpty(musicFolders)) {
-            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, new Date()));
+            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now()));
         }
         return musicFolders;
     }
@@ -161,7 +161,7 @@ class IndexManagerTest extends AbstractNeedsScan {
         candidates = artistDao.getExpungeCandidates();
         assertEquals(0, candidates.size());
 
-        artistDao.markNonPresent(new Date());
+        artistDao.markNonPresent(now());
 
         candidates = artistDao.getExpungeCandidates();
         assertEquals(4, candidates.size());
@@ -174,7 +174,7 @@ class IndexManagerTest extends AbstractNeedsScan {
         candidates = albumDao.getExpungeCandidates();
         assertEquals(0, candidates.size());
 
-        albumDao.markNonPresent(new Date());
+        albumDao.markNonPresent(now());
 
         candidates = albumDao.getExpungeCandidates();
         assertEquals(4, candidates.size());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/QueryFactoryTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/QueryFactoryTest.java
@@ -22,6 +22,7 @@
 package com.tesshu.jpsonic.service.search;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -61,8 +62,8 @@ class QueryFactoryTest {
     private static final int FID1 = 10;
     private static final int FID2 = 20;
 
-    private static final MusicFolder MUSIC_FOLDER1 = new MusicFolder(FID1, PATH1, "music1", true, new java.util.Date());
-    private static final MusicFolder MUSIC_FOLDER2 = new MusicFolder(FID2, PATH2, "music2", true, new java.util.Date());
+    private static final MusicFolder MUSIC_FOLDER1 = new MusicFolder(FID1, PATH1, "music1", true, now());
+    private static final MusicFolder MUSIC_FOLDER2 = new MusicFolder(FID2, PATH2, "music2", true, now());
 
     private static final List<MusicFolder> SINGLE_FOLDERS = Arrays.asList(MUSIC_FOLDER1);
     private static final List<MusicFolder> MULTI_FOLDERS = Arrays.asList(MUSIC_FOLDER1, MUSIC_FOLDER2);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/SearchServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/SearchServiceTest.java
@@ -21,12 +21,12 @@
 
 package com.tesshu.jpsonic.service.search;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -591,8 +591,8 @@ class SearchServiceTest {
         @Override
         public List<MusicFolder> getMusicFolders() {
             if (isEmpty(musicFolders)) {
-                musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Search/SpecialGenre"),
-                        "accessible", true, new Date()));
+                musicFolders = Arrays.asList(
+                        new MusicFolder(1, resolveBaseMediaPath("Search/SpecialGenre"), "accessible", true, now()));
             }
             return musicFolders;
         }
@@ -868,11 +868,11 @@ class SearchServiceTest {
             if (isEmpty(musicFolders)) {
                 musicFolders = Arrays.asList(
                         new MusicFolder(1, resolveBaseMediaPath("Search/SpecialPath/accessible"), "accessible", true,
-                                new Date()),
+                                now()),
                         new MusicFolder(2, resolveBaseMediaPath("Search/SpecialPath/accessible's"), "accessible's",
-                                true, new Date()),
+                                true, now()),
                         new MusicFolder(3, resolveBaseMediaPath("Search/SpecialPath/accessible+s"), "accessible+s",
-                                true, new Date()));
+                                true, now()));
             }
             return musicFolders;
         }
@@ -932,7 +932,7 @@ class SearchServiceTest {
         public List<MusicFolder> getMusicFolders() {
             if (isEmpty(musicFolders)) {
                 musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Search/StartWithStopwards"),
-                        "accessible", true, new Date()));
+                        "accessible", true, now()));
             }
             return musicFolders;
         }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/UPnPSearchCriteriaDirectorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/UPnPSearchCriteriaDirectorTest.java
@@ -22,13 +22,13 @@
 package com.tesshu.jpsonic.service.search;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.annotation.Documented;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import com.tesshu.jpsonic.domain.Album;
@@ -244,7 +244,7 @@ public class UPnPSearchCriteriaDirectorTest {
         Mockito.when(settingsService.isSearchComposer()).thenReturn(true);
 
         List<MusicFolder> musicFolders = new ArrayList<>();
-        musicFolders.add(new MusicFolder(1, "dummy", "accessible", true, new Date()));
+        musicFolders.add(new MusicFolder(1, "dummy", "accessible", true, now()));
         musicFolderService = mock(MusicFolderService.class);
         Mockito.when(musicFolderService.getMusicFoldersForUser(User.USERNAME_GUEST)).thenReturn(musicFolders);
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/AlbumUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/AlbumUpnpProcessorTest.java
@@ -21,10 +21,10 @@
 
 package com.tesshu.jpsonic.service.upnp.processor;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 
 import com.tesshu.jpsonic.AbstractNeedsScan;
@@ -44,7 +44,7 @@ import org.springframework.context.annotation.ComponentScan;
 class AlbumUpnpProcessorTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Albums"), "Albums", true, new Date()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Albums"), "Albums", true, now()));
 
     @Autowired
     private AlbumUpnpProcessor albumUpnpProcessor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/ArtistUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/ArtistUpnpProcessorTest.java
@@ -21,12 +21,12 @@
 
 package com.tesshu.jpsonic.service.upnp.processor;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -46,7 +46,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class ArtistUpnpProcessorTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, new Date()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now()));
 
     @Autowired
     private ArtistUpnpProcessor artistUpnpProcessor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/IndexUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/IndexUpnpProcessorTest.java
@@ -24,13 +24,13 @@ package com.tesshu.jpsonic.service.upnp.processor;
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
 import static com.tesshu.jpsonic.service.upnp.processor.UpnpProcessorTestUtils.INDEX_LIST;
 import static com.tesshu.jpsonic.service.upnp.processor.UpnpProcessorTestUtils.JPSONIC_NATURAL_LIST;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
@@ -79,7 +79,7 @@ class IndexUpnpProcessorTest {
         @Test
         void testRefreshIndex() {
             // not scanning
-            List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, "", "name", true, new Date()));
+            List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, "", "name", true, now()));
             Mockito.when(util.getGuestMusicFolders()).thenReturn(musicFolders);
             Mockito.when(musicIndexService.getMusicFolderContent(musicFolders, true))
                     .thenReturn(new MusicFolderContent(new TreeMap<>(), Collections.emptyList()));
@@ -102,8 +102,8 @@ class IndexUpnpProcessorTest {
     @Nested
     class IntegrationTest extends AbstractNeedsScan {
 
-        private final List<MusicFolder> musicFolders = Arrays.asList(
-                new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, new Date()));
+        private final List<MusicFolder> musicFolders = Arrays
+                .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now()));
 
         @Autowired
         private IndexUpnpProcessor indexUpnpProcessor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/MediaFileUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/MediaFileUpnpProcessorTest.java
@@ -22,6 +22,7 @@
 package com.tesshu.jpsonic.service.upnp.processor;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -30,7 +31,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -75,8 +75,8 @@ class MediaFileUpnpProcessorTest {
             folder1.setMediaType(MediaType.DIRECTORY);
             Mockito.when(mediaFileService.getMediaFile(musicFolderPath1)).thenReturn(folder1);
 
-            Mockito.when(upnpProcessorUtil.getGuestMusicFolders()).thenReturn(
-                    Arrays.asList(new MusicFolder(0, musicFolderPath1.toString(), "Music", true, new Date())));
+            Mockito.when(upnpProcessorUtil.getGuestMusicFolders())
+                    .thenReturn(Arrays.asList(new MusicFolder(0, musicFolderPath1.toString(), "Music", true, now())));
             List<MediaFile> result = mediaFileUpnpProcessor.getItems(0, Integer.MAX_VALUE);
             Mockito.verify(mediaFileService, Mockito.times(1)).getMediaFile(Mockito.any(Path.class));
             assertEquals(0, result.size());
@@ -88,9 +88,9 @@ class MediaFileUpnpProcessorTest {
             folder2.setMediaType(MediaType.DIRECTORY);
             Mockito.when(mediaFileService.getMediaFile(musicFolderPath2)).thenReturn(folder2);
 
-            Mockito.when(upnpProcessorUtil.getGuestMusicFolders()).thenReturn(
-                    Arrays.asList(new MusicFolder(0, musicFolderPath1.toString(), "Music1", true, new Date()),
-                            new MusicFolder(1, musicFolderPath2.toString(), "Music2", true, new Date())));
+            Mockito.when(upnpProcessorUtil.getGuestMusicFolders())
+                    .thenReturn(Arrays.asList(new MusicFolder(0, musicFolderPath1.toString(), "Music1", true, now()),
+                            new MusicFolder(1, musicFolderPath2.toString(), "Music2", true, now())));
             result = mediaFileUpnpProcessor.getItems(0, Integer.MAX_VALUE);
             Mockito.verify(mediaFileService, Mockito.times(2)).getMediaFile(Mockito.any(Path.class));
             assertEquals(2, result.size());
@@ -117,7 +117,7 @@ class MediaFileUpnpProcessorTest {
             musicFolders = Arrays.asList(new MusicFolder(1,
                     Path.of(MediaFileUpnpProcessorTest.class.getResource("/MEDIAS/Sort/Pagination/Artists").toURI())
                             .toString(),
-                    "Artists", true, new Date()));
+                    "Artists", true, now()));
 
             setSortStrict(true);
             setSortAlphanum(true);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/PlaylistUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/PlaylistUpnpProcessorTest.java
@@ -21,12 +21,13 @@
 
 package com.tesshu.jpsonic.service.upnp.processor;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -50,7 +51,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class PlaylistUpnpProcessorTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, new Date()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now()));
 
     @Autowired
     private PlaylistUpnpProcessor playlistUpnpProcessor;
@@ -79,7 +80,7 @@ class PlaylistUpnpProcessorTest extends AbstractNeedsScan {
         populateDatabaseOnlyOnce();
 
         Function<String, Playlist> toPlaylist = (title) -> {
-            Date now = new Date();
+            Instant now = now();
             Playlist playlist = new Playlist();
             playlist.setName(title);
             playlist.setUsername("admin");

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RandomSongByArtistUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RandomSongByArtistUpnpProcessorTest.java
@@ -21,10 +21,10 @@
 
 package com.tesshu.jpsonic.service.upnp.processor;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -43,7 +43,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class RandomSongByArtistUpnpProcessorTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, new Date()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now()));
 
     @Autowired
     private RandomSongByArtistUpnpProcessor randomSongByArtistUpnpProcessor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RandomSongByFolderArtistUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RandomSongByFolderArtistUpnpProcessorTest.java
@@ -21,10 +21,10 @@
 
 package com.tesshu.jpsonic.service.upnp.processor;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 
 import com.tesshu.jpsonic.AbstractNeedsScan;
@@ -36,7 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class RandomSongByFolderArtistUpnpProcessorTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, new Date()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now()));
 
     @Autowired
     private RandomSongByFolderArtistUpnpProcessor processor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumId3UpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumId3UpnpProcessorTest.java
@@ -21,10 +21,10 @@
 
 package com.tesshu.jpsonic.service.upnp.processor;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -41,7 +41,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class RecentAlbumId3UpnpProcessorTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Albums"), "Albums", true, new Date()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Albums"), "Albums", true, now()));
 
     @Autowired
     private RecentAlbumId3UpnpProcessor processor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumUpnpProcessorTest.java
@@ -21,10 +21,10 @@
 
 package com.tesshu.jpsonic.service.upnp.processor;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -43,7 +43,7 @@ class RecentAlbumUpnpProcessorTest extends AbstractNeedsScan {
     private static final Logger LOG = LoggerFactory.getLogger(RecentAlbumUpnpProcessorTest.class);
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Albums"), "Albums", true, new Date()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Albums"), "Albums", true, now()));
 
     @Autowired
     private RecentAlbumUpnpProcessor processor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/SongByGenreUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/SongByGenreUpnpProcessorTest.java
@@ -21,10 +21,10 @@
 
 package com.tesshu.jpsonic.service.upnp.processor;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -43,7 +43,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class SongByGenreUpnpProcessorTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, new Date()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now()));
 
     @Autowired
     private SongByGenreUpnpProcessor songByGenreUpnpProcessor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/PlayerUtilsTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/PlayerUtilsTest.java
@@ -60,6 +60,14 @@ class PlayerUtilsTest {
         assertEquals("2930491082", stringStringMap.get("totalLengthInBytes"));
         assertEquals(Long.toString(date.getEpochSecond()) + "." + String.format("%09d", date.getNano()),
                 stringStringMap.get("scanDate"));
+
+        MediaLibraryStatistics restored = PlayerUtils.stringMapToObject(MediaLibraryStatistics.class, stringStringMap);
+        assertEquals(statistics.getAlbumCount(), restored.getAlbumCount());
+        assertEquals(statistics.getArtistCount(), restored.getArtistCount());
+        assertEquals(statistics.getScanDate(), restored.getScanDate());
+        assertEquals(statistics.getSongCount(), restored.getSongCount());
+        assertEquals(statistics.getTotalDurationInSeconds(), restored.getTotalDurationInSeconds());
+        assertEquals(statistics.getTotalLengthInBytes(), restored.getTotalLengthInBytes());
     }
 
     @Test

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/PlayerUtilsTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/PlayerUtilsTest.java
@@ -21,17 +21,19 @@
 
 package com.tesshu.jpsonic.util;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.Map;
 
 import com.tesshu.jpsonic.domain.MediaLibraryStatistics;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("PMD.TooManyStaticImports")
 class PlayerUtilsTest {
 
     @Test
@@ -43,7 +45,7 @@ class PlayerUtilsTest {
 
     @Test
     void testObjectToStringMap() {
-        Date date = new Date(1_568_350_960_725L);
+        Instant date = now();
         MediaLibraryStatistics statistics = new MediaLibraryStatistics(date);
         statistics.incrementAlbums(5);
         statistics.incrementSongs(4);
@@ -56,13 +58,15 @@ class PlayerUtilsTest {
         assertEquals("910823", stringStringMap.get("artistCount"));
         assertEquals("30", stringStringMap.get("totalDurationInSeconds"));
         assertEquals("2930491082", stringStringMap.get("totalLengthInBytes"));
-        assertEquals("1568350960725", stringStringMap.get("scanDate"));
+        assertEquals(Long.toString(date.getEpochSecond()) + "." + String.format("%09d", date.getNano()),
+                stringStringMap.get("scanDate"));
     }
 
     @Test
     void testStringMapToObject() {
+        Instant scanDate = now();
         Map<String, String> stringStringMap = LegacyMap.of("albumCount", "5", "songCount", "4", "artistCount", "910823",
-                "totalDurationInSeconds", "30", "totalLengthInBytes", "2930491082", "scanDate", "1568350960725");
+                "totalDurationInSeconds", "30", "totalLengthInBytes", "2930491082", "scanDate", scanDate.toString());
         MediaLibraryStatistics statistics = PlayerUtils.stringMapToObject(MediaLibraryStatistics.class,
                 stringStringMap);
         assertEquals(Integer.valueOf(5), statistics.getAlbumCount());
@@ -70,13 +74,14 @@ class PlayerUtilsTest {
         assertEquals(Integer.valueOf(910_823), statistics.getArtistCount());
         assertEquals(Long.valueOf(30L), statistics.getTotalDurationInSeconds());
         assertEquals(Long.valueOf(2_930_491_082L), statistics.getTotalLengthInBytes());
-        assertEquals(new Date(1_568_350_960_725L), statistics.getScanDate());
+        assertEquals(scanDate, statistics.getScanDate());
     }
 
     @Test
     void testStringMapToObjectWithExtraneousData() {
+        Instant scanDate = now();
         Map<String, String> stringStringMap = LegacyMap.of("albumCount", "5", "songCount", "4", "artistCount", "910823",
-                "totalDurationInSeconds", "30", "totalLengthInBytes", "2930491082", "scanDate", "1568350960725",
+                "totalDurationInSeconds", "30", "totalLengthInBytes", "2930491082", "scanDate", scanDate.toString(),
                 "extraneousData", "nothingHereToLookAt");
         MediaLibraryStatistics statistics = PlayerUtils.stringMapToObject(MediaLibraryStatistics.class,
                 stringStringMap);
@@ -85,7 +90,7 @@ class PlayerUtilsTest {
         assertEquals(Integer.valueOf(910_823), statistics.getArtistCount());
         assertEquals(Long.valueOf(30L), statistics.getTotalDurationInSeconds());
         assertEquals(Long.valueOf(2_930_491_082L), statistics.getTotalLengthInBytes());
-        assertEquals(new Date(1_568_350_960_725L), statistics.getScanDate());
+        assertEquals(scanDate, statistics.getScanDate());
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -179,11 +179,16 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.13.4</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
@@ -689,13 +694,13 @@
                                 <ignoredUsedUndeclaredDependency>org.eclipse.jetty:*</ignoredUsedUndeclaredDependency>
                                 <ignoredUsedUndeclaredDependency>org.apache.tomcat:*</ignoredUsedUndeclaredDependency>
                                 <ignoredUsedUndeclaredDependency>org.apache.tomcat.embed:*</ignoredUsedUndeclaredDependency>
-                                <ignoredUnusedDeclaredDependency>commons-lang:commons-lang:jar:*</ignoredUnusedDeclaredDependency>
-                                <ignoredUnusedDeclaredDependency>com.drewnoakes:metadata-extractor:jar:*</ignoredUnusedDeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>commons-lang:commons-lang:jar:*</ignoredUsedUndeclaredDependency>
+                                <ignoredUsedUndeclaredDependency>com.drewnoakes:metadata-extractor:jar:*</ignoredUsedUndeclaredDependency>
                             </ignoredUsedUndeclaredDependencies>
                             <ignoredUnusedDeclaredDependencies>
                                 <ignoredUnusedDeclaredDependency>org.springframework.security:*</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.springframework.boot:*</ignoredUnusedDeclaredDependency>
-                                <ignoredUsedUndeclaredDependency>org.eclipse.jetty:*</ignoredUsedUndeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>org.eclipse.jetty:*</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>javax.annotation:javax.annotation-api:jar:*</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>jakarta.xml.bind:jakarta.xml.bind-api:jar:*</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>jakarta.servlet.jsp:jakarta.servlet.jsp-api:jar:*</ignoredUnusedDeclaredDependency>
@@ -708,6 +713,7 @@
                                 <ignoredUnusedDeclaredDependency>org.postgresql:postgresql:jar:*</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>mysql:mysql-connector-java:jar:*</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.mariadb.jdbc:mariadb-java-client:jar:*</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:*</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                             <ignoredNonTestScopedDependencies>
                                 <!-- Not a test-only scope -->


### PR DESCRIPTION
Migration from Java's ancient date classes to modern APIs.

Modifications are those pointed out by Sonatype Lift, i.e. all dates. There are three viewpoints as follows.

 - [JavaTimeDefaultTimeZone](https://errorprone.info/bugpattern/JavaTimeDefaultTimeZone)
 - [UndefinedEquals](https://errorprone.info/bugpattern/UndefinedEquals)
 - [JavaUtilDate](https://errorprone.info/bugpattern/JavaUtilDate)

This pull request solves all of these and leaves Sonatype Lift with only one warning left.

 [before](https://lift.sonatype.com/results/github.com/tesshucom/jpsonic/01GC4SWXXNGFAW4506NQF2JSWX) / [after](https://lift.sonatype.com/results/github.com/tesshucom/jpsonic/01GCJH7C1ECCNEN10JBBF7PZZ4)

As for DIGEST_MD5, it will be done in the last version of v111.x.x as it may involve database changes(This is a lower priority issue if the communication is encrypted.).

___

This pull request is primarily focused on rewriting the Java source date type. (And a fix for new and different Sonatype warnings popping by eliminating bugs) Difficulty is low, but the scope is wide, so peer review is necessary.

 - If there are tests to add, they will be added
 - Check the output format on the web page (slashes used in dates corrected to hyphens; slash separators had used to truncate display size, so additional CSS changes may be required).
 - Other small refactorings etc.
 - Beware of Podcast date input/output. Previously there were almost no specifications