### PR TITLE
Remove LGTM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,9 @@ jobs:
           paths_ignore: '["**/README.md", "**/CHANGELOG.md"]'
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
   ##########################################################################
-  ## Although use for evaluation purposes, most checks are included in LGTM.
-  ## Run only on master to save time.
   analyze:
-    if: github.ref == 'refs/heads/master'
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' && github.event_name == 'pull_request' }}
     name: Analyze with CodeQL
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -3,10 +3,7 @@
 # jpsonic/jpsonic
 -->
 
-[![CI](https://github.com/tesshucom/jpsonic/workflows/CI/badge.svg)](https://github.com/tesshucom/jpsonic/actions?query=workflow%3ACI)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/tesshucom/jpsonic.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/tesshucom/jpsonic/alerts/)
-[![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/tesshucom/jpsonic.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/tesshucom/jpsonic/context:javascript) 
-[![Language grade: Java](https://img.shields.io/lgtm/grade/java/g/tesshucom/jpsonic.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/tesshucom/jpsonic/context:java)
+[![CI with CodeQL](https://github.com/tesshucom/jpsonic/workflows/CI/badge.svg)](https://github.com/tesshucom/jpsonic/actions?query=workflow%3ACI)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/7c127f864af74cf8954c691e87bea3e5)](https://www.codacy.com/gh/tesshucom/jpsonic/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=tesshucom/jpsonic&amp;utm_campaign=Badge_Grade)
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/7c127f864af74cf8954c691e87bea3e5)](https://www.codacy.com/gh/tesshucom/jpsonic/dashboard?utm_source=github.com&utm_medium=referral&utm_content=tesshucom/jpsonic&utm_campaign=Badge_Coverage)
 


### PR DESCRIPTION
LGTM functionality will be fully integrated into Github/CodeQL and LGTM will be closed.

[The next step for LGTM.com: GitHub code scanning!](https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/)

Therefore, CodeQL, which has been used as a sub-check until now, is incorporated into the main flow.

 - CodeQL only runs on pull request(Not executable on push event as it requires write permission).
 - The LGTM badge has been removed and will not be replaced by a CodeQL badge. This is because the workflow needs to be split in order to output CodeQL badges. Workflow is not split.



#### Before

![image](https://user-images.githubusercontent.com/27724847/191803447-7e18072d-6d7d-48c6-8c14-db49c88af4f6.png)

#### After

![image](https://user-images.githubusercontent.com/27724847/191893249-a3c4d589-6f81-4267-a827-26337f653c84.png)
