### PR TITLE
Split MediaFileDao#createOrUpdateMediaFile

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -188,6 +188,11 @@ public class MediaFileDao extends AbstractDao {
                 file.getAlbumArtistSortRaw(), file.getComposerSortRaw(), file.getOrder(), file.getPathString());
     }
 
+    public void updateChildrenLastUpdated(String pathString, Instant childrenLastUpdated) {
+        update("update media_file set children_last_updated = ?, present=? where path=?", childrenLastUpdated, true,
+                pathString);
+    }
+
     public void updateFolder(String pathString, String folder) {
         update("update media_file set folder = ? where path=?", folder, pathString);
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
@@ -240,7 +240,7 @@ public class ScannerProcedureService {
             file.setAlbumArtistReading(album.getArtistReading());
             file.setAlbumArtistSort(album.getArtistSort());
             // TODO To be fixed in v111.6.0 #1925 Do not use createOrUpdate here.
-            mediaFileDao.createOrUpdateMediaFile(file);
+            mediaFileDao.updateMediaFile(file);
         }
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/WritableMediaFileService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/WritableMediaFileService.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.tesshu.jpsonic.SuppressLint;
 import com.tesshu.jpsonic.dao.AlbumDao;
 import com.tesshu.jpsonic.dao.MediaFileDao;
 import com.tesshu.jpsonic.domain.Album;
@@ -101,7 +102,7 @@ public class WritableMediaFileService {
     }
 
     /**
-     * Use of this method suggests imperfect workflow design.
+     * Will be removed in v111.7.0. Use of this method suggests imperfect workflow design.
      *
      * @deprecated Use MediaFileService#getMediaFile if use the cache, otherwise use
      *             WritableMediaFileService#getMediaFile(Instant, Path)
@@ -112,6 +113,13 @@ public class WritableMediaFileService {
         return getMediaFile(newScanDate(), path);
     }
 
+    /**
+     * Will be removed in v111.7.0.
+     *
+     * @deprecated Only used on top nodes in scans. So creating a top-level node is necessary and there should be no
+     *             need to provide a multipurpose method.
+     */
+    @Deprecated
     @Nullable
     MediaFile getMediaFile(@NonNull Instant scanDate, @Nullable Path path) {
 
@@ -121,15 +129,14 @@ public class WritableMediaFileService {
             throw new SecurityException("Access denied to file " + path);
         }
 
-        MediaFile mediaFile = mediaFileDao.getMediaFile(path.toString());
-        if (mediaFile != null) {
-            mediaFile = checkLastModified(scanDate, mediaFile);
-            mediaFileCache.put(path, mediaFile);
-            return mediaFile;
+        MediaFile registered = mediaFileDao.getMediaFile(path.toString());
+        if (registered != null) {
+            registered = checkLastModified(scanDate, registered);
+            mediaFileCache.put(path, registered);
+            return registered;
         }
 
-        mediaFile = createMediaFile(scanDate, path);
-        return mediaFileDao.createMediaFile(mediaFile);
+        return createMediaFile(scanDate, path);
     }
 
     boolean isSchemeLastModified() {
@@ -156,7 +163,7 @@ public class WritableMediaFileService {
         try (DirectoryStream<Path> ds = Files.newDirectoryStream(parent.toPath())) {
             for (Path childPath : ds) {
                 if (mediaFileService.includeMediaFile(childPath) && stored.remove(childPath.toString()) == null) {
-                    mediaFileDao.createMediaFile(createMediaFile(scanDate, childPath));
+                    createMediaFile(scanDate, childPath);
                 }
             }
         } catch (IOException e) {
@@ -168,10 +175,7 @@ public class WritableMediaFileService {
             mediaFileDao.deleteMediaFile(path);
         }
 
-        // Update timestamp in parent.
-        parent.setChildrenLastUpdated(parent.getChanged());
-        parent.setPresent(true);
-        mediaFileDao.updateMediaFile(parent);
+        mediaFileDao.updateChildrenLastUpdated(parent.getPathString(), parent.getChanged());
     }
 
     List<MediaFile> getChildrenOf(@NonNull Instant scanDate, @NonNull MediaFile parent, boolean fileOnly) {
@@ -220,16 +224,11 @@ public class WritableMediaFileService {
             }
         }
 
-        MediaFile oldFile = mediaFileDao.getMediaFile(mediaFile.getPathString());
-        MediaFile newFile = createMediaFile(scanDate, mediaFile.toPath());
-        if (oldFile == null) {
-            newFile = mediaFileDao.createMediaFile(newFile);
-            return newFile;
+        MediaFile registered = mediaFileDao.getMediaFile(mediaFile.getPathString());
+        if (registered == null) {
+            return createMediaFile(scanDate, mediaFile.toPath());
         }
-
-        newFile.setId(oldFile.getId());
-        mediaFileDao.updateMediaFile(newFile);
-        return newFile;
+        return refreshMediaFile(scanDate, registered);
     }
 
     long getLastModified(@NonNull Instant scanDate, @NonNull Path path) {
@@ -243,18 +242,34 @@ public class WritableMediaFileService {
         return scanDate.toEpochMilli();
     }
 
+    @SuppressLint(value = "NULL_DEREFERENCE", justification = "False positive. parseMediaFile is NonNull")
     MediaFile createMediaFile(@NonNull Instant scanDate, @NonNull Path path) {
+        return mediaFileDao.createMediaFile(parseMediaFile(scanDate, path, false));
+    }
 
-        MediaFile existingFile = mediaFileDao.getMediaFile(path.toString());
+    @NonNull
+    private MediaFile parseMediaFile(@NonNull Instant scanDate, @NonNull Path path, boolean refresh) {
+        MediaFile registered = refresh ? mediaFileDao.getMediaFile(path.toString()) : null;
+        MediaFile mediaFile = instanceOf(scanDate, path, registered);
+        if (Files.isDirectory(path)) {
+            applyDirectory(path, mediaFile, scanDate);
+        } else {
+            applyFile(path, mediaFile, scanDate);
+        }
+        return mediaFile;
+    }
 
+    private @NonNull MediaFile instanceOf(@NonNull Instant scanDate, @NonNull Path path, MediaFile registered) {
         MediaFile mediaFile = new MediaFile();
+
+        mediaFile.setId(registered == null ? 0 : registered.getId());
 
         // Variable initial value
         Instant lastModified = Instant.ofEpochMilli(getLastModified(scanDate, path));
         mediaFile.setChanged(lastModified);
         mediaFile.setCreated(lastModified);
 
-        mediaFile.setLastScanned(existingFile == null ? FAR_PAST : existingFile.getLastScanned());
+        mediaFile.setLastScanned(registered == null ? FAR_PAST : registered.getLastScanned());
         mediaFile.setChildrenLastUpdated(FAR_PAST);
 
         mediaFile.setPathString(path.toString());
@@ -265,17 +280,11 @@ public class WritableMediaFileService {
             throw new IllegalArgumentException("Illegal path specified: " + path);
         }
         mediaFile.setParentPathString(parent.toString());
-        mediaFile.setPlayCount(existingFile == null ? 0 : existingFile.getPlayCount());
-        mediaFile.setLastPlayed(existingFile == null ? null : existingFile.getLastPlayed());
-        mediaFile.setComment(existingFile == null ? null : existingFile.getComment());
+        mediaFile.setPlayCount(registered == null ? 0 : registered.getPlayCount());
+        mediaFile.setLastPlayed(registered == null ? null : registered.getLastPlayed());
+        mediaFile.setComment(registered == null ? null : registered.getComment());
         mediaFile.setMediaType(MediaFile.MediaType.DIRECTORY);
         mediaFile.setPresent(true);
-
-        if (Files.isDirectory(path)) {
-            applyDirectory(path, mediaFile, scanDate);
-        } else {
-            applyFile(path, mediaFile, scanDate);
-        }
         return mediaFile;
     }
 
@@ -385,14 +394,24 @@ public class WritableMediaFileService {
     }
 
     /*
-     * Used for some tag updates. Note that it only updates the tags and does not take into account the completeness of
-     * the scan.
+     * TODO To be fixed in v111.6.0 #1927. Used for some tag updates. Note that it only updates the tags and does not
+     * take into account the completeness of the scan.
      */
-    void refreshMediaFile(@NonNull final MediaFile mediaFile) {
-        Path path = mediaFile.toPath();
-        MediaFile mf = createMediaFile(newScanDate(), path);
-        mediaFileDao.updateMediaFile(mf);
-        mediaFileCache.remove(path);
+    @Deprecated
+    void refreshMediaFile(@NonNull MediaFile mediaFile) {
+        refreshMediaFile(newScanDate(), mediaFile);
+    }
+
+    /**
+     * Refreshing of registered media files. This process involves for parsing the file and re-searching cover art.
+     */
+    @SuppressLint(value = "NULL_DEREFERENCE", justification = "False positive. parseMediaFile is NonNull")
+    MediaFile refreshMediaFile(@NonNull Instant scanDate, @NonNull MediaFile registered) {
+        Path registeredPath = registered.toPath();
+        MediaFile parsed = parseMediaFile(scanDate, registeredPath, true);
+        mediaFileDao.updateMediaFile(parsed);
+        mediaFileCache.remove(registeredPath);
+        return parsed;
     }
 
     // Updateable even during scanning

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureServiceTest.java
@@ -273,7 +273,7 @@ class ScannerProcedureServiceTest {
             ArgumentCaptor<Album> albumCap = ArgumentCaptor.forClass(Album.class);
             Mockito.verify(albumDao, Mockito.times(1)).createOrUpdateAlbum(albumCap.capture());
             Mockito.verify(indexManager, Mockito.times(1)).index(Mockito.any(Album.class));
-            Mockito.verify(mediaFileDao, Mockito.times(1)).createOrUpdateMediaFile(mediaCap.capture());
+            Mockito.verify(mediaFileDao, Mockito.times(1)).updateMediaFile(mediaCap.capture());
 
             Album registeredAlbum = albumCap.getValue();
             assertEquals(registeredAlbum.getLastScanned(), statistics.getExecuted());
@@ -291,7 +291,7 @@ class ScannerProcedureServiceTest {
 
             // Not executed if already executed
             Mockito.verify(indexManager, Mockito.times(1)).index(Mockito.any(Album.class));
-            Mockito.verify(mediaFileDao, Mockito.times(1)).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.times(1)).updateMediaFile(Mockito.any(MediaFile.class));
         }
 
         @Test
@@ -393,7 +393,7 @@ class ScannerProcedureServiceTest {
             ArgumentCaptor<Album> albumCap = ArgumentCaptor.forClass(Album.class);
             Mockito.verify(albumDao, Mockito.times(1)).createOrUpdateAlbum(albumCap.capture());
             Mockito.verify(indexManager, Mockito.times(1)).index(Mockito.any(Album.class));
-            Mockito.verify(mediaFileDao, Mockito.times(1)).createOrUpdateMediaFile(mediaCap.capture());
+            Mockito.verify(mediaFileDao, Mockito.times(1)).updateMediaFile(mediaCap.capture());
 
             Album registeredAlbum = albumCap.getValue();
             Mockito.when(albumDao.getAlbumForFile(Mockito.any(MediaFile.class))).thenReturn(registeredAlbum);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/SortProcedureServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/SortProcedureServiceTest.java
@@ -342,7 +342,7 @@ class SortProcedureServiceTest {
                     files.stream().filter(m -> "file10".equals(m.getName()) || "file12".equals(m.getName())
                             || "file14".equals(m.getName()) || "file17".equals(m.getName())).forEach(m -> {
                                 m.setChanged(now);
-                                mediaFileDao.createOrUpdateMediaFile(m);
+                                mediaFileDao.updateMediaFile(m);
                             });
                 });
                 return true;
@@ -965,7 +965,7 @@ class SortProcedureServiceTest {
                         if ("file10".equals(m.getName()) || "file12".equals(m.getName()) || "file14".equals(m.getName())
                                 || "file17".equals(m.getName())) {
                             m.setChanged(now);
-                            mediaFileDao.createOrUpdateMediaFile(m);
+                            mediaFileDao.updateMediaFile(m);
                         }
                     });
                 });
@@ -1781,7 +1781,7 @@ class SortProcedureServiceTest {
                     songs.forEach(m -> {
                         if (latestMediaFileTitle1.equals(m.getTitle()) || latestMediaFileTitle2.equals(m.getTitle())) {
                             m.setChanged(now);
-                            mediaFileDao.createOrUpdateMediaFile(m);
+                            mediaFileDao.updateMediaFile(m);
                         }
                     });
                 });

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/WritableMediaFileServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/WritableMediaFileServiceTest.java
@@ -218,7 +218,7 @@ class WritableMediaFileServiceTest {
                     lessThan(MediaFileDao.VERSION));
 
             assertEquals(mediaFile, writableMediaFileService.checkLastModified(scanStart, mediaFile));
-            Mockito.verify(mediaFileDao, Mockito.times(1)).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.times(1)).updateMediaFile(Mockito.any(MediaFile.class));
         }
 
         @CheckLastModifiedDecision.Conditions.MediaFile.Version.GtEqDaoVersion
@@ -244,7 +244,7 @@ class WritableMediaFileServiceTest {
             assertEquals(mediaFile.getChanged(), Files.getLastModifiedTime(mediaFile.toPath()).toInstant());
             assertEquals(FAR_PAST, mediaFile.getLastScanned());
             assertEquals(mediaFile, writableMediaFileService.checkLastModified(scanStart, mediaFile));
-            Mockito.verify(mediaFileDao, Mockito.times(1)).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.times(1)).updateMediaFile(Mockito.any(MediaFile.class));
             Mockito.clearInvocations(mediaFileDao);
 
             try {
@@ -256,7 +256,7 @@ class WritableMediaFileServiceTest {
                     greaterThan(Files.getLastModifiedTime(mediaFile.toPath()).toMillis()));
             assertEquals(FAR_PAST, mediaFile.getLastScanned());
             assertEquals(mediaFile, writableMediaFileService.checkLastModified(scanStart, mediaFile));
-            Mockito.verify(mediaFileDao, Mockito.times(1)).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.times(1)).updateMediaFile(Mockito.any(MediaFile.class));
         }
 
         @CheckLastModifiedDecision.Conditions.MediaFile.Version.GtEqDaoVersion
@@ -282,7 +282,7 @@ class WritableMediaFileServiceTest {
             assertEquals(mediaFile.getChanged(), Files.getLastModifiedTime(mediaFile.toPath()).toInstant());
             assertNotEquals(FAR_PAST, mediaFile.getLastScanned());
             assertEquals(mediaFile, writableMediaFileService.checkLastModified(scanStart, mediaFile));
-            Mockito.verify(mediaFileDao, Mockito.never()).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.never()).updateMediaFile(Mockito.any(MediaFile.class));
 
             try {
                 mediaFile.setChanged(Files.getLastModifiedTime(dir).toInstant().plus(1, ChronoUnit.DAYS));
@@ -293,7 +293,7 @@ class WritableMediaFileServiceTest {
                     greaterThan(Files.getLastModifiedTime(mediaFile.toPath()).toMillis()));
             assertNotEquals(FAR_PAST, mediaFile.getLastScanned());
             assertEquals(mediaFile, writableMediaFileService.checkLastModified(scanStart, mediaFile));
-            Mockito.verify(mediaFileDao, Mockito.never()).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.never()).updateMediaFile(Mockito.any(MediaFile.class));
         }
 
         @CheckLastModifiedDecision.Conditions.MediaFile.Version.GtEqDaoVersion
@@ -320,7 +320,7 @@ class WritableMediaFileServiceTest {
                     lessThan(Files.getLastModifiedTime(mediaFile.toPath()).toMillis()));
             assertEquals(FAR_PAST, mediaFile.getLastScanned());
             assertEquals(mediaFile, writableMediaFileService.checkLastModified(scanStart, mediaFile));
-            Mockito.verify(mediaFileDao, Mockito.times(1)).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.times(1)).updateMediaFile(Mockito.any(MediaFile.class));
         }
 
         @CheckLastModifiedDecision.Conditions.MediaFile.Version.GtEqDaoVersion
@@ -347,7 +347,7 @@ class WritableMediaFileServiceTest {
                     lessThan(Files.getLastModifiedTime(mediaFile.toPath()).toMillis()));
             assertNotEquals(FAR_PAST, mediaFile.getLastScanned());
             assertEquals(mediaFile, writableMediaFileService.checkLastModified(scanStart, mediaFile));
-            Mockito.verify(mediaFileDao, Mockito.never()).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.never()).updateMediaFile(Mockito.any(MediaFile.class));
         }
 
         @CheckLastModifiedDecision.Conditions.MediaFile.Version.GtEqDaoVersion
@@ -374,7 +374,7 @@ class WritableMediaFileServiceTest {
                     Files.getLastModifiedTime(mediaFile.toPath()).toMillis());
             assertEquals(FAR_PAST, mediaFile.getLastScanned());
             assertEquals(mediaFile, writableMediaFileService.checkLastModified(scanStart, mediaFile));
-            Mockito.verify(mediaFileDao, Mockito.times(1)).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.times(1)).updateMediaFile(Mockito.any(MediaFile.class));
             Mockito.clearInvocations(mediaFileDao);
 
             try {
@@ -386,7 +386,7 @@ class WritableMediaFileServiceTest {
                     greaterThan(Files.getLastModifiedTime(mediaFile.toPath()).toMillis()));
             assertEquals(FAR_PAST, mediaFile.getLastScanned());
             assertEquals(mediaFile, writableMediaFileService.checkLastModified(scanStart, mediaFile));
-            Mockito.verify(mediaFileDao, Mockito.times(1)).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.times(1)).updateMediaFile(Mockito.any(MediaFile.class));
         }
 
         @CheckLastModifiedDecision.Conditions.MediaFile.Version.GtEqDaoVersion
@@ -413,7 +413,7 @@ class WritableMediaFileServiceTest {
                     Files.getLastModifiedTime(mediaFile.toPath()).toMillis());
             assertNotEquals(FAR_PAST, mediaFile.getLastScanned());
             assertEquals(mediaFile, writableMediaFileService.checkLastModified(scanStart, mediaFile));
-            Mockito.verify(mediaFileDao, Mockito.never()).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.never()).updateMediaFile(Mockito.any(MediaFile.class));
 
             try {
                 mediaFile.setChanged(Files.getLastModifiedTime(dir).toInstant().plus(1, ChronoUnit.DAYS));
@@ -424,7 +424,7 @@ class WritableMediaFileServiceTest {
                     greaterThan(Files.getLastModifiedTime(mediaFile.toPath()).toMillis()));
             assertNotEquals(FAR_PAST, mediaFile.getLastScanned());
             assertEquals(mediaFile, writableMediaFileService.checkLastModified(scanStart, mediaFile));
-            Mockito.verify(mediaFileDao, Mockito.never()).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.never()).updateMediaFile(Mockito.any(MediaFile.class));
 
         }
 
@@ -452,7 +452,7 @@ class WritableMediaFileServiceTest {
                     lessThan(Files.getLastModifiedTime(mediaFile.toPath()).toMillis()));
             assertEquals(FAR_PAST, mediaFile.getLastScanned());
             assertEquals(mediaFile, writableMediaFileService.checkLastModified(scanStart, mediaFile));
-            Mockito.verify(mediaFileDao, Mockito.times(1)).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.times(1)).updateMediaFile(Mockito.any(MediaFile.class));
         }
 
         @CheckLastModifiedDecision.Conditions.MediaFile.Version.GtEqDaoVersion
@@ -479,7 +479,7 @@ class WritableMediaFileServiceTest {
                     lessThan(Files.getLastModifiedTime(mediaFile.toPath()).toMillis()));
             assertNotEquals(FAR_PAST, mediaFile.getLastScanned());
             assertEquals(mediaFile, writableMediaFileService.checkLastModified(scanStart, mediaFile));
-            Mockito.verify(mediaFileDao, Mockito.times(1)).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.times(1)).updateMediaFile(Mockito.any(MediaFile.class));
         }
 
         @CheckLastModifiedDecision.Conditions.MediaFile.Version.GtEqDaoVersion
@@ -503,7 +503,7 @@ class WritableMediaFileServiceTest {
 
             assertEquals(FAR_PAST, mediaFile.getLastScanned());
             assertEquals(mediaFile, writableMediaFileService.checkLastModified(scanStart, mediaFile));
-            Mockito.verify(mediaFileDao, Mockito.times(1)).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.times(1)).updateMediaFile(Mockito.any(MediaFile.class));
         }
 
         @CheckLastModifiedDecision.Conditions.MediaFile.Version.GtEqDaoVersion
@@ -529,7 +529,7 @@ class WritableMediaFileServiceTest {
                     Files.getLastModifiedTime(mediaFile.toPath()).toMillis());
             assertNotEquals(FAR_PAST, mediaFile.getLastScanned());
             assertEquals(mediaFile, writableMediaFileService.checkLastModified(scanStart, mediaFile));
-            Mockito.verify(mediaFileDao, Mockito.never()).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.never()).updateMediaFile(Mockito.any(MediaFile.class));
             Mockito.clearInvocations(mediaFileDao);
 
             try {
@@ -541,7 +541,7 @@ class WritableMediaFileServiceTest {
                     greaterThan(Files.getLastModifiedTime(mediaFile.toPath()).toMillis()));
             assertNotEquals(FAR_PAST, mediaFile.getLastScanned());
             assertEquals(mediaFile, writableMediaFileService.checkLastModified(scanStart, mediaFile));
-            Mockito.verify(mediaFileDao, Mockito.never()).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.never()).updateMediaFile(Mockito.any(MediaFile.class));
         }
 
         @CheckLastModifiedDecision.Conditions.MediaFile.Version.GtEqDaoVersion
@@ -567,7 +567,7 @@ class WritableMediaFileServiceTest {
                     lessThan(Files.getLastModifiedTime(mediaFile.toPath()).toMillis()));
             assertEquals(FAR_PAST, mediaFile.getLastScanned());
             assertEquals(mediaFile, writableMediaFileService.checkLastModified(scanStart, mediaFile));
-            Mockito.verify(mediaFileDao, Mockito.times(1)).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.times(1)).updateMediaFile(Mockito.any(MediaFile.class));
         }
 
         @CheckLastModifiedDecision.Conditions.MediaFile.Version.GtEqDaoVersion
@@ -593,7 +593,7 @@ class WritableMediaFileServiceTest {
                     lessThan(Files.getLastModifiedTime(mediaFile.toPath()).toMillis()));
             assertNotEquals(FAR_PAST, mediaFile.getLastScanned());
             assertEquals(mediaFile, writableMediaFileService.checkLastModified(scanStart, mediaFile));
-            Mockito.verify(mediaFileDao, Mockito.never()).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+            Mockito.verify(mediaFileDao, Mockito.never()).updateMediaFile(Mockito.any(MediaFile.class));
         }
     }
 
@@ -616,7 +616,7 @@ class WritableMediaFileServiceTest {
     // // Typical case where an update is performed
     // mediaFileService.updateChildren(album);
     // Mockito.verify(mediaFileDao, Mockito.times(1)).getChildrenOf(Mockito.anyString());
-    // Mockito.verify(mediaFileDao, Mockito.times(3)).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+    // Mockito.verify(mediaFileDao, Mockito.times(3)).updateMediaFile(Mockito.any(MediaFile.class));
     // Mockito.verify(mediaFileDao, Mockito.never()).deleteMediaFile(Mockito.anyString());
     // Mockito.clearInvocations(mediaFileDao);
     //
@@ -624,7 +624,7 @@ class WritableMediaFileServiceTest {
     // album.setChildrenLastUpdated(now()); // If it has already been executed, etc.
     // mediaFileService.updateChildren(album);
     // Mockito.verify(mediaFileDao, Mockito.never()).getChildrenOf(Mockito.anyString());
-    // Mockito.verify(mediaFileDao, Mockito.never()).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+    // Mockito.verify(mediaFileDao, Mockito.never()).updateMediaFile(Mockito.any(MediaFile.class));
     // Mockito.verify(mediaFileDao, Mockito.never()).deleteMediaFile(Mockito.anyString());
     //
     // Mockito.when(settingsService.getFileModifiedCheckSchemeName())
@@ -637,13 +637,13 @@ class WritableMediaFileServiceTest {
     // */
     // mediaFileService.updateChildren(album);
     // Mockito.verify(mediaFileDao, Mockito.never()).getChildrenOf(Mockito.anyString());
-    // Mockito.verify(mediaFileDao, Mockito.never()).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+    // Mockito.verify(mediaFileDao, Mockito.never()).updateMediaFile(Mockito.any(MediaFile.class));
     // Mockito.verify(mediaFileDao, Mockito.never()).deleteMediaFile(Mockito.anyString());
     //
     // album.setChildrenLastUpdated(FAR_PAST);
     // mediaFileService.updateChildren(album);
     // Mockito.verify(mediaFileDao, Mockito.times(1)).getChildrenOf(Mockito.anyString());
-    // Mockito.verify(mediaFileDao, Mockito.times(3)).createOrUpdateMediaFile(Mockito.any(MediaFile.class));
+    // Mockito.verify(mediaFileDao, Mockito.times(3)).updateMediaFile(Mockito.any(MediaFile.class));
     // Mockito.verify(mediaFileDao, Mockito.never()).deleteMediaFile(Mockito.anyString());
     // }
     // }
@@ -805,7 +805,7 @@ class WritableMediaFileServiceTest {
              * Because firstChild is registered. Since firstChild is registered at this time, firstChild will not be
              * parsed when updateChildren is executed.
              */
-            Mockito.verify(mediaFileDao, Mockito.times(1)).createOrUpdateMediaFile(mediaFileCaptor.capture());
+            Mockito.verify(mediaFileDao, Mockito.times(1)).createMediaFile(mediaFileCaptor.capture());
             // [Windows] assertEquals("02 eyes like dull hazlenuts", mediaFileCaptor.getValue().getName());
             // [Linux] assertEquals("10 telegraph hill", mediaFileCaptor.getValue().getName());
 


### PR DESCRIPTION
Prerequisites: #1922, #1941.

Remove Split MediaFileDao#createOrUpdateMediaFile.

 - Appropriate use of the update and create methods will enable design changes and process optimizations.
 - The implementation for the music_file_info table is removed.
   - Scheme will remain until removed in https://github.com/tesshucom/jpsonic/issues/1958.
- Relatedly, part of the WritableMediaFileService that previously used createOrUpdate will be refactored.
  - This clarifies the code that calls MediaFileDao#createMediaFile and updateMediaFile

In an ideal design, code that calls create or update (update all fields) the record of Mediafile withDao's is expected to be very limited. Excessively standardized legacy code made the CRUD design ambiguous, making it difficult to improve the design. These are corrected sequentially. After https://github.com/tesshucom/jpsonic/issues/1925, more refactoring will be possible.


