### PR TITLE
LGTM/CodeQL : Overly permissive regular expression range

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/JapaneseReadingUtils.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/JapaneseReadingUtils.java
@@ -52,7 +52,7 @@ import org.springframework.util.ObjectUtils;
 @DependsOn({ "settingsService" })
 public class JapaneseReadingUtils {
 
-    public static final Pattern ALPHA = Pattern.compile("^[a-zA-Zａ-ｚＡ-Ｚ]+$");
+    public static final Pattern ALPHA = Pattern.compile("^[a-zA-Zａ-ｚＡ-Ｚ]+$"); // lgtm [java/overly-large-range]
     private static final Pattern KATAKANA = Pattern.compile("^[\\u30A0-\\u30FF]+$");
     private static final String ASTER = "*";
     private static final String HYPHEN = "-";
@@ -275,7 +275,7 @@ public class JapaneseReadingUtils {
     }
 
     /* AtoZ only true. */
-    private static boolean isStartWithAlpha(@Nullable String s) {
+    static boolean isStartWithAlpha(@Nullable String s) {
         if (isEmpty(s)) {
             return false;
         }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JapaneseReadingUtilsTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JapaneseReadingUtilsTest.java
@@ -66,6 +66,29 @@ class JapaneseReadingUtilsTest {
     }
 
     @Test
+    @Order(0)
+    void testIsStartWithAlpha() {
+        assertTrue(JapaneseReadingUtils.isStartWithAlpha("a"));
+        assertTrue(JapaneseReadingUtils.isStartWithAlpha("z"));
+        assertTrue(JapaneseReadingUtils.isStartWithAlpha("A"));
+        assertTrue(JapaneseReadingUtils.isStartWithAlpha("Z"));
+        assertTrue(JapaneseReadingUtils.isStartWithAlpha("ａ"));
+        assertTrue(JapaneseReadingUtils.isStartWithAlpha("ｚ"));
+        assertTrue(JapaneseReadingUtils.isStartWithAlpha("Ａ"));
+        assertTrue(JapaneseReadingUtils.isStartWithAlpha("Ｚ"));
+
+        assertFalse(JapaneseReadingUtils.isStartWithAlpha("\\"));
+        assertFalse(JapaneseReadingUtils.isStartWithAlpha("^"));
+        assertFalse(JapaneseReadingUtils.isStartWithAlpha("_"));
+        assertFalse(JapaneseReadingUtils.isStartWithAlpha("`"));
+        assertFalse(JapaneseReadingUtils.isStartWithAlpha("``"));
+        assertFalse(JapaneseReadingUtils.isStartWithAlpha("."));
+        assertFalse(JapaneseReadingUtils.isStartWithAlpha(","));
+        assertFalse(JapaneseReadingUtils.isStartWithAlpha("-"));
+        assertFalse(JapaneseReadingUtils.isStartWithAlpha("_"));
+    }
+
+    @Test
     @Order(1)
     void testIsPunctuation() {
         assertFalse(JapaneseReadingUtils.isPunctuation('a'));


### PR DESCRIPTION
Suppression of false positives.

 - False positive for https://lgtm.com/rules/1515921952940/
 - Because the input is one character

As usual, the alert pop comes LGTM first. Luckily, CodeQL on Github also generated a similar warning a few days later.

___

LGTM will be going out of service.

> LGTM.com will be shut down in December 2022 — we recommend that you use GitHub code scanning instead. Read more in [our blog post on the GitHub blog](https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/).

Therefore, the LGTM badge should be removed and CodeQL required for workflows. It seems to be running for a while, so activate both and observe the difference in behavior.

