### PR TITLE
Improve scan initiation flow

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImpl.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImpl.java
@@ -26,14 +26,11 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.concurrent.ExecutionException;
 
-import javax.annotation.PostConstruct;
-
 import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.service.MediaScannerService;
 import com.tesshu.jpsonic.service.MusicFolderService;
 import com.tesshu.jpsonic.service.SettingsService;
-import com.tesshu.jpsonic.service.search.IndexManager;
 import com.tesshu.jpsonic.util.concurrent.ConcurrentUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +49,6 @@ public class MediaScannerServiceImpl implements MediaScannerService {
 
     private final SettingsService settingsService;
     private final MusicFolderService musicFolderService;
-    private final IndexManager indexManager;
     private final WritableMediaFileService writableMediaFileService;
     private final ThreadPoolTaskExecutor scanExecutor;
 
@@ -61,25 +57,17 @@ public class MediaScannerServiceImpl implements MediaScannerService {
     private final ExpungeService expungeService;
 
     public MediaScannerServiceImpl(SettingsService settingsService, MusicFolderService musicFolderService,
-            IndexManager indexManager, WritableMediaFileService writableMediaFileService,
-            ThreadPoolTaskExecutor scanExecutor, ScannerStateServiceImpl scannerStateService,
-            ScannerProcedureService procedure, ExpungeService expungeService) {
+            WritableMediaFileService writableMediaFileService, ThreadPoolTaskExecutor scanExecutor,
+            ScannerStateServiceImpl scannerStateService, ScannerProcedureService procedure,
+            ExpungeService expungeService) {
         super();
         this.settingsService = settingsService;
         this.musicFolderService = musicFolderService;
-        this.indexManager = indexManager;
         this.writableMediaFileService = writableMediaFileService;
         this.scanExecutor = scanExecutor;
         this.scannerState = scannerStateService;
         this.procedure = procedure;
         this.expungeService = expungeService;
-    }
-
-    // TODO To be fixed in v111.6.0
-    @PostConstruct
-    public void init() {
-        indexManager.deleteOldIndexFiles();
-        indexManager.initializeIndexDirectory();
     }
 
     private void writeInfo(String msg) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
@@ -40,6 +40,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.annotation.PostConstruct;
+
 import com.tesshu.jpsonic.dao.AlbumDao;
 import com.tesshu.jpsonic.dao.ArtistDao;
 import com.tesshu.jpsonic.dao.MediaFileDao;
@@ -141,6 +143,12 @@ public class IndexManager {
         searchers = new ConcurrentHashMap<>();
         writers = new ConcurrentHashMap<>();
         multiGenreMaster = new ConcurrentHashMap<>();
+    }
+
+    @PostConstruct
+    public void init() {
+        deleteOldIndexFiles();
+        initializeIndexDirectory();
     }
 
     public void index(Album album) {
@@ -387,7 +395,7 @@ public class IndexManager {
      * with lucene) are deleted. If there is no index directory, initialize the directory. If the index directory exists
      * and is not the current version, initialize the directory.
      */
-    public void deleteOldIndexFiles() {
+    void deleteOldIndexFiles() {
         deleteLegacyFiles();
         deleteOldFiles();
     }
@@ -438,7 +446,7 @@ public class IndexManager {
     /**
      * Create a directory corresponding to the current index version.
      */
-    public void initializeIndexDirectory() {
+    void initializeIndexDirectory() {
         // Check if Index is current version
         if (Files.exists(getRootIndexDirectory())) {
             // Index of current version already exists

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
@@ -52,6 +52,7 @@ import com.tesshu.jpsonic.domain.JpsonicComparators;
 import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.service.SettingsService;
+import com.tesshu.jpsonic.service.scanner.ScannerStateServiceImpl;
 import com.tesshu.jpsonic.util.FileUtil;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.FieldInfos;
@@ -115,6 +116,8 @@ public class IndexManager {
     private final SearchServiceUtilities util;
     private final JpsonicComparators comparators;
     private final SettingsService settingsService;
+    private final ScannerStateServiceImpl scannerState;
+
     private final Map<IndexType, SearcherManager> searchers;
     private final Map<IndexType, IndexWriter> writers;
     private final Map<GenreSort, List<Genre>> multiGenreMaster;
@@ -129,7 +132,7 @@ public class IndexManager {
 
     public IndexManager(AnalyzerFactory analyzerFactory, DocumentFactory documentFactory, MediaFileDao mediaFileDao,
             ArtistDao artistDao, AlbumDao albumDao, QueryFactory queryFactory, SearchServiceUtilities util,
-            JpsonicComparators comparators, SettingsService settingsService) {
+            JpsonicComparators comparators, SettingsService settingsService, ScannerStateServiceImpl scannerState) {
         super();
         this.analyzerFactory = analyzerFactory;
         this.documentFactory = documentFactory;
@@ -140,6 +143,7 @@ public class IndexManager {
         this.util = util;
         this.comparators = comparators;
         this.settingsService = settingsService;
+        this.scannerState = scannerState;
         searchers = new ConcurrentHashMap<>();
         writers = new ConcurrentHashMap<>();
         multiGenreMaster = new ConcurrentHashMap<>();
@@ -149,6 +153,7 @@ public class IndexManager {
     public void init() {
         deleteOldIndexFiles();
         initializeIndexDirectory();
+        scannerState.setReady();
     }
 
     public void index(Album album) {

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/AbstractNeedsScan.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/AbstractNeedsScan.java
@@ -41,7 +41,6 @@ import com.tesshu.jpsonic.service.scanner.MediaScannerServiceImpl;
 import com.tesshu.jpsonic.service.scanner.ScannerProcedureService;
 import com.tesshu.jpsonic.service.scanner.ScannerStateServiceImpl;
 import com.tesshu.jpsonic.service.scanner.WritableMediaFileService;
-import com.tesshu.jpsonic.service.search.IndexManager;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,8 +81,6 @@ public abstract class AbstractNeedsScan implements NeedsScan {
     protected SecurityService securityService;
 
     @Autowired
-    private IndexManager indexManager;
-    @Autowired
     private WritableMediaFileService writableMediaFileService;
     @Autowired
     private ScannerStateServiceImpl scannerStateService;
@@ -98,8 +95,8 @@ public abstract class AbstractNeedsScan implements NeedsScan {
 
     @PostConstruct
     public void init() {
-        mediaScannerService = new MediaScannerServiceImpl(settingsService, musicFolderService, indexManager,
-                writableMediaFileService, scanExecutor, scannerStateService, procedure, expungeService);
+        mediaScannerService = new MediaScannerServiceImpl(settingsService, musicFolderService, writableMediaFileService,
+                scanExecutor, scannerStateService, procedure, expungeService);
     }
 
     public interface BeforeScan extends Supplier<Boolean> {

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImplTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImplTest.java
@@ -135,7 +135,7 @@ class MediaScannerServiceImplTest {
                     artistDao, albumDao, mock(StaticsDao.class), utils, scannerStateService, mock(Ehcache.class),
                     mock(MediaFileCache.class));
             mediaScannerService = new MediaScannerServiceImpl(settingsService, mock(MusicFolderService.class),
-                    indexManager, writableMediaFileService, executor, scannerStateService, scannerProcedureService,
+                    writableMediaFileService, executor, scannerStateService, scannerProcedureService,
                     mock(ExpungeService.class));
         }
 
@@ -158,7 +158,7 @@ class MediaScannerServiceImplTest {
             final ThreadPoolTaskExecutor executor = executorConf.scanExecutor();
 
             mediaScannerService = new MediaScannerServiceImpl(settingsService, mock(MusicFolderService.class),
-                    indexManager, writableMediaFileService, executor, scannerStateService, scannerProcedureService,
+                    writableMediaFileService, executor, scannerStateService, scannerProcedureService,
                     mock(ExpungeService.class));
             mediaScannerService.scanLibrary();
             executor.shutdown();
@@ -685,8 +685,6 @@ class MediaScannerServiceImplTest {
         @Autowired
         private MusicFolderService musicFolderService;
         @Autowired
-        private IndexManager indexManager;
-        @Autowired
         private MediaFileService mediaFileService;
         @Autowired
         private WritableMediaFileService writableMediaFileService;
@@ -708,7 +706,7 @@ class MediaScannerServiceImplTest {
         @BeforeEach
         public void setup() {
             ThreadPoolTaskExecutor scanExecutor = ServiceMockUtils.mockNoAsyncTaskExecutor();
-            mediaScannerService = new MediaScannerServiceImpl(settingsService, musicFolderService, indexManager,
+            mediaScannerService = new MediaScannerServiceImpl(settingsService, musicFolderService,
                     writableMediaFileService, scanExecutor, scannerStateService, procedure, expungeService);
         }
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/ScannerStateServiceImplTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/ScannerStateServiceImplTest.java
@@ -51,6 +51,9 @@ class ScannerStateServiceImplTest {
 
     @Test
     void testScanCount() {
+
+        scannerStateService.setReady();
+
         assertEquals(0, scannerStateService.getScanCount());
         scannerStateService.incrementScanCount();
         assertEquals(1, scannerStateService.getScanCount());


### PR DESCRIPTION
Some aspects of the launch flow have been improved to better define the conditions under which the scanning process can begin.

 - There is creation of a directory to store the index in the initialization process of IndexManager (Lucene Index). This index differs in directory name and content depending on the version of the product. (Different for Subsonic/Airsonic/Jpsonic). In some cases the old index will be deleted and a new index directory created at startup. Deleting and creating files is not instantaneous.
 - Previously this process was called from MediaScannerService@PostConstruct. This has been moved to the IndexManager@PostConstruct where it should be.
   - This in itself does not change the process significantly. This is for correcting dependencies.
 - ScannerStateServiceImpl#setReady() was added. The field ready flag of ScannerStateServiceImpl is initialized with false. Lock acquisitions to perform scans will be refused until setReady() is called once after server startup.
 - ScannerStateServiceImpl#setReady() is called after index initialization is complete in IndexManager@PostConstruct. In other words, the scan will be denied until these file operations are completed. (Simply specifying the order in which classes are loaded by Spring does not provide adequate control over these flow, as file manipulation is indeterminate.)

A scan launch action has three paths.

A scan button on a web page or invoking Scan via REST cannot cause problems. It's almost the last time in the Spring startup process that they are available. The schedule is relatively early. (The execution log may be output while Spring is loading). This pull request will prevent such processing conflicts.

___

That's all for now... Flow is more robust than before.

If we want to speed up the startup time even a little, you can move the IndexManager@PostConstruct processing to an event listener and run it asynchronously. 