### PR TITLE
Fix not to allow duplicate paths in music folder

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MusicFolderSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MusicFolderSettingsController.java
@@ -183,9 +183,16 @@ public class MusicFolderSettingsController {
         if (validated.isEmpty()) {
             return Optional.empty();
         }
+
+        Path newPath = Path.of(validated.get());
+        if (musicFolderService.getAllMusicFolders(true, true).stream()
+                .anyMatch(old -> old.toPath().startsWith(newPath) || newPath.startsWith(old.toPath()))) {
+            return Optional.empty();
+        }
+
         String name = StringUtils.trimToNull(info.getName());
         if (name == null) {
-            name = Path.of(validated.get()).getFileName().toString();
+            name = newPath.getFileName().toString();
         }
         return Optional.of(new MusicFolder(info.getId(), validated.get(), name, info.isEnabled(), now()));
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MusicFolderSettingsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MusicFolderSettingsControllerTest.java
@@ -28,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.annotation.Documented;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 
@@ -368,6 +369,18 @@ class MusicFolderSettingsControllerTest {
                         }
 
                         @interface NonTraversal {
+
+                            @interface OldPathStartWithNewPath {
+
+                            }
+
+                            @interface NewPathStartWithOldPath {
+
+                            }
+
+                            @interface NonDuplication {
+
+                            }
                         }
                     }
 
@@ -422,10 +435,37 @@ class MusicFolderSettingsControllerTest {
         }
 
         @Test
-        @ToMusicFolderDecisions.Conditions.MusicFolderInfo.Path.NonNull.NonTraversal
+        @ToMusicFolderDecisions.Conditions.MusicFolderInfo.Path.NonNull.NonTraversal.OldPathStartWithNewPath
+        @ToMusicFolderDecisions.Results.Empty
+        void c03() {
+            List<MusicFolder> oldMusicFolders = Arrays.asList(new MusicFolder(0, "/jpsonic", "old", false, null));
+            Mockito.when(musicFolderService.getAllMusicFolders(true, true)).thenReturn(oldMusicFolders);
+            MusicFolderInfo info = new MusicFolderInfo();
+            String path = "/jpsonic/subDirectory";
+            info.setPath(path);
+            assertTrue(controller.toMusicFolder(info).isEmpty());
+        }
+
+        @Test
+        @ToMusicFolderDecisions.Conditions.MusicFolderInfo.Path.NonNull.NonTraversal.NewPathStartWithOldPath
+        @ToMusicFolderDecisions.Results.Empty
+        void c04() {
+            List<MusicFolder> oldMusicFolders = Arrays
+                    .asList(new MusicFolder(0, "/jpsonic/subDirectory", "old", false, null));
+            Mockito.when(musicFolderService.getAllMusicFolders(true, true)).thenReturn(oldMusicFolders);
+            MusicFolderInfo info = new MusicFolderInfo();
+            String path = "/jpsonic";
+            info.setPath(path);
+            assertTrue(controller.toMusicFolder(info).isEmpty());
+        }
+
+        @Test
+        @ToMusicFolderDecisions.Conditions.MusicFolderInfo.Path.NonNull.NonTraversal.NonDuplication
         @ToMusicFolderDecisions.Conditions.MusicFolderInfo.Name.NonNull
         @ToMusicFolderDecisions.Results.NotEmpty
-        void c03() {
+        void c05() {
+            List<MusicFolder> oldMusicFolders = Arrays.asList(new MusicFolder(0, "/jpsonic", "old", false, null));
+            Mockito.when(musicFolderService.getAllMusicFolders(true, true)).thenReturn(oldMusicFolders);
             MusicFolderInfo info = new MusicFolderInfo();
             String path = "foo/bar";
             info.setPath(path);
@@ -434,11 +474,11 @@ class MusicFolderSettingsControllerTest {
         }
 
         @Test
-        @ToMusicFolderDecisions.Conditions.MusicFolderInfo.Path.NonNull.NonTraversal
+        @ToMusicFolderDecisions.Conditions.MusicFolderInfo.Path.NonNull.NonTraversal.NonDuplication
         @ToMusicFolderDecisions.Conditions.MusicFolderInfo.Name.Null
         @ToMusicFolderDecisions.Conditions.MusicFolderInfo.Path.DirName.NonNull
         @ToMusicFolderDecisions.Results.NotEmpty
-        void c04() {
+        void c06() {
             MusicFolderInfo info = new MusicFolderInfo();
             String path = "foo/bar";
             info.setPath(path);
@@ -450,7 +490,7 @@ class MusicFolderSettingsControllerTest {
         @ToMusicFolderDecisions.Conditions.MusicFolderInfo.Name.Null
         @ToMusicFolderDecisions.Conditions.MusicFolderInfo.Path.DirName.Null
         @ToMusicFolderDecisions.Results.Empty
-        void c05() {
+        void c07() {
             MusicFolderInfo info = new MusicFolderInfo();
             String path = "/";
             info.setPath(path);
@@ -463,7 +503,7 @@ class MusicFolderSettingsControllerTest {
         @ToMusicFolderDecisions.Conditions.MusicFolderInfo.Path.DirName.Null
         @ToMusicFolderDecisions.Results.Empty
         @EnabledOnOs(OS.WINDOWS)
-        void c06() {
+        void c08() {
             MusicFolderInfo info = new MusicFolderInfo();
             String path = "/:";
             info.setPath(path);


### PR DESCRIPTION
To prevent data inconsistencies, the check at the time of registration of Musicfolder has become a little stricter.

When registering a new folder, the path is compared with registered folders. Same or subfolders cannot be registered.



#### Same path

![image](https://user-images.githubusercontent.com/27724847/208691001-eb77ce72-c913-41d0-8c71-3c663e8cedc1.png)

#### Subfolders 

Subfolders of already registered Musicfolder are not allowed.

![image](https://user-images.githubusercontent.com/27724847/208691608-b7128c7d-05a7-4051-8dee-0ef2d800a022.png)

Reverse combination is also not allowed.

![image](https://user-images.githubusercontent.com/27724847/208692249-d0259711-e5b3-40fa-bb7d-110ef1912c14.png)

#### When updating the already registered Musicfolder path to a subfolder

Delete the music folder you are trying to update and recreate it.

 - If you want to change D:\music to D:\music\subfolder, delete D:\music first
 - If you want to change D:\music\subfolder to D:\music , delete D:\music\subfolder