### PR TITLE
Fix bug that Postgres cannot be used

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/PlayerDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/PlayerDao.java
@@ -114,10 +114,7 @@ public class PlayerDao extends AbstractDao {
      */
     @Transactional
     public void createPlayer(Player player) {
-        Integer existingMax = getJdbcTemplate().queryForObject("select max(id) from player", Integer.class);
-        if (existingMax == null) {
-            existingMax = 0;
-        }
+        Integer existingMax = queryForInt("select max(id) from player", 0);
         int id = existingMax + 1;
         player.setId(id);
         String sql = "insert into player (" + QUERY_COLUMNS + ") values (" + questionMarks(QUERY_COLUMNS) + ")";

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/PodcastDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/PodcastDao.java
@@ -70,11 +70,7 @@ public class PodcastDao extends AbstractDao {
                 + questionMarks(CHANNEL_INSERT_COLUMNS) + ")";
         update(sql, channel.getUrl(), channel.getTitle(), channel.getDescription(), channel.getImageUrl(),
                 channel.getStatus().name(), channel.getErrorMessage());
-        Integer result = getJdbcTemplate().queryForObject("select max(id) from podcast_channel", Integer.class);
-        if (result != null) {
-            return result;
-        }
-        return -1;
+        return queryForInt("select max(id) from podcast_channel", -1);
     }
 
     /**

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/RatingDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/RatingDao.java
@@ -119,8 +119,8 @@ public class RatingDao extends AbstractDao {
      */
     public Integer getRatingForUser(String username, MediaFile mediaFile) {
         try {
-            return getJdbcTemplate().queryForObject("select rating from user_rating where username=? and path=?",
-                    Integer.class, new Object[] { username, mediaFile.getPathString() });
+            return queryForInt("select rating from user_rating where username=? and path=?", null,
+                    new Object[] { username, mediaFile.getPathString() });
         } catch (EmptyResultDataAccessException x) {
             return null;
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/ShareDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/ShareDao.java
@@ -65,7 +65,7 @@ public class ShareDao extends AbstractDao {
         String sql = "insert into share (" + INSERT_COLUMNS + ") values (" + questionMarks(INSERT_COLUMNS) + ")";
         update(sql, share.getName(), share.getDescription(), share.getUsername(), share.getCreated(),
                 share.getExpires(), share.getLastVisited(), share.getVisitCount());
-        Integer id = getJdbcTemplate().queryForObject("select max(id) from share", Integer.class);
+        Integer id = queryForInt("select max(id) from share", null);
         if (id != null) {
             share.setId(id);
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/TranscodingDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/TranscodingDao.java
@@ -99,10 +99,7 @@ public class TranscodingDao extends AbstractDao {
      */
     @Transactional
     public int createTranscoding(Transcoding transcoding) {
-        Integer existingMax = getJdbcTemplate().queryForObject("select max(id) from transcoding2", Integer.class);
-        if (existingMax == null) {
-            existingMax = 0;
-        }
+        Integer existingMax = queryForInt("select max(id) from transcoding2", 0);
         int registered = existingMax + 1;
         transcoding.setId(registered);
         String sql = "insert into transcoding2 (" + QUERY_COLUMNS + ") values (" + questionMarks(QUERY_COLUMNS) + ")";

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/UserDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/UserDao.java
@@ -189,8 +189,8 @@ public class UserDao extends AbstractDao {
         String sql = "update " + getUserTable()
                 + " set password=?, email=?, ldap_authenticated=?, bytes_streamed=?, bytes_downloaded=?, bytes_uploaded=? "
                 + "where username=?";
-        getJdbcTemplate().update(sql, encrypt(user.getPassword()), user.getEmail(), user.isLdapAuthenticated(),
-                user.getBytesStreamed(), user.getBytesDownloaded(), user.getBytesUploaded(), user.getUsername());
+        update(sql, encrypt(user.getPassword()), user.getEmail(), user.isLdapAuthenticated(), user.getBytesStreamed(),
+                user.getBytesDownloaded(), user.getBytesUploaded(), user.getUsername());
         writeRoles(user);
     }
 
@@ -233,23 +233,23 @@ public class UserDao extends AbstractDao {
      */
     @SuppressFBWarnings(value = "SQL_INJECTION_SPRING_JDBC", justification = "False positive. find-sec-bugs#385")
     public void updateUserSettings(UserSettings settings) {
-        getJdbcTemplate().update("delete from user_settings where username=?", settings.getUsername());
+        update("delete from user_settings where username=?", settings.getUsername());
 
         String sql = "insert into user_settings (" + USER_SETTINGS_COLUMNS + ") values ("
                 + questionMarks(USER_SETTINGS_COLUMNS) + ')';
         String locale = settings.getLocale() == null ? null : settings.getLocale().toString();
         UserSettings.Visibility main = settings.getMainVisibility();
         UserSettings.Visibility playlist = settings.getPlaylistVisibility();
-        getJdbcTemplate().update(sql, settings.getUsername(), locale, settings.getThemeId(),
-                settings.isFinalVersionNotificationEnabled(), settings.isBetaVersionNotificationEnabled(),
-                settings.isSongNotificationEnabled(), main.isTrackNumberVisible(), main.isArtistVisible(),
-                main.isAlbumVisible(), main.isGenreVisible(), main.isYearVisible(), main.isBitRateVisible(),
-                main.isDurationVisible(), main.isFormatVisible(), main.isFileSizeVisible(),
-                playlist.isTrackNumberVisible(), playlist.isArtistVisible(), playlist.isAlbumVisible(),
-                playlist.isGenreVisible(), playlist.isYearVisible(), playlist.isBitRateVisible(),
-                playlist.isDurationVisible(), playlist.isFormatVisible(), playlist.isFileSizeVisible(),
-                settings.isLastFmEnabled(), settings.getLastFmUsername(), encrypt(settings.getLastFmPassword()),
-                settings.isListenBrainzEnabled(), settings.getListenBrainzToken(), settings.getTranscodeScheme().name(),
+        update(sql, settings.getUsername(), locale, settings.getThemeId(), settings.isFinalVersionNotificationEnabled(),
+                settings.isBetaVersionNotificationEnabled(), settings.isSongNotificationEnabled(),
+                main.isTrackNumberVisible(), main.isArtistVisible(), main.isAlbumVisible(), main.isGenreVisible(),
+                main.isYearVisible(), main.isBitRateVisible(), main.isDurationVisible(), main.isFormatVisible(),
+                main.isFileSizeVisible(), playlist.isTrackNumberVisible(), playlist.isArtistVisible(),
+                playlist.isAlbumVisible(), playlist.isGenreVisible(), playlist.isYearVisible(),
+                playlist.isBitRateVisible(), playlist.isDurationVisible(), playlist.isFormatVisible(),
+                playlist.isFileSizeVisible(), settings.isLastFmEnabled(), settings.getLastFmUsername(),
+                encrypt(settings.getLastFmPassword()), settings.isListenBrainzEnabled(),
+                settings.getListenBrainzToken(), settings.getTranscodeScheme().name(),
                 settings.isShowNowPlayingEnabled(), settings.getSelectedMusicFolderId(), settings.isPartyModeEnabled(),
                 settings.isNowPlayingAllowed(), settings.getAvatarScheme().name(), settings.getSystemAvatarId(),
                 settings.getChanged(), settings.isShowArtistInfoEnabled(), settings.isAutoHidePlayQueue(),
@@ -339,7 +339,7 @@ public class UserDao extends AbstractDao {
 
     @SuppressWarnings("PMD.NPathComplexity") // It's not particularly difficult, so you can leave it as it is.
     private void writeRoles(User user) {
-        getJdbcTemplate().update("delete from user_role where username=?", user.getUsername());
+        update("delete from user_role where username=?", user.getUsername());
         if (user.isAdminRole()) {
             updateRole(user.getUsername(), ROLE_ID_ADMIN);
         }
@@ -373,7 +373,7 @@ public class UserDao extends AbstractDao {
     }
 
     private void updateRole(String username, Integer role) {
-        getJdbcTemplate().update("insert into user_role (username, role_id) values(?, ?)", username, role);
+        update("insert into user_role (username, role_id) values(?, ?)", username, role);
     }
 
     private static class UserRowMapper implements RowMapper<User> {

--- a/jpsonic-main/src/main/resources/liquibase/db-changelog.xml
+++ b/jpsonic-main/src/main/resources/liquibase/db-changelog.xml
@@ -8,6 +8,8 @@
     <property name="curr_date_expr" value="current_timestamp" />
     <property name="varchar_type" dbms="mariadb,mysql" value="varchar(${mysqlVarcharLimit})" />
     <property name="varchar_type" value="varchar" />
+    <property name="timestamp_type" dbms="postgresql,mysql,mariadb,hsqldb" value="datetime(6)" />
+    <property name="timestamp_type" value="datetime" />
     <include file="legacy/legacy-changelog.xml" relativeToChangelogFile="true"/>
     <include file="6.2/changelog.xml" relativeToChangelogFile="true"/>
     <include file="6.3/changelog.xml" relativeToChangelogFile="true"/>

--- a/jpsonic-main/src/main/resources/liquibase/jp110.2.0/delete_admin-update_role.xml
+++ b/jpsonic-main/src/main/resources/liquibase/jp110.2.0/delete_admin-update_role.xml
@@ -6,7 +6,7 @@
     <!-- Changes to schema25_005 -->
     <changeSet id="delete_admin-update_role" author="tesshucom">
         <preConditions onFail="MARK_RAN">
-            <sqlCheck expectedResult="1">select count(*) from user where username ='admin'</sqlCheck>
+            <sqlCheck expectedResult="1">select count(*) from ${userTableQuote}user${userTableQuote} where username ='admin'</sqlCheck>
         </preConditions>
         <delete tableName="user_role">
             <where>username='admin' and role_id = 3</where>

--- a/jpsonic-main/src/main/resources/liquibase/legacy/schema26.xml
+++ b/jpsonic-main/src/main/resources/liquibase/legacy/schema26.xml
@@ -62,7 +62,7 @@
             <column name="rating" type="int" />
             <column name="comment" type="${varchar_type}" />
             <column name="play_count" type="int" />
-            <column name="last_played" type="datetime" />
+            <column name="last_played" type="${timestamp_type}" />
         </createTable>
         <createIndex tableName="music_file_info" indexName="idx_music_file_info_path">
             <column name="path"/>
@@ -115,7 +115,7 @@
             <column name="auto_control_enabled" type="boolean" >
                 <constraints nullable="false" />
             </column>
-            <column name="last_seen" type="datetime" />
+            <column name="last_seen" type="${timestamp_type}" />
             <column name="cover_art_scheme" type="${varchar_type}" >
                 <constraints nullable="false" />
             </column>

--- a/jpsonic-main/src/main/resources/liquibase/legacy/schema32.xml
+++ b/jpsonic-main/src/main/resources/liquibase/legacy/schema32.xml
@@ -85,7 +85,7 @@
             <column name="path" type="${varchar_type}" />
             <column name="title" type="${varchar_type}" />
             <column name="description" type="${varchar_type}" />
-            <column name="publish_date" type="datetime" />
+            <column name="publish_date" type="${timestamp_type}" />
             <column name="duration" type="${varchar_type}" />
             <column name="bytes_total" type="bigint" />
             <column name="bytes_downloaded" type="bigint" />

--- a/jpsonic-main/src/main/resources/liquibase/legacy/schema35.xml
+++ b/jpsonic-main/src/main/resources/liquibase/legacy/schema35.xml
@@ -74,7 +74,7 @@
         <rollback></rollback>
     </changeSet>
     <changeSet id="schema35_005" author="muff1nman">
-        <validCheckSum>8:d428266eb794ae2f1361a6eec0f67672</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="system_avatar" />
@@ -85,7 +85,7 @@
                 <constraints primaryKey="true" />
             </column>
             <column name="name" type="${varchar_type}" />
-            <column name="created_date" type="datetime" defaultValueComputed="${curr_date_expr}">
+            <column name="created_date" type="${timestamp_type}" defaultValueComputed="${curr_date_expr}">
                 <constraints nullable="false" />
             </column>
             <column name="mime_type" type="${varchar_type}" >
@@ -120,7 +120,7 @@
         <rollback></rollback>
     </changeSet>
     <changeSet id="schema35_006" author="muff1nman">
-        <validCheckSum>8:60a4f99dea63d7813457a1b8f981f763</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="custom_avatar" />
@@ -131,7 +131,7 @@
                 <constraints primaryKey="true" />
             </column>
             <column name="name" type="${varchar_type}"/>
-            <column name="created_date" type="datetime" defaultValueComputed="${curr_date_expr}">
+            <column name="created_date" type="${timestamp_type}" defaultValueComputed="${curr_date_expr}">
                 <constraints nullable="false" />
             </column>
             <column name="mime_type" type="${varchar_type}" >
@@ -166,7 +166,7 @@
         <rollback></rollback>
     </changeSet>
     <changeSet id="schema35_007" author="muff1nman">
-        <validCheckSum>8:653b5e40160877def2fe855b03f8ed42</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="user_settings" columnName="avatar_scheme" />
@@ -203,7 +203,7 @@
         </addColumn>
     </changeSet>
     <changeSet id="schema35_010_Formal" author="muff1nman">
-        <validCheckSum>7:54035115d2d5d88756e872b3462f26cc</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Formal'</sqlCheck>
         </preConditions>
@@ -221,7 +221,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Engineer" author="muff1nman">
-        <validCheckSum>7:1f00633cd526800eeaa0f96d5d2d0ab4</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Engineer'</sqlCheck>
         </preConditions>
@@ -239,7 +239,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Footballer" author="muff1nman">
-        <validCheckSum>7:74067f5a06636f5f4e05fc165652da8e</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Footballer'</sqlCheck>
         </preConditions>
@@ -257,7 +257,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Green-Boy" author="muff1nman">
-        <validCheckSum>7:58eb7d10640898003be6f1742733078e</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Green-Boy'</sqlCheck>
         </preConditions>
@@ -275,7 +275,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Linux-Zealot" author="muff1nman">
-        <validCheckSum>7:6a27c30211f114b76bfb8dc87e39afe0</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Linux-Zealot'</sqlCheck>
         </preConditions>
@@ -293,7 +293,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Mac-Zealot" author="muff1nman">
-        <validCheckSum>7:9cddcb5f9a6a360f60ab72b305345817</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Mac-Zealot'</sqlCheck>
         </preConditions>
@@ -311,7 +311,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Windows-Zealot" author="muff1nman">
-        <validCheckSum>7:f2b9ba75a5bd06e4523e78362044ae7a</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Windows-Zealot'</sqlCheck>
         </preConditions>
@@ -329,7 +329,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Army-Officer" author="muff1nman">
-        <validCheckSum>7:f82442701bee7b16b2f11c83f02aabab</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Army-Officer'</sqlCheck>
         </preConditions>
@@ -347,7 +347,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Beatnik" author="muff1nman">
-        <validCheckSum>7:51ebe6f94e5cafaf3c5fcd568e950434</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Beatnik'</sqlCheck>
         </preConditions>
@@ -365,7 +365,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_All-Caps" author="muff1nman">
-        <validCheckSum>7:d22cdfc57fc0ce6413ec04fd6e2fe5f8</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'All-Caps'</sqlCheck>
         </preConditions>
@@ -383,7 +383,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Clown" author="muff1nman">
-        <validCheckSum>7:7e50b09bc5cfd25bdb353562f3f1f768</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Clown'</sqlCheck>
         </preConditions>
@@ -401,7 +401,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Commie-Pinko" author="muff1nman">
-        <validCheckSum>7:b674559ca9b7dd1c2466e138e7137405</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Commie-Pinko'</sqlCheck>
         </preConditions>
@@ -419,7 +419,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Forum-Flirt" author="muff1nman">
-        <validCheckSum>7:7290bba7007dcc3fe8d90991971b4030</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Forum-Flirt'</sqlCheck>
         </preConditions>
@@ -437,7 +437,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Gamer" author="muff1nman">
-        <validCheckSum>7:4543410f8e5681f20ecef97e780e0573</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Gamer'</sqlCheck>
         </preConditions>
@@ -455,7 +455,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Hopelessly-Addicted" author="muff1nman">
-        <validCheckSum>7:f3c66c12b246da0a90349b6a3da741a3</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Hopelessly-Addicted'</sqlCheck>
         </preConditions>
@@ -473,7 +473,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Jekyll-And-Hyde" author="muff1nman">
-        <validCheckSum>7:81c5f814838707b89721759498743da0</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Jekyll-And-Hyde'</sqlCheck>
         </preConditions>
@@ -491,7 +491,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Joker" author="muff1nman">
-        <validCheckSum>7:1a15275764dc97170319825b94f70fb3</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Joker'</sqlCheck>
         </preConditions>
@@ -509,7 +509,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Lurker" author="muff1nman">
-        <validCheckSum>7:66415321945789d22a16d042b1b3306f</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Lurker'</sqlCheck>
         </preConditions>
@@ -527,7 +527,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Moderator" author="muff1nman">
-        <validCheckSum>7:e60a95cc8d57ff522415b581f13d52e6</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Moderator'</sqlCheck>
         </preConditions>
@@ -545,7 +545,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Newbie" author="muff1nman">
-        <validCheckSum>7:9b38b2025882a11fb02d9f9784f067ed</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Newbie'</sqlCheck>
         </preConditions>
@@ -563,7 +563,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_No-Dissent" author="muff1nman">
-        <validCheckSum>7:1cd5940012c95e26462840dfaacd1ee5</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'No-Dissent'</sqlCheck>
         </preConditions>
@@ -581,7 +581,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Performer" author="muff1nman">
-        <validCheckSum>7:b6f3765aa9733f026a6eced46f17fd76</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Performer'</sqlCheck>
         </preConditions>
@@ -599,7 +599,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Push-My-Button" author="muff1nman">
-        <validCheckSum>7:e959c49fb38e99fe7fc1e00efd3d7b16</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Push-My-Button'</sqlCheck>
         </preConditions>
@@ -617,7 +617,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Ray-Of-Sunshine" author="muff1nman">
-        <validCheckSum>7:ad41d5220459ea33978c0b7c7e05b282</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Ray-Of-Sunshine'</sqlCheck>
         </preConditions>
@@ -635,7 +635,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Red-Hot-Chili-Peppers-1" author="muff1nman">
-        <validCheckSum>7:d7f6b7675de11283a5a61ece4693cdfe</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Red-Hot-Chili-Peppers-1'</sqlCheck>
         </preConditions>
@@ -653,7 +653,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Red-Hot-Chili-Peppers-2" author="muff1nman">
-        <validCheckSum>7:35f2791297bbdca1cd04447aeafd70e9</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Red-Hot-Chili-Peppers-2'</sqlCheck>
         </preConditions>
@@ -671,7 +671,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Red-Hot-Chili-Peppers-3" author="muff1nman">
-        <validCheckSum>7:97b4ee07300628c37c422dc2c4570e5a</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Red-Hot-Chili-Peppers-3'</sqlCheck>
         </preConditions>
@@ -689,7 +689,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Red-Hot-Chili-Peppers-4" author="muff1nman">
-        <validCheckSum>7:a8d662d989026bef363ea0096f2eb3f5</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Red-Hot-Chili-Peppers-4'</sqlCheck>
         </preConditions>
@@ -707,7 +707,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Ringmaster" author="muff1nman">
-        <validCheckSum>7:ee2340f09e351c1ccda3c9dfa71ffcbf</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Ringmaster'</sqlCheck>
         </preConditions>
@@ -725,7 +725,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Rumor-Junkie" author="muff1nman">
-        <validCheckSum>7:46c9cfd1d5d60eef0277d046064e7670</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Rumor-Junkie'</sqlCheck>
         </preConditions>
@@ -743,7 +743,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Sozzled-Surfer" author="muff1nman">
-        <validCheckSum>7:c018f6267a19989ba99c2361ad959fc6</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Sozzled-Surfer'</sqlCheck>
         </preConditions>
@@ -761,7 +761,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Statistician" author="muff1nman">
-        <validCheckSum>7:786c0d65ab283f6cad03fdd0757480f9</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Statistician'</sqlCheck>
         </preConditions>
@@ -779,7 +779,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Tech-Support" author="muff1nman">
-        <validCheckSum>7:5cfbe2a8a4ad2a605880170d27b195ed</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Tech-Support'</sqlCheck>
         </preConditions>
@@ -797,7 +797,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_The-Guru" author="muff1nman">
-        <validCheckSum>7:ab9565e7768e03193d2de5c60be74843</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'The-Guru'</sqlCheck>
         </preConditions>
@@ -815,7 +815,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_The-Referee" author="muff1nman">
-        <validCheckSum>7:705db6a005696ae8d9d7a39d9ef626a8</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'The-Referee'</sqlCheck>
         </preConditions>
@@ -833,7 +833,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Troll" author="muff1nman">
-        <validCheckSum>7:6eb305b202548b993d7edd0746ea71d9</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Troll'</sqlCheck>
         </preConditions>
@@ -851,7 +851,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Uptight" author="muff1nman">
-        <validCheckSum>7:dc955eccac25bbe19b61de970ddea05e</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Uptight'</sqlCheck>
         </preConditions>
@@ -869,7 +869,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Fire-Guitar" author="muff1nman">
-        <validCheckSum>7:2c8eb5047dc5ebe3fbb1c5bc4f614122</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Fire-Guitar'</sqlCheck>
         </preConditions>
@@ -887,7 +887,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Drum" author="muff1nman">
-        <validCheckSum>7:4e77bbb7cca43ba206f0bbfd4af38d7f</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Drum'</sqlCheck>
         </preConditions>
@@ -905,7 +905,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Headphones" author="muff1nman">
-        <validCheckSum>7:b577f199dd646877d51f4766d63dbd72</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Headphones'</sqlCheck>
         </preConditions>
@@ -923,7 +923,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Mic" author="muff1nman">
-        <validCheckSum>7:999caf515ab0b3d5ac99d3c81893bd67</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Mic'</sqlCheck>
         </preConditions>
@@ -941,7 +941,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Turntable" author="muff1nman">
-        <validCheckSum>7:14ea8fa0912b13ab337c940b871d7782</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Turntable'</sqlCheck>
         </preConditions>
@@ -959,7 +959,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Vinyl" author="muff1nman">
-        <validCheckSum>7:391aefb55d1076fd9e05c1ae7377d5cd</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Vinyl'</sqlCheck>
         </preConditions>
@@ -977,7 +977,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Cool" author="muff1nman">
-        <validCheckSum>7:c4fbec5479846de62714bf0fed6224c3</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Cool'</sqlCheck>
         </preConditions>
@@ -995,7 +995,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Laugh" author="muff1nman">
-        <validCheckSum>7:9ddb901cd6baef436261d8719973988d</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Laugh'</sqlCheck>
         </preConditions>
@@ -1013,7 +1013,7 @@
         </rollback>
     </changeSet>
     <changeSet id="schema35_010_Study" author="muff1nman">
-        <validCheckSum>7:d4bc85dc419904b95ff88b95dfc4694a</validCheckSum>
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">select count(*) from system_avatar where name = 'Study'</sqlCheck>
         </preConditions>

--- a/jpsonic-main/src/main/resources/liquibase/legacy/schema37.xml
+++ b/jpsonic-main/src/main/resources/liquibase/legacy/schema37.xml
@@ -43,37 +43,40 @@
         <rollback />
     </changeSet>
     <changeSet id="schema37_004" author="muff1nman">
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="music_folder" columnName="changed" />
             </not>
         </preConditions>
         <addColumn tableName="music_folder">
-            <column name="changed" type="datetime" defaultValueComputed="${curr_date_expr}">
+            <column name="changed" type="${timestamp_type}" defaultValueComputed="${curr_date_expr}">
                 <constraints nullable="false" />
             </column>
         </addColumn>
     </changeSet>
     <changeSet id="schema37_005" author="muff1nman">
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="internet_radio" columnName="changed" />
             </not>
         </preConditions>
         <addColumn tableName="internet_radio">
-            <column name="changed" type="datetime" defaultValueComputed="${curr_date_expr}">
+            <column name="changed" type="${timestamp_type}" defaultValueComputed="${curr_date_expr}">
                 <constraints nullable="false" />
             </column>
         </addColumn>
     </changeSet>
     <changeSet id="schema37_006" author="muff1nman">
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="user_settings" columnName="changed" />
             </not>
         </preConditions>
         <addColumn tableName="user_settings">
-            <column name="changed" type="datetime" defaultValueComputed="${curr_date_expr}">
+            <column name="changed" type="${timestamp_type}" defaultValueComputed="${curr_date_expr}">
                 <constraints nullable="false" />
             </column>
         </addColumn>

--- a/jpsonic-main/src/main/resources/liquibase/legacy/schema45.xml
+++ b/jpsonic-main/src/main/resources/liquibase/legacy/schema45.xml
@@ -48,11 +48,11 @@
             <column name="username" type="${varchar_type}" >
                 <constraints nullable="false" foreignKeyName="s_u_fk" referencedTableName="user" referencedColumnNames="username" deleteCascade="true"/>
             </column>
-            <column name="created" type="datetime" >
+            <column name="created" type="${timestamp_type}" >
                 <constraints nullable="false" />
             </column>
-            <column name="expires" type="datetime" />
-            <column name="last_visited" type="datetime" />
+            <column name="expires" type="${timestamp_type}" />
+            <column name="last_visited" type="${timestamp_type}" />
             <column name="visit_count" type="int" defaultValueNumeric="0" >
                 <constraints nullable="false" />
             </column>

--- a/jpsonic-main/src/main/resources/liquibase/legacy/schema47.xml
+++ b/jpsonic-main/src/main/resources/liquibase/legacy/schema47.xml
@@ -55,18 +55,18 @@
             <column name="play_count" type="int" >
                 <constraints nullable="false" />
             </column>
-            <column name="last_played" type="datetime" />
+            <column name="last_played" type="${timestamp_type}" />
             <column name="comment" type="${varchar_type}" />
-            <column name="created" type="datetime" >
+            <column name="created" type="${timestamp_type}" >
                 <constraints nullable="false" />
             </column>
-            <column name="changed" type="datetime" >
+            <column name="changed" type="${timestamp_type}" >
                 <constraints nullable="false" />
             </column>
-            <column name="last_scanned" type="datetime" >
+            <column name="last_scanned" type="${timestamp_type}" >
                 <constraints nullable="false" />
             </column>
-            <column name="children_last_updated" type="datetime" >
+            <column name="children_last_updated" type="${timestamp_type}" >
                 <constraints nullable="false" />
             </column>
             <column name="present" type="boolean" >
@@ -134,7 +134,7 @@
             <column name="album_count" type="int" defaultValueNumeric="0">
                 <constraints nullable="false" />
             </column>
-            <column name="last_scanned" type="datetime" >
+            <column name="last_scanned" type="${timestamp_type}" >
                 <constraints nullable="false" />
             </column>
             <column name="present" type="boolean" >
@@ -185,12 +185,12 @@
             <column name="play_count" type="int" defaultValueNumeric="0" >
                 <constraints nullable="false" />
             </column>
-            <column name="last_played" type="datetime" />
+            <column name="last_played" type="${timestamp_type}" />
             <column name="comment" type="${varchar_type}" />
-            <column name="created" type="datetime" >
+            <column name="created" type="${timestamp_type}" >
                 <constraints nullable="false" />
             </column>
-            <column name="last_scanned" type="datetime" >
+            <column name="last_scanned" type="${timestamp_type}" >
                 <constraints nullable="false" />
             </column>
             <column name="present" type="boolean" >
@@ -265,7 +265,7 @@
             <column name="username" type="${varchar_type}" >
                 <constraints nullable="false" foreignKeyName="smf_u_fk" referencedTableName="user" referencedColumnNames="username" deleteCascade="true" />
             </column>
-            <column name="created" type="datetime" >
+            <column name="created" type="${timestamp_type}" >
                 <constraints nullable="false" />
             </column>
         </createTable>
@@ -297,7 +297,7 @@
             <column name="username" type="${varchar_type}" >
                 <constraints nullable="false" foreignKeyName="sa_u_fk" referencedTableName="user" referencedColumnNames="username" deleteCascade="true" />
             </column>
-            <column name="created" type="datetime" >
+            <column name="created" type="${timestamp_type}" >
                 <constraints nullable="false" />
             </column>
         </createTable>
@@ -329,7 +329,7 @@
             <column name="username" type="${varchar_type}" >
                 <constraints nullable="false" foreignKeyName="sar_u_fk" referencedTableName="user" referencedColumnNames="username" deleteCascade="true" />
             </column>
-            <column name="created" type="datetime" >
+            <column name="created" type="${timestamp_type}" >
                 <constraints nullable="false" />
             </column>
         </createTable>
@@ -371,10 +371,10 @@
             <column name="duration_seconds" type="int" defaultValueNumeric="0" >
                 <constraints nullable="false" />
             </column>
-            <column name="created" type="datetime" >
+            <column name="created" type="${timestamp_type}" >
                 <constraints nullable="false" />
             </column>
-            <column name="changed" type="datetime" >
+            <column name="changed" type="${timestamp_type}" >
                 <constraints nullable="false" />
             </column>
         </createTable>
@@ -461,10 +461,10 @@
                 <constraints nullable="false" foreignKeyName="b_u_fk" referencedTableName="user" referencedColumnNames="username" deleteCascade="true" />
             </column>
             <column name="comment" type="${varchar_type}" />
-            <column name="created" type="datetime" >
+            <column name="created" type="${timestamp_type}" >
                 <constraints nullable="false" />
             </column>
-            <column name="changed" type="datetime" >
+            <column name="changed" type="${timestamp_type}" >
                 <constraints nullable="false" />
             </column>
         </createTable>

--- a/jpsonic-main/src/main/resources/liquibase/legacy/schema52.xml
+++ b/jpsonic-main/src/main/resources/liquibase/legacy/schema52.xml
@@ -69,7 +69,7 @@
             </column>
             <column name="current" type="int" />
             <column name="position_millis" type="bigint" />
-            <column name="changed" type="datetime" >
+            <column name="changed" type="${timestamp_type}" >
                 <constraints nullable="false" />
             </column>
             <column name="changed_by" type="${varchar_type}" >


### PR DESCRIPTION

Includes 2 bug fixes and 1 specification change.

#### Bugs

 - Add missing userTableQuote
   - Simple bug since v110.2.0.
 - Add param cast for specific data type registration
   - Date type mismatch for Postgres since v110.5.0. If possible, I would like to avoid that conversion, but at present, that method is the safest. This implementation may be removed as the respective JDBC specifications evolve.

#### Spec change

 - Fix timestamp type (does not affect operation)
   - Since the legacy implementation, the precision of date fields created in schemas has not been specified. As a result, the product's default value had been adopted.
   - Unify precision of timestamps output to major database products to (6) in this Fix. This will be unified to 6 decimal places.
     - Because it is supported by most databases. Also, you don't need more precision than this.
     - There is one less thing to consider when using the HSQLSB's script files for database migration purposes.
   - Jpsonic moved to Date API in v111.5.0. See #1680.
     - The API has been modernized, but Jpsonic's the internal accuracy implementation  is still based on Epock milli seconds as before.
     - In other words, all times can be long converted. Even if you change the database and debug it, the number of digits will not change for each database, and the value will not overflow.

___

This fix requires liquibase 4.18.0.

https://github.com/tesshucom/jpsonic/pull/1948 (Already merged.)

Liquibase once had a bug with blobs of Postgres, and had a regression since 4.12. 4.18.0 improved that. See #1935.
