### PR TITLE
Update Libs

### DIFF
--- a/install/docker/alpine-jdk17/pom.xml
+++ b/install/docker/alpine-jdk17/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.13</version>
+        <version>111.5.14</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/alpine-jdk17/pom.xml
+++ b/install/docker/alpine-jdk17/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.14</version>
+        <version>111.5.15</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/jammy/pom.xml
+++ b/install/docker/jammy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.13</version>
+        <version>111.5.14</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/jammy/pom.xml
+++ b/install/docker/jammy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.14</version>
+        <version>111.5.15</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/liberica-jdk11/pom.xml
+++ b/install/docker/liberica-jdk11/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.13</version>
+        <version>111.5.14</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/liberica-jdk11/pom.xml
+++ b/install/docker/liberica-jdk11/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.14</version>
+        <version>111.5.15</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.14</version>
+        <version>111.5.15</version>
     </parent>
 
     <properties>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.13</version>
+        <version>111.5.14</version>
     </parent>
 
     <properties>

--- a/jpsonic-upnp-template/pom.xml
+++ b/jpsonic-upnp-template/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.13</version>
+        <version>111.5.14</version>
     </parent>
 
     <dependencies>

--- a/jpsonic-upnp-template/pom.xml
+++ b/jpsonic-upnp-template/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.14</version>
+        <version>111.5.15</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>111.5.13</version>
+    <version>111.5.14</version>
     <name>Jpsonic</name>
     <packaging>pom</packaging>
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>111.5.14</version>
+    <version>111.5.15</version>
     <name>Jpsonic</name>
     <packaging>pom</packaging>
     <organization>

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.14</version>
+        <version>111.5.15</version>
     </parent>
 
     <dependencies>

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-        <version>111.5.13</version>
+        <version>111.5.14</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
Includes patch release of dependency-check-maven. A bug occurred because a long version string of a specific CVE data exceeded the database field length of dependency-check-maven.

Merged because it interferes with compilation.

> [DependencyCheck](https://github.com/jeremylong/DependencyCheck/issues)
> 
>  - DatabaseException: Error updating 'CVE-2020-36569' `DependencyCheck#5220`
>  - fix: long version of go dependency unable to inserted into software table (CVE-2020-36569)  `DependencyCheck#5229`
