### PR TITLE
Accept non zero-fill numeric values in Podcast

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PodcastService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PodcastService.java
@@ -99,7 +99,7 @@ public class PodcastService {
     // Wed, 6 Jul 2014 13:00:00 PDT
     // Wed, 6 Jul 2014 13:00:00 -0700
     private static final DateTimeFormatter RSS_DATE_FORMAT = DateTimeFormatter
-            .ofPattern("EEE, dd MMM yyyy HH:mm:ss [Z][zzz]", Locale.ROOT);
+            .ofPattern("EEE, d MMM yyyy H:m:s [Z][zzz]", Locale.ROOT);
 
     private static final Namespace[] ITUNES_NAMESPACES = {
             Namespace.getNamespace("http://www.itunes.com/DTDs/Podcast-1.0.dtd"),
@@ -517,7 +517,7 @@ public class PodcastService {
             return ZonedDateTime.parse(s, RSS_DATE_FORMAT).toInstant();
         } catch (DateTimeParseException e) {
             if (LOG.isWarnEnabled()) {
-                LOG.warn("Podcast dates must comply with RFC 2822.", e);
+                LOG.warn("Podcast dates must comply with RFC 2822. : {}", e.getMessage());
             }
         }
         return null;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PodcastServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PodcastServiceTest.java
@@ -61,5 +61,8 @@ class PodcastServiceTest {
         assertEquals("2022-09-09 08:47:01", fmt.format(toJST("Fri, 09 Sep 2022 08:47:01 ROK")));
         assertEquals("2022-09-09 22:48:02", fmt.format(toJST("Fri, 09 Sep 2022 08:48:02 CDT")));
         assertEquals("2022-09-09 21:49:03", fmt.format(toJST("Fri, 09 Sep 2022 08:49:03 EST")));
+
+        // Accept non zero-fill-numeric values
+        assertEquals("2022-09-09 08:07:05", fmt.format(toJST("Fri, 9 Sep 2022 8:7:5 JST")));
     }
 }


### PR DESCRIPTION
Minor change in date formatter. Podcast specs are shown below.

> [Podcast RSS feed requirements](https://podcasters.apple.com/support/823-podcast-requirements)
> ![image](https://user-images.githubusercontent.com/27724847/190661718-3e9456c0-3247-4311-8d06-11911476856d.png)

Therefore, Days, Hours, Minutes, Seconds are modified to parse even if zero is not added.