### PR TITLE
Fix ExpungeService

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -720,6 +720,7 @@ public class MediaFileDao extends AbstractDao {
                 + "and starred_media_file.username = :username", 0, args);
     }
 
+    @Transactional
     public void starMediaFile(int id, String username) {
         unstarMediaFile(id, username);
         update("insert into starred_media_file(media_file_id, username, created) values (?,?,?)", id, username, now());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/PlaylistDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/PlaylistDao.java
@@ -101,6 +101,7 @@ public class PlaylistDao extends AbstractDao {
         playlist.setId(id);
     }
 
+    @Transactional
     public void setFilesInPlaylist(int id, List<MediaFile> files) {
         update("delete from playlist_file where playlist_id=?", id);
         int duration = 0;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/RatingDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/RatingDao.java
@@ -30,6 +30,7 @@ import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.util.LegacyMap;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Provides database services for ratings.
@@ -79,6 +80,7 @@ public class RatingDao extends AbstractDao {
      * @param rating
      *            The rating between 1 and 5, or <code>null</code> to remove the rating.
      */
+    @Transactional
     public void setRatingForUser(String username, MediaFile mediaFile, Integer rating) {
         if (rating != null && (rating < 1 || rating > 5)) {
             return;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/RatingDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/RatingDao.java
@@ -138,4 +138,9 @@ public class RatingDao extends AbstractDao {
                         + "and media_file.folder in (:folders) " + "and user_rating.username = :username",
                 0, args);
     }
+
+    public void expunge() {
+        update("delete from user_rating where path in (select  user_rating.path from user_rating "
+                + "left join media_file on media_file.path = user_rating.path where media_file.path is null)");
+    }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/TranscodingDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/TranscodingDao.java
@@ -81,6 +81,7 @@ public class TranscodingDao extends AbstractDao {
      * @param transcodingIds
      *            ID's of the active transcodings.
      */
+    @Transactional
     public void setTranscodingsForPlayer(Integer playerId, int... transcodingIds) {
         update("delete from player_transcoding2 where player_id = ?", playerId);
         String sql = "insert into player_transcoding2(player_id, transcoding_id) values (?, ?)";

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ExpungeService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ExpungeService.java
@@ -3,6 +3,7 @@ package com.tesshu.jpsonic.service.scanner;
 import com.tesshu.jpsonic.dao.AlbumDao;
 import com.tesshu.jpsonic.dao.ArtistDao;
 import com.tesshu.jpsonic.dao.MediaFileDao;
+import com.tesshu.jpsonic.dao.RatingDao;
 import com.tesshu.jpsonic.service.search.IndexManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,15 +22,17 @@ public class ExpungeService {
     private final ArtistDao artistDao;
     private final AlbumDao albumDao;
     private final MediaFileDao mediaFileDao;
+    private final RatingDao ratingDao;
 
     public ExpungeService(ScannerStateServiceImpl scannerState, IndexManager indexManager, ArtistDao artistDao,
-            AlbumDao albumDao, MediaFileDao mediaFileDao) {
+            AlbumDao albumDao, MediaFileDao mediaFileDao, RatingDao ratingDao) {
         super();
         this.scannerState = scannerState;
         this.indexManager = indexManager;
         this.artistDao = artistDao;
         this.albumDao = albumDao;
         this.mediaFileDao = mediaFileDao;
+        this.ratingDao = ratingDao;
     }
 
     void expunge() {
@@ -54,6 +57,10 @@ public class ExpungeService {
             artistDao.expunge();
             albumDao.expunge();
             mediaFileDao.expunge();
+
+            // to be after mediaFileDao#expunge
+            ratingDao.expunge();
+
             mediaFileDao.checkpoint();
         }
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
@@ -244,7 +244,7 @@ class IndexManagerTest extends AbstractNeedsScan {
         assertEquals(3, ratingDao.getRatedAlbumCount(USER_NAME, musicFolders), "Because one album has been deleted.");
         int ratingsCount = ratingDao.getJdbcTemplate().queryForObject(
                 "select count(*) from user_rating where user_rating.username = ?", Integer.class, USER_NAME);
-        assertEquals(5, ratingsCount, "Nothing has been deleted!");
+        assertEquals(3, ratingsCount, "Will be removed, including oldPath");
     }
 
     @Test

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
@@ -37,8 +37,11 @@ import com.tesshu.jpsonic.AbstractNeedsScan;
 import com.tesshu.jpsonic.dao.AlbumDao;
 import com.tesshu.jpsonic.dao.ArtistDao;
 import com.tesshu.jpsonic.dao.MediaFileDao;
+import com.tesshu.jpsonic.dao.RatingDao;
+import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.domain.SearchResult;
+import com.tesshu.jpsonic.service.MediaScannerService;
 import com.tesshu.jpsonic.service.SearchService;
 import com.tesshu.jpsonic.service.SettingsService;
 import com.tesshu.jpsonic.util.FileUtil;
@@ -75,6 +78,14 @@ class IndexManagerTest extends AbstractNeedsScan {
     @Autowired
     private AlbumDao albumDao;
 
+    @Autowired
+    private MediaScannerService mediaScannerService;
+
+    @Autowired
+    private RatingDao ratingDao;
+
+    private static final String USER_NAME = "admin";
+
     @Override
     public List<MusicFolder> getMusicFolders() {
         if (ObjectUtils.isEmpty(musicFolders)) {
@@ -85,7 +96,35 @@ class IndexManagerTest extends AbstractNeedsScan {
 
     @BeforeEach
     public void setup() {
-        populateDatabaseOnlyOnce();
+        populateDatabaseOnlyOnce(() -> {
+            return true;
+        }, () -> {
+
+            // #1842 Airsonic does not implement Rating expunge
+
+            List<MediaFile> albums = mediaFileDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, true, musicFolders);
+            assertEquals(4, albums.size());
+
+            albums.forEach(m -> ratingDao.setRatingForUser(USER_NAME, m, 1));
+            assertEquals(4, ratingDao.getRatedAlbumCount(USER_NAME, musicFolders));
+            int ratingsCount = ratingDao.getJdbcTemplate().queryForObject(
+                    "select count(*) from user_rating where user_rating.username = ?", Integer.class, USER_NAME);
+            assertEquals(4, ratingsCount, "Because explicitly registered 4 Ratings.");
+
+            // Register a dummy rate (reproduce old path data by moving files)
+            MediaFile dummyMediaFile = new MediaFile();
+            dummyMediaFile.setPathString("oldPath");
+            ratingDao.setRatingForUser(USER_NAME, dummyMediaFile, 1);
+
+            assertEquals(4, ratingDao.getRatedAlbumCount(USER_NAME, musicFolders),
+                    "Because the SELECT condition only references real paths.");
+            ratingsCount = ratingDao.getJdbcTemplate().queryForObject(
+                    "select count(*) from user_rating where user_rating.username = ?", Integer.class, USER_NAME);
+            assertEquals(5, ratingsCount, "Because counted directly, including non-existent paths.");
+
+            return true;
+        });
+
     }
 
     @Test
@@ -180,9 +219,7 @@ class IndexManagerTest extends AbstractNeedsScan {
         assertEquals(4, candidates.size());
 
         /* Does not scan, only expunges the index. */
-        indexManager.startIndexing();
-        indexManager.expunge();
-        indexManager.stopIndexing();
+        mediaScannerService.expunge();
 
         /*
          * Subsequent search results. Results can also be confirmed with Luke.
@@ -203,6 +240,11 @@ class IndexManagerTest extends AbstractNeedsScan {
         result = searchService.search(criteriaAlbumId3);
         assertEquals(0, result.getAlbums().size());
 
+        // See this#setup
+        assertEquals(3, ratingDao.getRatedAlbumCount(USER_NAME, musicFolders), "Because one album has been deleted.");
+        int ratingsCount = ratingDao.getJdbcTemplate().queryForObject(
+                "select count(*) from user_rating where user_rating.username = ?", Integer.class, USER_NAME);
+        assertEquals(5, ratingsCount, "Nothing has been deleted!");
     }
 
     @Test


### PR DESCRIPTION
 - Implemented because there is no user_rating record deletion. Running Clean up from the web page will remove unnecessary data
   - If you've never used the rate feature, it probably isn't garbage to begin with.
   - For example deleting or moving files would leave previous rate records behind.
   - Having old rate records does not cause bugs. This is because it is referenced in conjunction with an existing path. Only garbage remains.
   - This fix will also remove any such data that occurred previously
 - `@Transactional` was added to the Dao method that performs delete&insert

___

FKs in pass fields that are probably not PKs were avoided at user_rating table. (Pass is not unique by definition). So expunge method was added as part of the Clean up process instead of CASCADE DELETE.


