### PR TITLE
Fix Roles glitch

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PasswordSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PasswordSettingsController.java
@@ -80,8 +80,7 @@ public class PasswordSettingsController {
             return new ModelAndView("passwordSettings");
         } else {
             User user = securityService.getUserByNameStrict(command.getUsername());
-            user.setPassword(command.getPassword());
-            securityService.updateUser(user);
+            securityService.updatePassword(user, command.getPassword(), user.isLdapAuthenticated());
 
             command.setPassword(null);
             command.setConfirmPassword(null);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/RecoverController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/RecoverController.java
@@ -91,13 +91,10 @@ public class RecoverController {
                 int index = random.nextInt(SYMBOLS.length());
                 sb.append(SYMBOLS.charAt(index));
             }
-            String password = sb.toString();
-
+            String newPass = sb.toString();
             if (sendEmail(user.getUsername(), user.getEmail())) {
                 map.put("sentTo", user.getEmail());
-                user.setLdapAuthenticated(false);
-                user.setPassword(password);
-                securityService.updateUser(user);
+                securityService.updatePassword(user, newPass, false);
             } else {
                 map.put(Attributes.Model.ERROR.getValue(), "recover.error.sendfailed");
             }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SubsonicRESTController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SubsonicRESTController.java
@@ -2163,11 +2163,9 @@ public class SubsonicRESTController {
             writeError(request, response, ErrorCode.NOT_FOUND, MSG_NO_USER + username);
             return;
         }
-        String password = decrypt(
+        String newPass = decrypt(
                 ServletRequestUtils.getRequiredStringParameter(request, Attributes.Request.PASSWORD.value()));
-        user.setPassword(password);
-        securityService.updateUser(user);
-
+        securityService.updatePassword(user, newPass, user.isLdapAuthenticated());
         writeEmptyResponse(request, response);
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/UserDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/UserDao.java
@@ -194,6 +194,11 @@ public class UserDao extends AbstractDao {
         writeRoles(user);
     }
 
+    public void updatePassword(User user, String newPass, boolean ldapAuthenticated) {
+        String sql = "update " + getUserTable() + " set password=?, ldap_authenticated=? where username=?";
+        update(sql, newPass, ldapAuthenticated, user.getUsername());
+    }
+
     public void updateUserByteCounts(long bytesStreamed, long bytesDownloaded, long bytesUploaded, String username) {
         String sql = "update " + getUserTable()
                 + " set bytes_streamed=?, bytes_downloaded=?, bytes_uploaded=? where username=?";

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/UserDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/UserDao.java
@@ -194,6 +194,12 @@ public class UserDao extends AbstractDao {
         writeRoles(user);
     }
 
+    public void updateUserByteCounts(long bytesStreamed, long bytesDownloaded, long bytesUploaded, String username) {
+        String sql = "update " + getUserTable()
+                + " set bytes_streamed=?, bytes_downloaded=?, bytes_uploaded=? where username=?";
+        update(sql, bytesStreamed, bytesDownloaded, bytesUploaded, username);
+    }
+
     /**
      * Returns the name of the roles for the given user.
      *

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
@@ -341,6 +341,10 @@ public class SecurityService implements UserDetailsService {
         userDao.updateUser(user);
     }
 
+    public void updatePassword(User user, String newPass, boolean ldapAuthenticated) {
+        userDao.updatePassword(user, newPass, ldapAuthenticated);
+    }
+
     /**
      * Updates the byte counts for given user.
      *

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
@@ -358,12 +358,9 @@ public class SecurityService implements UserDetailsService {
         if (user == null) {
             return;
         }
-
-        user.setBytesStreamed(user.getBytesStreamed() + bytesStreamedDelta);
-        user.setBytesDownloaded(user.getBytesDownloaded() + bytesDownloadedDelta);
-        user.setBytesUploaded(user.getBytesUploaded() + bytesUploadedDelta);
-
-        userDao.updateUser(user);
+        userDao.updateUserByteCounts(user.getBytesStreamed() + bytesStreamedDelta,
+                user.getBytesDownloaded() + bytesDownloadedDelta, user.getBytesUploaded() + bytesUploadedDelta,
+                user.getUsername());
     }
 
     /**

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/RecoverControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/RecoverControllerTest.java
@@ -389,6 +389,7 @@ class RecoverControllerTest {
         assertEquals(ServiceMockUtils.ADMIN_NAME, model.get(Attributes.Request.USERNAME_OR_EMAIL.value()));
         assertEquals(RECAPTCHA_SITE_KEY, model.get(ATTR_SITE_KEY));
         Assertions.assertFalse(model.containsKey(Attributes.Request.ERROR.value()));
-        Mockito.verify(securityService, Mockito.times(1)).updateUser(Mockito.any());
+        Mockito.verify(securityService, Mockito.times(1)).updatePassword(Mockito.any(User.class), Mockito.anyString(),
+                Mockito.anyBoolean());
     }
 }


### PR DESCRIPTION
Related #1839

Bug fixes for Airsonic's famous that the menu may not be displayed very rarely.

#### Cause

- ByteCounts per user are updated as songs are played and downloaded. 
- Generic method UserDao#updateUser is used when updating
- UserDao#updateUser also updates roles, so roles may be overwritten if there is a conflict

#### Countermeasure

 - [x] Fix SecurityService#updateUserByteCounts 
 - [x] Validation in Postgres
   - Not so long ago you had to specify the isolation level with `@Transactional`. Currently the many DB isolation level is above READ COMMITTED so no fix will be done. (Mysql is REPEATABLE)
   - However, in the case of Postgres, the behavior is a little special, so it will be confirmed.

<details>
<summary>Validation</summary>

 - Data is protected from conflicts, but constraint violation occurs in case of delete-insert(v9-15). If autocommit off(default), later session is aborted and waits for commit.
     - Countermeasure. 
        - 1. Change table design.
          - At this time, it is our policy not to easily `modify` the sheme. The speed gains from the design changes here are limited. Because rarely used and less conflicted. Try to keep the bug fixes as low impact as possible.
        - 2. Increase isolation level
          - Same in the sense that an SQL exception is thrown.(SQL:40001): 
        - 3. Lock UserDao#updateUser on the Java side
        - 4. Do nothing **Maybe this.**

If we don't want to show the error screen to the user in any case, either change the table design to avoid Delete-Inserts, or put a lock on the method in Java. If we want to do any of these, even if it's not now, we can always do it.

But if we don't care about it, we have the option of doing nothing. This is because if updateUserByteCounts were fixed, there would be virtually no conflicts. (It would be difficult even to reproduce intentionally)

In this case, Postgres accepts the spec that the latecomer fails in case of conflict. Postgres will wait for commit after an exception occurs, but Spring will catch the checked exception and commit, so it will be aborted. A SQL error will appear on the screen. However, your data is protected. Run it again and it should work.

</details>

Well, currently only the SecurityService#updateUserByteCounts fix is the minimal fix.

#### Similar bug

If anything, it's a design bug rather than an implementation bug. The fact that **roles are updated based on the activity of users who do not have permission to change roles** is probrem in the first place. It does not mean that it is correct if the later COMMIT priority is realized without SQL errors or inconsistencies. The criterion is whether or not it is acceptable to overwrite.
 - Strictly speaking, there are equivalent design bugs in password change and password recovery, too.
 - Very infrequently occurring, in normal operational flow.

 - [x] Fix password change

#### And more, similar bugs

The following is related information not covered in this Issues.

This issue is just the tip of the iceberg. Jpsonic's v111.6.0 theme is scanning, v111.7.0 theme is podcasts, but this phase includes fixes for Unintentional Overwriting of data similar to this issue.

 - A few public methods near the end of the [WritableMediaFileService](https://github.com/tesshucom/jpsonic/blob/develop/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/WritableMediaFileService.java) class are functions that have had data overwrite problems similar to the issues covered in this issue.
 - Mediafiles can lead to inconsistencies and secondary problems if dates, flags, etc. are unintentionally overwritten.
   - These can also be considered **similar design bugs**. Scans are inherently actions that cannot be performed without scan privileges. Overwriting fields critical to scanning with features not directly related to scanning is itself a source of problems. Data duplication and inconsistency is the result.
 - In this respect, v111.6.0 provides a fairly defensive implementation. Related design changes were made in #1922 and #1941.

Minor features like podcasts and tag changes will be deferred to v111.7.0. But on web pages, they are already protected from use during scanning. (Podcast fixes are in a separate version, as table changes may occur)
