### PR TITLE
Update Libs

### DIFF
--- a/install/docker/alpine-jdk17/pom.xml
+++ b/install/docker/alpine-jdk17/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.0</version>
+        <version>111.5.1</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/alpine-jdk17/pom.xml
+++ b/install/docker/alpine-jdk17/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.1</version>
+        <version>111.5.2</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/alpine-jdk17/pom.xml
+++ b/install/docker/alpine-jdk17/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.3</version>
+        <version>111.5.4</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/alpine-jdk17/pom.xml
+++ b/install/docker/alpine-jdk17/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.2</version>
+        <version>111.5.3</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/jammy/pom.xml
+++ b/install/docker/jammy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.0</version>
+        <version>111.5.1</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/jammy/pom.xml
+++ b/install/docker/jammy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.1</version>
+        <version>111.5.2</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/jammy/pom.xml
+++ b/install/docker/jammy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.3</version>
+        <version>111.5.4</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/jammy/pom.xml
+++ b/install/docker/jammy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.2</version>
+        <version>111.5.3</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/liberica-jdk11/pom.xml
+++ b/install/docker/liberica-jdk11/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.0</version>
+        <version>111.5.1</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/liberica-jdk11/pom.xml
+++ b/install/docker/liberica-jdk11/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.1</version>
+        <version>111.5.2</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/liberica-jdk11/pom.xml
+++ b/install/docker/liberica-jdk11/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.3</version>
+        <version>111.5.4</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/liberica-jdk11/pom.xml
+++ b/install/docker/liberica-jdk11/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.2</version>
+        <version>111.5.3</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.0</version>
+        <version>111.5.1</version>
     </parent>
 
     <properties>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.3</version>
+        <version>111.5.4</version>
     </parent>
 
     <properties>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.1</version>
+        <version>111.5.2</version>
     </parent>
 
     <properties>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.2</version>
+        <version>111.5.3</version>
     </parent>
 
     <properties>

--- a/jpsonic-upnp-template/pom.xml
+++ b/jpsonic-upnp-template/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.2</version>
+        <version>111.5.3</version>
     </parent>
 
     <dependencies>

--- a/jpsonic-upnp-template/pom.xml
+++ b/jpsonic-upnp-template/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.3</version>
+        <version>111.5.4</version>
     </parent>
 
     <dependencies>

--- a/jpsonic-upnp-template/pom.xml
+++ b/jpsonic-upnp-template/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.1</version>
+        <version>111.5.2</version>
     </parent>
 
     <dependencies>

--- a/jpsonic-upnp-template/pom.xml
+++ b/jpsonic-upnp-template/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.0</version>
+        <version>111.5.1</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>111.5.1</version>
+    <version>111.5.2</version>
     <name>Jpsonic</name>
     <packaging>pom</packaging>
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>111.5.0</version>
+    <version>111.5.1</version>
     <name>Jpsonic</name>
     <packaging>pom</packaging>
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>111.5.3</version>
+    <version>111.5.4</version>
     <name>Jpsonic</name>
     <packaging>pom</packaging>
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>111.5.2</version>
+    <version>111.5.3</version>
     <name>Jpsonic</name>
     <packaging>pom</packaging>
     <organization>

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.2</version>
+        <version>111.5.3</version>
     </parent>
 
     <dependencies>

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.1</version>
+        <version>111.5.2</version>
     </parent>
 
     <dependencies>

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.3</version>
+        <version>111.5.4</version>
     </parent>
 
     <dependencies>

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.0</version>
+        <version>111.5.1</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
Includes suppression of CVE-2022-41853. This can be a problem mainly forthe remote code execution app that accept direct query input from the user (...like Subsonic). Since that function has been removed in Airsonic, it is assumed that it is impossible to reproduce in Jpsonioc.

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=50212#c7

> Comment 16 by ``f...@cluedup.com`` on Mon, Sep 26, 2022, 11:50 PM GMT+9 (16 days ago)
Yes, please publish the CVE. Please note this is not a bug, but a deployment requirement for those servers where the users directly enter SQL

Unfortunately, HSQLDB will not release a patch for this issue (Advisory misinformation).

[v2.7.1 release](https://sourceforge.net/p/hsqldb/discussion/73673/thread/0df9e4f45a/)
