### PR TITLE
Fix the comparison method violates general contract

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/JpMediaFileComparator.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/JpMediaFileComparator.java
@@ -25,6 +25,8 @@ import java.text.Collator;
 import java.util.Comparator;
 
 import org.apache.commons.lang3.ObjectUtils;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Comparator for sorting media files.
@@ -64,7 +66,10 @@ class JpMediaFileComparator implements MediaFileComparator {
         }
 
         if (a.isDirectory() && b.isDirectory()) {
-            return compareDirectory(a, b);
+            i = compareDirectory(a, b);
+            if (i != 0) {
+                return i;
+            }
         }
 
         // Compare by disc and track numbers, if present.
@@ -78,7 +83,7 @@ class JpMediaFileComparator implements MediaFileComparator {
         return comparator.compare(a.getPathString(), b.getPathString());
     }
 
-    private int compareDirectoryAndFile(MediaFile a, MediaFile b) {
+    int compareDirectoryAndFile(MediaFile a, MediaFile b) {
         if (a.isFile() && b.isDirectory()) {
             return 1;
         }
@@ -88,7 +93,7 @@ class JpMediaFileComparator implements MediaFileComparator {
         return 0;
     }
 
-    private int compareAlbumAndNotAlbum(MediaFile a, MediaFile b) {
+    int compareAlbumAndNotAlbum(@NonNull MediaFile a, @NonNull MediaFile b) {
         if (a.isAlbum() && b.getMediaType() == MediaFile.MediaType.DIRECTORY) {
             return 1;
         }
@@ -99,7 +104,7 @@ class JpMediaFileComparator implements MediaFileComparator {
     }
 
     @SuppressWarnings("PMD.ConfusingTernary") // false positive
-    private int compareDirectory(MediaFile a, MediaFile b) {
+    int compareDirectory(@NonNull MediaFile a, @NonNull MediaFile b) {
         int n;
         if (a.isAlbum() && b.isAlbum() && !isEmpty(a.getAlbumReading()) && !isEmpty(b.getAlbumReading())) {
             n = comparator.compare(a.getAlbumReading(), b.getAlbumReading());
@@ -112,7 +117,7 @@ class JpMediaFileComparator implements MediaFileComparator {
         // MediaFile.equals()
     }
 
-    private <T extends Comparable<T>> int nullSafeCompare(T a, T b, boolean nullIsSmaller) {
+    <T extends Comparable<T>> int nullSafeCompare(@Nullable T a, @Nullable T b, boolean nullIsSmaller) {
         if (a == null && b == null) {
             return 0;
         }
@@ -125,7 +130,8 @@ class JpMediaFileComparator implements MediaFileComparator {
         return a.compareTo(b);
     }
 
-    private Integer getSortableDiscAndTrackNumber(MediaFile file) {
+    @Nullable
+    Integer getSortableDiscAndTrackNumber(@NonNull MediaFile file) {
         Integer trackNumber = file.getTrackNumber();
         if (trackNumber == null) {
             return null;
@@ -133,5 +139,4 @@ class JpMediaFileComparator implements MediaFileComparator {
         int discNumber = ObjectUtils.defaultIfNull(file.getDiscNumber(), 1);
         return discNumber * 1000 + trackNumber;
     }
-
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/JpMediaFileComparator.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/JpMediaFileComparator.java
@@ -19,6 +19,7 @@
 
 package com.tesshu.jpsonic.domain;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import java.text.Collator;
@@ -58,14 +59,14 @@ class JpMediaFileComparator implements MediaFileComparator {
         }
 
         // Sort albums by year
-        if (sortAlbumsByYear && a.isAlbum() && b.isAlbum()) {
+        if (sortAlbumsByYear && a.isAlbum()) {
             i = nullSafeCompare(a.getYear(), b.getYear(), false);
             if (i != 0) {
                 return i;
             }
         }
 
-        if (a.isDirectory() && b.isDirectory()) {
+        if (a.isDirectory()) {
             i = compareDirectory(a, b);
             if (i != 0) {
                 return i;
@@ -103,18 +104,11 @@ class JpMediaFileComparator implements MediaFileComparator {
         return 0;
     }
 
-    @SuppressWarnings("PMD.ConfusingTernary") // false positive
-    int compareDirectory(@NonNull MediaFile a, @NonNull MediaFile b) {
-        int n;
+    int compareDirectory(MediaFile a, MediaFile b) {
         if (a.isAlbum() && b.isAlbum() && !isEmpty(a.getAlbumReading()) && !isEmpty(b.getAlbumReading())) {
-            n = comparator.compare(a.getAlbumReading(), b.getAlbumReading());
-        } else if (!a.isAlbum() && !b.isAlbum() && !isEmpty(a.getArtistReading()) && !isEmpty(b.getArtistReading())) {
-            n = comparator.compare(a.getArtistReading(), b.getArtistReading());
-        } else {
-            n = comparator.compare(a.getName(), b.getName());
+            return comparator.compare(a.getAlbumReading(), b.getAlbumReading());
         }
-        return n == 0 ? comparator.compare(a.getPathString(), b.getPathString()) : n; // To make it consistent to
-        // MediaFile.equals()
+        return comparator.compare(defaultString(a.getArtistReading()), defaultString(b.getArtistReading()));
     }
 
     <T extends Comparable<T>> int nullSafeCompare(@Nullable T a, @Nullable T b, boolean nullIsSmaller) {

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JpMediaFileComparatorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JpMediaFileComparatorTest.java
@@ -135,7 +135,6 @@ class JpMediaFileComparatorTest {
                 assertEquals(0, sortAlbumsByYear.compare(file1, file1));
                 assertEquals(0, sortAlbumsByYear.compare(file2, file2));
             }
-
         }
 
         @Test
@@ -163,6 +162,31 @@ class JpMediaFileComparatorTest {
             MediaFile file2 = new MediaFile();
             file2.setPathString("path2");
             file2.setMediaType(MediaType.MUSIC);
+
+            assertEquals(-1, alphabetical.compare(file1, file2));
+            assertEquals(1, alphabetical.compare(file2, file1));
+            assertEquals(0, sortAlbumsByYear.compare(file1, file1));
+            assertEquals(0, sortAlbumsByYear.compare(file2, file2));
+        }
+
+        @Test
+        void testComparePathForDirectory() {
+            MediaFile file1 = new MediaFile();
+            file1.setPathString("path1");
+            file1.setMediaType(MediaType.DIRECTORY);
+            file1.setArtistReading("reading");
+            MediaFile file2 = new MediaFile();
+            file2.setPathString("path2");
+            file2.setMediaType(MediaType.DIRECTORY);
+            file2.setArtistReading("reading");
+
+            assertEquals(-1, alphabetical.compare(file1, file2));
+            assertEquals(1, alphabetical.compare(file2, file1));
+            assertEquals(0, sortAlbumsByYear.compare(file1, file1));
+            assertEquals(0, sortAlbumsByYear.compare(file2, file2));
+
+            file1.setArtistReading("reading1");
+            file2.setArtistReading("reading2");
 
             assertEquals(-1, alphabetical.compare(file1, file2));
             assertEquals(1, alphabetical.compare(file2, file1));
@@ -207,66 +231,6 @@ class JpMediaFileComparatorTest {
     class CompareDirectoryTest {
 
         @Test
-        void testCompareForPath() {
-            MediaFile file1 = new MediaFile();
-            file1.setPathString("path1");
-            MediaFile file2 = new MediaFile();
-            file2.setPathString("path2");
-
-            assertEquals("path1", file1.getName());
-            assertEquals("path2", file2.getName());
-            assertEquals(-1, alphabetical.compareDirectory(file1, file2));
-            assertEquals(1, alphabetical.compareDirectory(file2, file1));
-        }
-
-        @Test
-        void testCompareForTitle() {
-            MediaFile file1 = new MediaFile();
-            file1.setPathString("path1");
-            file1.setTitle("title1");
-            MediaFile file2 = new MediaFile();
-            file2.setPathString("path2");
-            file2.setTitle("title2");
-
-            assertEquals("title1", file1.getName());
-            assertEquals("title2", file2.getName());
-            assertEquals(-1, alphabetical.compareDirectory(file1, file2));
-            assertEquals(1, alphabetical.compareDirectory(file2, file1));
-        }
-
-        @Test
-        void testCompareForSameTitle() {
-            MediaFile file1 = new MediaFile();
-            file1.setPathString("path1");
-            file1.setTitle("title");
-            MediaFile file2 = new MediaFile();
-            file2.setPathString("path2");
-            file2.setTitle("title");
-
-            assertEquals("title", file1.getName());
-            assertEquals("title", file2.getName());
-            assertEquals(-1, alphabetical.compareDirectory(file1, file2));
-            assertEquals(1, alphabetical.compareDirectory(file2, file1));
-            assertEquals(0, alphabetical.compareDirectory(file1, file1));
-            assertEquals(0, alphabetical.compareDirectory(file2, file2));
-        }
-
-        @Test
-        void testCompareForSameTitleAndPath() {
-            MediaFile file1 = new MediaFile();
-            file1.setPathString("path");
-            MediaFile file2 = new MediaFile();
-            file2.setPathString("path");
-
-            file1.setTitle("title");
-            assertEquals("title", file1.getName());
-            file2.setTitle("title");
-            assertEquals("title", file2.getName());
-            assertEquals(0, alphabetical.compareDirectory(file1, file2));
-            assertEquals(0, alphabetical.compareDirectory(file2, file1));
-        }
-
-        @Test
         void testCompareForAlbumReading() {
             MediaFile file1 = new MediaFile();
             file1.setPathString("path1");
@@ -276,16 +240,16 @@ class JpMediaFileComparatorTest {
             assertEquals("path2", file2.getName());
 
             file1.setMediaType(MediaType.ALBUM);
-            assertEquals(-1, alphabetical.compareDirectory(file1, file2));
-            assertEquals(1, alphabetical.compareDirectory(file2, file1));
+            assertEquals(0, alphabetical.compareDirectory(file1, file2));
+            assertEquals(0, alphabetical.compareDirectory(file2, file1));
 
             file2.setMediaType(MediaType.ALBUM);
-            assertEquals(-1, alphabetical.compareDirectory(file1, file2));
-            assertEquals(1, alphabetical.compareDirectory(file2, file1));
+            assertEquals(0, alphabetical.compareDirectory(file1, file2));
+            assertEquals(0, alphabetical.compareDirectory(file2, file1));
 
             file1.setAlbumReading("albumReading1");
-            assertEquals(-1, alphabetical.compareDirectory(file1, file2));
-            assertEquals(1, alphabetical.compareDirectory(file2, file1));
+            assertEquals(0, alphabetical.compareDirectory(file1, file2));
+            assertEquals(0, alphabetical.compareDirectory(file2, file1));
 
             file2.setAlbumReading("albumReading2");
             assertEquals(-1, alphabetical.compareDirectory(file1, file2));
@@ -304,16 +268,16 @@ class JpMediaFileComparatorTest {
             assertEquals("path2", file2.getName());
 
             file1.setMediaType(MediaType.DIRECTORY);
-            assertEquals(-1, alphabetical.compareDirectory(file1, file2));
-            assertEquals(1, alphabetical.compareDirectory(file2, file1));
+            assertEquals(0, alphabetical.compareDirectory(file1, file2));
+            assertEquals(0, alphabetical.compareDirectory(file2, file1));
 
             file2.setMediaType(MediaType.DIRECTORY);
-            assertEquals(-1, alphabetical.compareDirectory(file1, file2));
-            assertEquals(1, alphabetical.compareDirectory(file2, file1));
+            assertEquals(0, alphabetical.compareDirectory(file1, file2));
+            assertEquals(0, alphabetical.compareDirectory(file2, file1));
 
             file1.setArtistReading("artistReading1");
-            assertEquals(-1, alphabetical.compareDirectory(file1, file2));
-            assertEquals(1, alphabetical.compareDirectory(file2, file1));
+            assertEquals(1, alphabetical.compareDirectory(file1, file2));
+            assertEquals(-1, alphabetical.compareDirectory(file2, file1));
 
             file2.setArtistReading("artistReading2");
             assertEquals(-1, alphabetical.compareDirectory(file1, file2));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JpMediaFileComparatorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JpMediaFileComparatorTest.java
@@ -1,0 +1,358 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2023 tesshucom
+ */
+
+package com.tesshu.jpsonic.domain;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.text.Collator;
+import java.util.Locale;
+
+import com.tesshu.jpsonic.domain.MediaFile.MediaType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class JpMediaFileComparatorTest {
+
+    private JpMediaFileComparator alphabetical;
+    private JpMediaFileComparator sortAlbumsByYear;
+
+    @BeforeEach
+    public void setup() {
+        Collator c = Collator.getInstance(Locale.US);
+        alphabetical = new JpMediaFileComparator(false, c);
+        sortAlbumsByYear = new JpMediaFileComparator(true, c);
+    }
+
+    @Nested
+    class CompareTest {
+
+        @Test
+        void testCompareDirectoryAndFile() {
+            MediaFile file1 = new MediaFile();
+            file1.setPathString("path1");
+            file1.setMediaType(MediaType.DIRECTORY);
+            MediaFile file2 = new MediaFile();
+            file2.setPathString("path2");
+            file2.setMediaType(MediaType.MUSIC);
+
+            assertTrue(file1.isDirectory());
+            assertTrue(file2.isFile());
+            assertEquals(-1, alphabetical.compare(file1, file2));
+            assertEquals(1, alphabetical.compare(file2, file1));
+            assertEquals(0, alphabetical.compare(file1, file1));
+            assertEquals(0, alphabetical.compare(file2, file2));
+        }
+
+        @Test
+        void testCompareAlbumAndNotAlbum() {
+            MediaFile file1 = new MediaFile();
+            file1.setPathString("path1");
+            file1.setMediaType(MediaType.DIRECTORY);
+            MediaFile file2 = new MediaFile();
+            file2.setPathString("path2");
+            file2.setMediaType(MediaType.ALBUM);
+
+            assertEquals(-1, alphabetical.compare(file1, file2));
+            assertEquals(1, alphabetical.compare(file2, file1));
+            assertEquals(0, alphabetical.compare(file1, file1));
+            assertEquals(0, alphabetical.compare(file2, file2));
+        }
+
+        @Test
+        void testCompareAlbumsByYear() {
+            MediaFile file1 = new MediaFile();
+            file1.setPathString("path1");
+            file1.setYear(1900);
+            MediaFile file2 = new MediaFile();
+            file2.setPathString("path2");
+            file2.setYear(2000);
+
+            file1.setMediaType(MediaType.ALBUM);
+            file2.setMediaType(MediaType.ALBUM);
+            assertEquals(-1, sortAlbumsByYear.compare(file1, file2));
+            assertEquals(1, sortAlbumsByYear.compare(file2, file1));
+            assertEquals(0, sortAlbumsByYear.compare(file1, file1));
+            assertEquals(0, sortAlbumsByYear.compare(file2, file2));
+
+            file1.setMediaType(MediaType.ALBUM);
+            file2.setMediaType(MediaType.DIRECTORY);
+            assertEquals(1, sortAlbumsByYear.compare(file1, file2));
+            assertEquals(-1, sortAlbumsByYear.compare(file2, file1));
+            assertEquals(0, sortAlbumsByYear.compare(file1, file1));
+            assertEquals(0, sortAlbumsByYear.compare(file2, file2));
+        }
+
+        @Nested
+        class CompareDirectoryTest {
+
+            @Test
+            void testCompareDirectory() {
+                MediaFile file1 = new MediaFile();
+                file1.setPathString("path1");
+                file1.setMediaType(MediaType.DIRECTORY);
+                MediaFile file2 = new MediaFile();
+                file2.setPathString("path2");
+                file2.setMediaType(MediaType.DIRECTORY);
+
+                assertEquals(-1, alphabetical.compare(file1, file2));
+                assertEquals(1, alphabetical.compare(file2, file1));
+                assertEquals(0, sortAlbumsByYear.compare(file1, file1));
+                assertEquals(0, sortAlbumsByYear.compare(file2, file2));
+            }
+
+            @Test
+            void testCompareDirectoryAndAlbum() {
+                MediaFile file1 = new MediaFile();
+                file1.setPathString("path1");
+                file1.setMediaType(MediaType.DIRECTORY);
+                MediaFile file2 = new MediaFile();
+                file2.setPathString("path2");
+                file2.setMediaType(MediaType.ALBUM);
+
+                assertEquals(-1, alphabetical.compare(file1, file2));
+                assertEquals(1, alphabetical.compare(file2, file1));
+                assertEquals(0, sortAlbumsByYear.compare(file1, file1));
+                assertEquals(0, sortAlbumsByYear.compare(file2, file2));
+            }
+
+        }
+
+        @Test
+        void testCompareDiscAndTrackNumber() {
+            MediaFile file1 = new MediaFile();
+            file1.setPathString("path1");
+            file1.setMediaType(MediaType.MUSIC);
+            file1.setTrackNumber(1);
+            MediaFile file2 = new MediaFile();
+            file2.setPathString("path2");
+            file2.setMediaType(MediaType.MUSIC);
+            file2.setTrackNumber(2);
+
+            assertEquals(-1, alphabetical.compare(file1, file2));
+            assertEquals(1, alphabetical.compare(file2, file1));
+            assertEquals(0, sortAlbumsByYear.compare(file1, file1));
+            assertEquals(0, sortAlbumsByYear.compare(file2, file2));
+        }
+
+        @Test
+        void testComparePath() {
+            MediaFile file1 = new MediaFile();
+            file1.setPathString("path1");
+            file1.setMediaType(MediaType.MUSIC);
+            MediaFile file2 = new MediaFile();
+            file2.setPathString("path2");
+            file2.setMediaType(MediaType.MUSIC);
+
+            assertEquals(-1, alphabetical.compare(file1, file2));
+            assertEquals(1, alphabetical.compare(file2, file1));
+            assertEquals(0, sortAlbumsByYear.compare(file1, file1));
+            assertEquals(0, sortAlbumsByYear.compare(file2, file2));
+        }
+    }
+
+    @Test
+    void testCompareDirectoryAndFile() {
+        MediaFile file1 = new MediaFile();
+        file1.setPathString("path1");
+        file1.setMediaType(MediaType.DIRECTORY);
+        MediaFile file2 = new MediaFile();
+        file2.setPathString("path2");
+        file2.setMediaType(MediaType.MUSIC);
+
+        assertTrue(file1.isDirectory());
+        assertTrue(file2.isFile());
+        assertEquals(-1, alphabetical.compareDirectoryAndFile(file1, file2));
+        assertEquals(1, alphabetical.compareDirectoryAndFile(file2, file1));
+        assertEquals(0, alphabetical.compareDirectoryAndFile(file1, file1));
+        assertEquals(0, alphabetical.compareDirectoryAndFile(file2, file2));
+    }
+
+    @Test
+    void testCompareAlbumAndNotAlbum() {
+        MediaFile file1 = new MediaFile();
+        file1.setPathString("path1");
+        file1.setMediaType(MediaType.DIRECTORY);
+        MediaFile file2 = new MediaFile();
+        file2.setPathString("path2");
+        file2.setMediaType(MediaType.ALBUM);
+
+        assertEquals(-1, alphabetical.compareAlbumAndNotAlbum(file1, file2));
+        assertEquals(1, alphabetical.compareAlbumAndNotAlbum(file2, file1));
+        assertEquals(0, alphabetical.compareAlbumAndNotAlbum(file1, file1));
+        assertEquals(0, alphabetical.compareAlbumAndNotAlbum(file2, file2));
+    }
+
+    @Nested
+    class CompareDirectoryTest {
+
+        @Test
+        void testCompareForPath() {
+            MediaFile file1 = new MediaFile();
+            file1.setPathString("path1");
+            MediaFile file2 = new MediaFile();
+            file2.setPathString("path2");
+
+            assertEquals("path1", file1.getName());
+            assertEquals("path2", file2.getName());
+            assertEquals(-1, alphabetical.compareDirectory(file1, file2));
+            assertEquals(1, alphabetical.compareDirectory(file2, file1));
+        }
+
+        @Test
+        void testCompareForTitle() {
+            MediaFile file1 = new MediaFile();
+            file1.setPathString("path1");
+            file1.setTitle("title1");
+            MediaFile file2 = new MediaFile();
+            file2.setPathString("path2");
+            file2.setTitle("title2");
+
+            assertEquals("title1", file1.getName());
+            assertEquals("title2", file2.getName());
+            assertEquals(-1, alphabetical.compareDirectory(file1, file2));
+            assertEquals(1, alphabetical.compareDirectory(file2, file1));
+        }
+
+        @Test
+        void testCompareForSameTitle() {
+            MediaFile file1 = new MediaFile();
+            file1.setPathString("path1");
+            file1.setTitle("title");
+            MediaFile file2 = new MediaFile();
+            file2.setPathString("path2");
+            file2.setTitle("title");
+
+            assertEquals("title", file1.getName());
+            assertEquals("title", file2.getName());
+            assertEquals(-1, alphabetical.compareDirectory(file1, file2));
+            assertEquals(1, alphabetical.compareDirectory(file2, file1));
+            assertEquals(0, alphabetical.compareDirectory(file1, file1));
+            assertEquals(0, alphabetical.compareDirectory(file2, file2));
+        }
+
+        @Test
+        void testCompareForSameTitleAndPath() {
+            MediaFile file1 = new MediaFile();
+            file1.setPathString("path");
+            MediaFile file2 = new MediaFile();
+            file2.setPathString("path");
+
+            file1.setTitle("title");
+            assertEquals("title", file1.getName());
+            file2.setTitle("title");
+            assertEquals("title", file2.getName());
+            assertEquals(0, alphabetical.compareDirectory(file1, file2));
+            assertEquals(0, alphabetical.compareDirectory(file2, file1));
+        }
+
+        @Test
+        void testCompareForAlbumReading() {
+            MediaFile file1 = new MediaFile();
+            file1.setPathString("path1");
+            MediaFile file2 = new MediaFile();
+            file2.setPathString("path2");
+            assertEquals("path1", file1.getName());
+            assertEquals("path2", file2.getName());
+
+            file1.setMediaType(MediaType.ALBUM);
+            assertEquals(-1, alphabetical.compareDirectory(file1, file2));
+            assertEquals(1, alphabetical.compareDirectory(file2, file1));
+
+            file2.setMediaType(MediaType.ALBUM);
+            assertEquals(-1, alphabetical.compareDirectory(file1, file2));
+            assertEquals(1, alphabetical.compareDirectory(file2, file1));
+
+            file1.setAlbumReading("albumReading1");
+            assertEquals(-1, alphabetical.compareDirectory(file1, file2));
+            assertEquals(1, alphabetical.compareDirectory(file2, file1));
+
+            file2.setAlbumReading("albumReading2");
+            assertEquals(-1, alphabetical.compareDirectory(file1, file2));
+            assertEquals(1, alphabetical.compareDirectory(file2, file1));
+            assertEquals(0, alphabetical.compareDirectory(file1, file1));
+            assertEquals(0, alphabetical.compareDirectory(file2, file2));
+        }
+
+        @Test
+        void testCompareForArtistReading() {
+            MediaFile file1 = new MediaFile();
+            file1.setPathString("path1");
+            MediaFile file2 = new MediaFile();
+            file2.setPathString("path2");
+            assertEquals("path1", file1.getName());
+            assertEquals("path2", file2.getName());
+
+            file1.setMediaType(MediaType.DIRECTORY);
+            assertEquals(-1, alphabetical.compareDirectory(file1, file2));
+            assertEquals(1, alphabetical.compareDirectory(file2, file1));
+
+            file2.setMediaType(MediaType.DIRECTORY);
+            assertEquals(-1, alphabetical.compareDirectory(file1, file2));
+            assertEquals(1, alphabetical.compareDirectory(file2, file1));
+
+            file1.setArtistReading("artistReading1");
+            assertEquals(-1, alphabetical.compareDirectory(file1, file2));
+            assertEquals(1, alphabetical.compareDirectory(file2, file1));
+
+            file2.setArtistReading("artistReading2");
+            assertEquals(-1, alphabetical.compareDirectory(file1, file2));
+            assertEquals(1, alphabetical.compareDirectory(file2, file1));
+            assertEquals(0, alphabetical.compareDirectory(file1, file1));
+        }
+    }
+
+    @Test
+    void testNullSafeCompare() {
+
+        /*
+         * This affects the specification of precedence when there is a mix of input and non-input data for song numbers
+         * and year.
+         */
+        boolean nullIsSmaller = false;
+        assertEquals(0, alphabetical.nullSafeCompare(null, null, nullIsSmaller));
+        assertEquals(-1, alphabetical.nullSafeCompare("1", null, nullIsSmaller));
+        assertEquals(1, alphabetical.nullSafeCompare(null, "1", nullIsSmaller));
+        assertEquals(0, alphabetical.nullSafeCompare("1", "1", nullIsSmaller));
+        assertEquals(-1, alphabetical.nullSafeCompare("1", "2", nullIsSmaller));
+        assertEquals(1, alphabetical.nullSafeCompare("2", "1", nullIsSmaller));
+
+        nullIsSmaller = true; // This is not currently used
+        assertEquals(0, alphabetical.nullSafeCompare(null, null, nullIsSmaller));
+        assertEquals(1, alphabetical.nullSafeCompare("1", null, nullIsSmaller)); // reverse
+        assertEquals(-1, alphabetical.nullSafeCompare(null, "1", nullIsSmaller)); // reverse
+        assertEquals(0, alphabetical.nullSafeCompare("1", "1", nullIsSmaller));
+        assertEquals(-1, alphabetical.nullSafeCompare("1", "2", nullIsSmaller));
+        assertEquals(1, alphabetical.nullSafeCompare("2", "1", nullIsSmaller));
+    }
+
+    @Test
+    void testGetSortableDiscAndTrackNumber() {
+        MediaFile file = new MediaFile();
+        assertNull(alphabetical.getSortableDiscAndTrackNumber(file));
+        file.setTrackNumber(2);
+        assertEquals(1002, alphabetical.getSortableDiscAndTrackNumber(file));
+        file.setDiscNumber(5);
+        assertEquals(5002, alphabetical.getSortableDiscAndTrackNumber(file));
+    }
+}


### PR DESCRIPTION
## Problem description

Fix for #1986. 

When there is data with a combination of specific data patterns, an error occurs at the time of sorting with probability. Incomplete Transitivity Implementation of Comparator Causes Timsort to Error.

## System information

 * **Java version**: All
 * **Jpsonic version**: Mostly since v111.5.11 (with postgres?)
 
 - This is a latent bug and has been around for a long time. But this is my first bug report.
 - Realistically, it is assumed that the probability of occurrence has increased after v111.5.11. Bug fixed in v111.5.11, Postgres is now available. #1950
   - It's tedious to reproduce situations where sort transitivity violates the convention. Depending on the size of the list and the position of the cause, even if the underlying data pattern is present in the list, it cannot be reproduce. 
     - In my environment, the exact same library was newly scanned with the default embedded DB and Postgres and an attempt was made to reproduce it. I couldn't reproduce it with the default HSQLDB, but I could reproduce it with Postgres by accident.
     - I've never seen it happen in HSQLDB. Combining the sorting implementation before modification with Postgres sorting rules might increase the chances of being reproducible. (HSQLDB and Postgres default sorting rules are different.)
