### PR TITLE
Fix scan date format for about pages

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/InternalHelpController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/InternalHelpController.java
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -165,7 +166,7 @@ public class InternalHelpController {
             map.put("statAlbumCount", stats.getAlbumCount());
             map.put("statArtistCount", stats.getArtistCount());
             map.put("statSongCount", stats.getSongCount());
-            map.put("statLastScanDate", stats.getScanDate());
+            map.put("statLastScanDate", stats.getScanDate().atZone(ZoneId.systemDefault()).toLocalDateTime());
             map.put("statTotalDurationSeconds", stats.getTotalDurationInSeconds());
             map.put("statTotalLengthBytes", FileUtil.byteCountToDisplaySize(stats.getTotalLengthInBytes()));
         }

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/internalhelp.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/internalhelp.jsp
@@ -9,7 +9,7 @@
 <body class="mainframe settings">
 
 <c:import url="helpHeader.jsp">
-	<c:param name="cat" value="internalhelp"/>
+    <c:param name="cat" value="internalhelp"/>
     <c:param name="isAdmin" value="${model.admin}"/>
     <c:param name="showStatus" value="${model.showStatus}"/>
 </c:import>
@@ -341,7 +341,12 @@
         <dt><fmt:message key="internalhelp.songcount"/></dt>
         <dd>${model.statSongCount}</dd>
         <dt><fmt:message key="internalhelp.lastscandate"/></dt>
-        <dd>${model.statLastScanDate}</dd>
+        <dd>
+            <c:if test="${not empty model.statLastScanDate}">
+                <fmt:parseDate value="${model.statLastScanDate}" type="both" pattern="yyyy-MM-dd'T'HH:mm:ss" var="parsedDate" />
+                <fmt:formatDate value="${parsedDate}" pattern="yyyy-MM-dd HH:mm:ss" />
+            </c:if>
+        </dd>
         <dt><fmt:message key="internalhelp.totaldurationseconds"/></dt>
         <dd>${model.statTotalDurationSeconds}</dd>
         <dt><fmt:message key="internalhelp.totalsizebytes"/></dt>


### PR DESCRIPTION
About > Internal Details > Statics.

Previously JST time was output as is.

![image](https://user-images.githubusercontent.com/27724847/203469563-09301222-4790-4547-b924-c5a8090ef662.png)

Fixed to output time in system default zone.

![image](https://user-images.githubusercontent.com/27724847/203469611-8f1193f6-f08c-462e-8e28-acfa3cdb92dd.png)
