### PR TITLE
Improve validation during pass registration

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/MusicFolderSettingsCommand.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/MusicFolderSettingsCommand.java
@@ -21,8 +21,6 @@
 
 package com.tesshu.jpsonic.command;
 
-import static com.tesshu.jpsonic.util.PlayerUtils.now;
-
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -30,8 +28,6 @@ import java.util.List;
 import com.tesshu.jpsonic.controller.MusicFolderSettingsController;
 import com.tesshu.jpsonic.domain.FileModifiedCheckScheme;
 import com.tesshu.jpsonic.domain.MusicFolder;
-import com.tesshu.jpsonic.util.PathValidator;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Command used in {@link MusicFolderSettingsController}.
@@ -218,22 +214,6 @@ public class MusicFolderSettingsCommand extends SettingsPageCommons {
 
         public void setDelete(boolean delete) {
             this.delete = delete;
-        }
-
-        public MusicFolder toMusicFolder() {
-            String path = StringUtils.trimToNull(this.path);
-            if (path == null || !PathValidator.isNoTraversal(path)) {
-                return null;
-            }
-            String name = StringUtils.trimToNull(this.name);
-            if (name == null) {
-                Path fileName = Path.of(path).getFileName();
-                if (fileName == null) {
-                    return null;
-                }
-                name = fileName.toString();
-            }
-            return new MusicFolder(id, path, name, enabled, now());
         }
 
         public boolean isExisting() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/MusicFolderSettingsCommand.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/MusicFolderSettingsCommand.java
@@ -30,7 +30,7 @@ import java.util.List;
 import com.tesshu.jpsonic.controller.MusicFolderSettingsController;
 import com.tesshu.jpsonic.domain.FileModifiedCheckScheme;
 import com.tesshu.jpsonic.domain.MusicFolder;
-import com.tesshu.jpsonic.service.SecurityService;
+import com.tesshu.jpsonic.util.PathValidator;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -222,7 +222,7 @@ public class MusicFolderSettingsCommand extends SettingsPageCommons {
 
         public MusicFolder toMusicFolder() {
             String path = StringUtils.trimToNull(this.path);
-            if (path == null || !SecurityService.isNoTraversal(path)) {
+            if (path == null || !PathValidator.isNoTraversal(path)) {
                 return null;
             }
             String name = StringUtils.trimToNull(this.name);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/PodcastSettingsCommand.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/PodcastSettingsCommand.java
@@ -22,7 +22,6 @@
 package com.tesshu.jpsonic.command;
 
 import com.tesshu.jpsonic.controller.PodcastSettingsController;
-import com.tesshu.jpsonic.util.PathValidator;
 
 /**
  * Command used in {@link PodcastSettingsController}.
@@ -49,9 +48,7 @@ public class PodcastSettingsCommand extends SettingsPageCommons {
     }
 
     public void setFolder(String folder) {
-        if (folder == null || PathValidator.isNoTraversal(folder)) {
-            this.folder = folder;
-        }
+        this.folder = folder;
     }
 
     public String getEpisodeRetentionCount() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/PodcastSettingsCommand.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/PodcastSettingsCommand.java
@@ -22,7 +22,7 @@
 package com.tesshu.jpsonic.command;
 
 import com.tesshu.jpsonic.controller.PodcastSettingsController;
-import com.tesshu.jpsonic.service.SecurityService;
+import com.tesshu.jpsonic.util.PathValidator;
 
 /**
  * Command used in {@link PodcastSettingsController}.
@@ -49,7 +49,7 @@ public class PodcastSettingsCommand extends SettingsPageCommons {
     }
 
     public void setFolder(String folder) {
-        if (folder == null || SecurityService.isNoTraversal(folder)) {
+        if (folder == null || PathValidator.isNoTraversal(folder)) {
             this.folder = folder;
         }
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/GeneralSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/GeneralSettingsController.java
@@ -252,9 +252,8 @@ public class GeneralSettingsController {
         settingsService.setMusicFileTypes(command.getMusicFileTypes());
         settingsService.setVideoFileTypes(command.getVideoFileTypes());
         settingsService.setCoverArtFileTypes(command.getCoverArtFileTypes());
-        if (command.getPlaylistFolder() == null || PathValidator.isNoTraversal(command.getPlaylistFolder())) {
-            settingsService.setPlaylistFolder(command.getPlaylistFolder());
-        }
+        PathValidator.validateFolderPath(command.getPlaylistFolder())
+                .ifPresent(folderPath -> settingsService.setPlaylistFolder(folderPath));
         settingsService.setShortcuts(command.getShortcuts());
 
         // Welcom message

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/GeneralSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/GeneralSettingsController.java
@@ -36,6 +36,7 @@ import com.tesshu.jpsonic.service.PlayerService;
 import com.tesshu.jpsonic.service.SecurityService;
 import com.tesshu.jpsonic.service.SettingsService;
 import com.tesshu.jpsonic.service.ShareService;
+import com.tesshu.jpsonic.util.PathValidator;
 import com.tesshu.jpsonic.util.PlayerUtils;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -251,7 +252,7 @@ public class GeneralSettingsController {
         settingsService.setMusicFileTypes(command.getMusicFileTypes());
         settingsService.setVideoFileTypes(command.getVideoFileTypes());
         settingsService.setCoverArtFileTypes(command.getCoverArtFileTypes());
-        if (command.getPlaylistFolder() == null || SecurityService.isNoTraversal(command.getPlaylistFolder())) {
+        if (command.getPlaylistFolder() == null || PathValidator.isNoTraversal(command.getPlaylistFolder())) {
             settingsService.setPlaylistFolder(command.getPlaylistFolder());
         }
         settingsService.setShortcuts(command.getShortcuts());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MusicFolderSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MusicFolderSettingsController.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 
+import com.tesshu.jpsonic.SuppressFBWarnings;
 import com.tesshu.jpsonic.command.MusicFolderSettingsCommand;
 import com.tesshu.jpsonic.domain.FileModifiedCheckScheme;
 import com.tesshu.jpsonic.domain.MusicFolder;
@@ -180,19 +181,16 @@ public class MusicFolderSettingsController {
         return new ModelAndView(new RedirectView(ViewName.MUSIC_FOLDER_SETTINGS.value()));
     }
 
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "Validated.")
     public Optional<MusicFolder> toMusicFolder(MusicFolderSettingsCommand.MusicFolderInfo info) {
-        String path = StringUtils.trimToNull(info.getPath());
-        if (PathValidator.validateFolderPath(path).isEmpty()) {
+        Optional<String> validated = PathValidator.validateFolderPath(StringUtils.trimToNull(info.getPath()));
+        if (validated.isEmpty()) {
             return Optional.empty();
         }
         String name = StringUtils.trimToNull(info.getName());
         if (name == null) {
-            Path fileName = Path.of(path).getFileName();
-            if (fileName == null) {
-                return Optional.empty();
-            }
-            name = fileName.toString();
+            name = Path.of(validated.get()).getFileName().toString();
         }
-        return Optional.of(new MusicFolder(info.getId(), path, name, info.isEnabled(), now()));
+        return Optional.of(new MusicFolder(info.getId(), validated.get(), name, info.isEnabled(), now()));
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PodcastSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PodcastSettingsController.java
@@ -24,6 +24,7 @@ package com.tesshu.jpsonic.controller;
 import com.tesshu.jpsonic.command.PodcastSettingsCommand;
 import com.tesshu.jpsonic.service.MediaScannerService;
 import com.tesshu.jpsonic.service.SettingsService;
+import com.tesshu.jpsonic.util.PathValidator;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -77,7 +78,8 @@ public class PodcastSettingsController {
             settingsService.setPodcastUpdateInterval(Integer.parseInt(command.getInterval()));
             settingsService.setPodcastEpisodeRetentionCount(Integer.parseInt(command.getEpisodeRetentionCount()));
             settingsService.setPodcastEpisodeDownloadCount(Integer.parseInt(command.getEpisodeDownloadCount()));
-            settingsService.setPodcastFolder(command.getFolder());
+            PathValidator.validateFolderPath(command.getFolder())
+                    .ifPresent(folderPath -> settingsService.setPodcastFolder(folderPath));
             settingsService.save();
             redirectAttributes.addFlashAttribute(Attributes.Redirect.TOAST_FLAG.value(), true);
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MediaFileService.java
@@ -56,6 +56,7 @@ import com.tesshu.jpsonic.service.metadata.MetaData;
 import com.tesshu.jpsonic.service.metadata.MetaDataParser;
 import com.tesshu.jpsonic.service.metadata.MetaDataParserFactory;
 import com.tesshu.jpsonic.service.metadata.ParserUtils;
+import com.tesshu.jpsonic.util.PathValidator;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -135,7 +136,7 @@ public class MediaFileService {
     }
 
     public @Nullable MediaFile getMediaFile(String path) {
-        if (!SecurityService.isNoTraversal(path)) {
+        if (!PathValidator.isNoTraversal(path)) {
             throw new SecurityException("Access denied to file : " + path);
         }
         return getMediaFile(Path.of(path));

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
@@ -29,7 +29,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -66,7 +65,6 @@ import org.springframework.util.StringUtils;
 public class SecurityService implements UserDetailsService {
 
     private static final Logger LOG = LoggerFactory.getLogger(SecurityService.class);
-    private static final Pattern NO_TRAVERSAL = Pattern.compile("^(?!.*(\\.\\./|\\.\\.\\\\)).*$");
 
     private final UserDao userDao;
     private final SettingsService settingsService;
@@ -382,10 +380,6 @@ public class SecurityService implements UserDetailsService {
     public boolean isReadAllowed(@NonNull Path path) {
         // Allowed to read from both music folder and podcast folder.
         return isInMusicFolder(path.toString()) || isInPodcastFolder(path);
-    }
-
-    public static boolean isNoTraversal(String path) {
-        return NO_TRAVERSAL.matcher(path).matches();
     }
 
     /**

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SettingsConstants.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SettingsConstants.java
@@ -152,8 +152,8 @@ final class SettingsConstants {
                     "flv avi mpg mpeg mp4 m4v mkv mov wmv ogv divx m2ts webm");
             static final Pair<String> COVER_ART_FILE_TYPES = Pair.of("CoverArtFileTypes2",
                     "cover.jpg cover.png cover.gif folder.jpg jpg jpeg gif png");
-            static final Pair<String> PLAYLIST_FOLDER = Pair.of("PlaylistFolder", System.getProperty(
-                    "jpsonic.defaultPlaylistFolder", PlayerUtils.isWindows() ? "c:\\playlists" : "/var/playlists"));
+            static final Pair<String> PLAYLIST_FOLDER = Pair.of("PlaylistFolder",
+                    PlayerUtils.getDefaultPlaylistFolder());
             static final Pair<String> SHORTCUTS = Pair.of("Shortcuts", "\"New Incoming\" Podcast");
 
             private Extension() {
@@ -249,8 +249,7 @@ final class SettingsConstants {
     }
 
     static class Podcast {
-        static final Pair<String> FOLDER = Pair.of("PodcastFolder", System.getProperty("jpsonic.defaultPodcastFolder",
-                PlayerUtils.isWindows() ? "c:\\music\\Podcast" : "/var/music/Podcast"));
+        static final Pair<String> FOLDER = Pair.of("PodcastFolder", PlayerUtils.getDefaultPodcastFolder());
         static final Pair<Integer> UPDATE_INTERVAL = Pair.of("PodcastUpdateInterval", 24);
         static final Pair<Integer> EPISODE_RETENTION_COUNT = Pair.of("PodcastEpisodeRetentionCount", 10);
         static final Pair<Integer> EPISODE_DOWNLOAD_COUNT = Pair.of("PodcastEpisodeDownloadCount", 1);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/PathValidator.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/PathValidator.java
@@ -19,6 +19,8 @@
 
 package com.tesshu.jpsonic.util;
 
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -37,9 +39,17 @@ public final class PathValidator {
      * Returns a path string pointing to the music, playlist, and podcast folders, if acceptable. otherwise empty.
      */
     public static Optional<String> validateFolderPath(String folderPath) {
-        if (folderPath == null || PathValidator.isNoTraversal(folderPath)) {
-            return Optional.ofNullable(folderPath);
+        if (folderPath == null || !isNoTraversal(folderPath)) {
+            return Optional.empty();
         }
-        return Optional.empty();
+        try {
+            Path path = Path.of(folderPath);
+            if (path.getFileName() == null) {
+                return Optional.empty();
+            }
+            return Optional.of(path.toString());
+        } catch (InvalidPathException e) {
+            return Optional.empty();
+        }
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/PathValidator.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/PathValidator.java
@@ -19,6 +19,7 @@
 
 package com.tesshu.jpsonic.util;
 
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 public final class PathValidator {
@@ -30,5 +31,15 @@ public final class PathValidator {
 
     public static boolean isNoTraversal(String path) {
         return NO_TRAVERSAL.matcher(path).matches();
+    }
+
+    /**
+     * Returns a path string pointing to the music, playlist, and podcast folders, if acceptable. otherwise empty.
+     */
+    public static Optional<String> validateFolderPath(String folderPath) {
+        if (folderPath == null || PathValidator.isNoTraversal(folderPath)) {
+            return Optional.ofNullable(folderPath);
+        }
+        return Optional.empty();
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/PathValidator.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/PathValidator.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2022 tesshucom
+ */
+
+package com.tesshu.jpsonic.util;
+
+import java.util.regex.Pattern;
+
+public final class PathValidator {
+
+    private static final Pattern NO_TRAVERSAL = Pattern.compile("^(?!.*(\\.\\./|\\.\\.\\\\)).*$");
+
+    private PathValidator() {
+    }
+
+    public static boolean isNoTraversal(String path) {
+        return NO_TRAVERSAL.matcher(path).matches();
+    }
+}

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/PlayerUtils.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/PlayerUtils.java
@@ -78,19 +78,24 @@ public final class PlayerUtils {
         return Instant.now().truncatedTo(ChronoUnit.MILLIS);
     }
 
+    private static String getDefaultFolder(String key, String winDefault, String linuxDefault) {
+        String arg = System.getProperty(key);
+        if (PathValidator.validateFolderPath(arg).isEmpty()) {
+            return isWindows() ? winDefault : linuxDefault;
+        }
+        return arg;
+    }
+
     public static String getDefaultMusicFolder() {
-        String def = isWindows() ? "c:\\music" : "/var/music";
-        return System.getProperty("jpsonic.defaultMusicFolder", def);
+        return getDefaultFolder("jpsonic.defaultMusicFolder", "c:\\music", "/var/music");
     }
 
     public static String getDefaultPodcastFolder() {
-        String def = isWindows() ? "c:\\music\\Podcast" : "/var/music/Podcast";
-        return System.getProperty("jpsonic.defaultPodcastFolder", def);
+        return getDefaultFolder("jpsonic.defaultPodcastFolder", "c:\\music\\Podcast", "/var/music/Podcast");
     }
 
     public static String getDefaultPlaylistFolder() {
-        String def = isWindows() ? "c:\\playlists" : "/var/playlists";
-        return System.getProperty("jpsonic.defaultPlaylistFolder", def);
+        return getDefaultFolder("jpsonic.defaultPlaylistFolder", "c:\\playlists", "/var/playlists");
     }
 
     public static boolean isWindows() {

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MusicFolderSettingsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MusicFolderSettingsControllerTest.java
@@ -49,6 +49,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -359,6 +361,9 @@ class MusicFolderSettingsControllerTest {
                         @interface Root {
                         }
 
+                        @interface Invalid {
+                        }
+
                         @interface Traversal {
                         }
 
@@ -448,6 +453,19 @@ class MusicFolderSettingsControllerTest {
         void c05() {
             MusicFolderInfo info = new MusicFolderInfo();
             String path = "/";
+            info.setPath(path);
+            assertTrue(controller.toMusicFolder(info).isEmpty());
+        }
+
+        @Test
+        @ToMusicFolderDecisions.Conditions.MusicFolderInfo.Path.NonNull.Invalid
+        @ToMusicFolderDecisions.Conditions.MusicFolderInfo.Name.Null
+        @ToMusicFolderDecisions.Conditions.MusicFolderInfo.Path.DirName.Null
+        @ToMusicFolderDecisions.Results.Empty
+        @EnabledOnOs(OS.WINDOWS)
+        void c06() {
+            MusicFolderInfo info = new MusicFolderInfo();
+            String path = "/:";
             info.setPath(path);
             assertTrue(controller.toMusicFolder(info).isEmpty());
         }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/PathValidatorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/PathValidatorTest.java
@@ -22,6 +22,9 @@ package com.tesshu.jpsonic.util;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.annotation.Documented;
+
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class PathValidatorTest {
@@ -31,5 +34,57 @@ class PathValidatorTest {
         assertTrue(PathValidator.isNoTraversal("/foo/bar"));
         assertFalse(PathValidator.isNoTraversal("/foo/../bar"));
         assertFalse(PathValidator.isNoTraversal("C:\\foo\\..\\bar"));
+    }
+
+    @Documented
+    private @interface ValidatePathDecisions {
+        @interface Conditions {
+
+            @interface Path {
+                @interface Null {
+                }
+
+                @interface NonNull {
+                    @interface Traversal {
+                    }
+
+                    @interface NonTraversal {
+                    }
+                }
+            }
+        }
+
+        @interface Results {
+            @interface Empty {
+            }
+
+            @interface NotEmpty {
+            }
+        }
+    }
+
+    @Nested
+    class ValidatePathTest {
+
+        @Test
+        @ValidatePathDecisions.Conditions.Path.Null
+        @ValidatePathDecisions.Results.Empty
+        void c01() {
+            assertTrue(PathValidator.validateFolderPath(null).isEmpty());
+        }
+
+        @Test
+        @ValidatePathDecisions.Conditions.Path.NonNull.Traversal
+        @ValidatePathDecisions.Results.Empty
+        void c02() {
+            assertTrue(PathValidator.validateFolderPath("/../foo").isEmpty());
+        }
+
+        @Test
+        @ValidatePathDecisions.Conditions.Path.NonNull.NonTraversal
+        @ValidatePathDecisions.Results.NotEmpty
+        void c03() {
+            assertFalse(PathValidator.validateFolderPath("/foo").isEmpty());
+        }
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/PathValidatorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/PathValidatorTest.java
@@ -26,6 +26,8 @@ import java.lang.annotation.Documented;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class PathValidatorTest {
 
@@ -45,6 +47,13 @@ class PathValidatorTest {
                 }
 
                 @interface NonNull {
+
+                    @interface Root {
+                    }
+
+                    @interface Invalid {
+                    }
+
                     @interface Traversal {
                     }
 
@@ -85,6 +94,21 @@ class PathValidatorTest {
         @ValidatePathDecisions.Results.NotEmpty
         void c03() {
             assertFalse(PathValidator.validateFolderPath("/foo").isEmpty());
+        }
+
+        @Test
+        @ValidatePathDecisions.Conditions.Path.NonNull.Root
+        @ValidatePathDecisions.Results.Empty
+        void c04() {
+            assertTrue(PathValidator.validateFolderPath("/").isEmpty());
+        }
+
+        @Test
+        @ValidatePathDecisions.Conditions.Path.NonNull.Invalid
+        @ValidatePathDecisions.Results.Empty
+        @EnabledOnOs(OS.WINDOWS)
+        void c05() {
+            assertTrue(PathValidator.validateFolderPath("/:").isEmpty());
         }
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/PathValidatorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/PathValidatorTest.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2022 tesshucom
+ */
+
+package com.tesshu.jpsonic.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class PathValidatorTest {
+
+    @Test
+    void testIsNoTraversal() {
+        assertTrue(PathValidator.isNoTraversal("/foo/bar"));
+        assertFalse(PathValidator.isNoTraversal("/foo/../bar"));
+        assertFalse(PathValidator.isNoTraversal("C:\\foo\\..\\bar"));
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/PlayerUtilsTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/PlayerUtilsTest.java
@@ -31,10 +31,97 @@ import java.time.Instant;
 import java.util.Map;
 
 import com.tesshu.jpsonic.domain.MediaLibraryStatistics;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
-@SuppressWarnings("PMD.TooManyStaticImports")
+@SuppressWarnings({ "PMD.TooManyStaticImports", "PMD.AvoidDuplicateLiterals" })
 class PlayerUtilsTest {
+
+    @Nested
+    class GetDefaultMusicFolderTest {
+
+        @Test
+        @EnabledOnOs(OS.WINDOWS)
+        void testDefaultOnWin() {
+            assertEquals("c:\\music", PlayerUtils.getDefaultMusicFolder());
+
+            System.setProperty("jpsonic.defaultMusicFolder", "/foo/bar");
+            assertEquals("/foo/bar", PlayerUtils.getDefaultMusicFolder());
+            System.setProperty("jpsonic.defaultMusicFolder", "/foo/../bar");
+            assertEquals("c:\\music", PlayerUtils.getDefaultMusicFolder());
+            System.clearProperty("jpsonic.defaultMusicFolder");
+        }
+
+        @Test
+        @EnabledOnOs(OS.LINUX)
+        void testDefaultOnLinux() {
+            assertEquals("/var/music", PlayerUtils.getDefaultMusicFolder());
+
+            System.setProperty("jpsonic.defaultMusicFolder", "/foo/bar");
+            assertEquals("/foo/bar", PlayerUtils.getDefaultMusicFolder());
+            System.setProperty("jpsonic.defaultMusicFolder", "/foo/../bar");
+            assertEquals("/var/music", PlayerUtils.getDefaultMusicFolder());
+            System.clearProperty("jpsonic.defaultMusicFolder");
+        }
+    }
+
+    @Nested
+    class GetDefaultPodcastFolderTest {
+
+        @Test
+        @EnabledOnOs(OS.WINDOWS)
+        void testDefaultOnWin() {
+            assertEquals("c:\\music\\Podcast", PlayerUtils.getDefaultPodcastFolder());
+
+            System.setProperty("jpsonic.defaultPodcastFolder", "/foo/bar");
+            assertEquals("/foo/bar", PlayerUtils.getDefaultPodcastFolder());
+            System.setProperty("jpsonic.defaultPodcastFolder", "/foo/../bar");
+            assertEquals("c:\\music\\Podcast", PlayerUtils.getDefaultPodcastFolder());
+            System.clearProperty("jpsonic.defaultPodcastFolder");
+        }
+
+        @Test
+        @EnabledOnOs(OS.LINUX)
+        void testDefaultOnLinux() {
+            assertEquals("/var/music/Podcast", PlayerUtils.getDefaultPodcastFolder());
+
+            System.setProperty("jpsonic.defaultPodcastFolder", "/foo/bar");
+            assertEquals("/foo/bar", PlayerUtils.getDefaultPodcastFolder());
+            System.setProperty("jpsonic.defaultPodcastFolder", "/foo/../bar");
+            assertEquals("/var/music/Podcast", PlayerUtils.getDefaultPodcastFolder());
+            System.clearProperty("jpsonic.defaultPodcastFolder");
+        }
+    }
+
+    @Nested
+    class GetDefaultPlaylistFolderTest {
+
+        @Test
+        @EnabledOnOs(OS.WINDOWS)
+        void testDefaultOnWin() {
+            assertEquals("c:\\playlists", PlayerUtils.getDefaultPlaylistFolder());
+
+            System.setProperty("jpsonic.defaultPlaylistFolder", "/foo/bar");
+            assertEquals("/foo/bar", PlayerUtils.getDefaultPlaylistFolder());
+            System.setProperty("jpsonic.defaultPlaylistFolder", "/foo/../bar");
+            assertEquals("c:\\playlists", PlayerUtils.getDefaultPlaylistFolder());
+            System.clearProperty("jpsonic.defaultPlaylistFolder");
+        }
+
+        @Test
+        @EnabledOnOs(OS.LINUX)
+        void testDefaultOnLinux() {
+            assertEquals("/var/playlists", PlayerUtils.getDefaultPlaylistFolder());
+
+            System.setProperty("jpsonic.defaultPlaylistFolder", "/foo/bar");
+            assertEquals("/foo/bar", PlayerUtils.getDefaultPlaylistFolder());
+            System.setProperty("jpsonic.defaultPlaylistFolder", "/foo/../bar");
+            assertEquals("/var/playlists", PlayerUtils.getDefaultPlaylistFolder());
+            System.clearProperty("jpsonic.defaultPlaylistFolder");
+        }
+    }
 
     @Test
     void testObjectToStringMapNull() {


### PR DESCRIPTION
Related #1708. If you enter an invalid directory path, it may become inoperable. 
(It is possible to recover by stopping the system and manually rewriting the directory with the database file)


The direct cause of the bug is the lack of consideration for the InvalidPathException introduced by the NIO rewrite. However, the problem part is not only MusicFolder, PodcastFolder and PlaylistFolder have the same problem.

These three are the direct input of the system path by user input. Also, there are two types of input, web page and environment variable, both of which need to be modified. No validation exists for environment variables in legacy implementations(Some inputs are also used from Liquibase).

This pull request solves them.

___

PodcastFolder and PlaylistFolder, which have not been path verified until now, will now be verified in the same way as MusicFolder.

 - Paths with invalid format are not allowed
 - Root path not allowed
 - Traversal paths not allowed

It's not the validator's responsibility to check if the directory exists there. Also, there is currently no detailed message implementation.


