### PR TITLE
Fix not to index podcast genres

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
@@ -6,6 +6,7 @@ import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
@@ -139,18 +140,21 @@ public class ScannerProcedureService {
 
     void beforeScan(@NonNull Instant scanDate) {
 
+        indexManager.startIndexing();
+
         // TODO To be fixed in v111.6.0
         if (settingsService.isIgnoreFileTimestampsNext()) {
+            indexManager.expungeGenreOtherThan(Collections.emptyList());
             mediaFileDao.resetLastScanned();
             settingsService.setIgnoreFileTimestampsNext(false);
             settingsService.save();
         } else if (settingsService.isIgnoreFileTimestamps()) {
+            indexManager.expungeGenreOtherThan(Collections.emptyList());
             mediaFileDao.resetLastScanned();
         }
 
         indexCache.removeAll();
         mediaFileCache.setEnabled(false);
-        indexManager.startIndexing();
         mediaFileCache.removeAll();
 
         createScanEvent(scanDate, ScanEventType.BEFORE_SCAN, null);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/DocumentFactory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/DocumentFactory.java
@@ -48,6 +48,7 @@ import com.tesshu.jpsonic.domain.Artist;
 import com.tesshu.jpsonic.domain.IndexScheme;
 import com.tesshu.jpsonic.domain.JapaneseReadingUtils;
 import com.tesshu.jpsonic.domain.MediaFile;
+import com.tesshu.jpsonic.domain.MediaFile.MediaType;
 import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.service.SettingsService;
 import org.apache.lucene.document.Document;
@@ -288,7 +289,9 @@ public class DocumentFactory {
         applyFieldValue(doc, COMPOSER, mediaFile.getComposer());
         acceptComposerReading(doc, mediaFile.getComposer(), mediaFile.getComposerSortRaw(),
                 mediaFile.getComposerSort());
-        applyGenre(doc, mediaFile.getGenre());
+        if (mediaFile.getMediaType() != MediaType.PODCAST) {
+            applyGenre(doc, mediaFile.getGenre());
+        }
         applyFieldYear(doc, YEAR, mediaFile.getYear());
         applyFieldFolderPath(doc, mediaFile.getFolder());
         return doc;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
@@ -49,6 +49,7 @@ import com.tesshu.jpsonic.domain.Artist;
 import com.tesshu.jpsonic.domain.Genre;
 import com.tesshu.jpsonic.domain.JpsonicComparators;
 import com.tesshu.jpsonic.domain.MediaFile;
+import com.tesshu.jpsonic.domain.MediaFile.MediaType;
 import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.service.SettingsService;
 import com.tesshu.jpsonic.service.scanner.ScannerStateServiceImpl;
@@ -178,7 +179,7 @@ public class IndexManager {
     }
 
     @ThreadSafe(enableChecks = false) // False positive. writers#get#updateDocument is atomic.
-    public void index(MediaFile mediaFile) {
+    public void index(@NonNull MediaFile mediaFile) {
         Term primarykey = DocumentFactory.createPrimarykey(mediaFile);
         try {
             if (mediaFile.isFile()) {
@@ -192,7 +193,7 @@ public class IndexManager {
                 writers.get(IndexType.ARTIST).updateDocument(primarykey, document);
             }
             String genre = mediaFile.getGenre();
-            if (!isEmpty(genre)) {
+            if (!isEmpty(genre) && mediaFile.getMediaType() != MediaType.PODCAST) {
                 Term genrekey = DocumentFactory.createPrimarykey(genre);
                 Document document = documentFactory.createGenreDocument(mediaFile);
                 writers.get(IndexType.GENRE).updateDocument(genrekey, document);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/DocumentFactoryTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/DocumentFactoryTest.java
@@ -231,6 +231,12 @@ class DocumentFactoryTest {
         final MediaFile file = new MediaFile();
         assertNull(file.getMediaType(), "MediaType is a required item.");
         assertThrows(NullPointerException.class, () -> documentFactory.createSongDocument(file));
+
+        MediaFile podcast = new MediaFile();
+        podcast.setFolder("folder");
+        podcast.setMediaType(MediaType.PODCAST);
+        document = documentFactory.createSongDocument(podcast);
+        assertNull(document.get(FieldNamesConstants.GENRE));
     }
 
     @Test


### PR DESCRIPTION
#### Overview

If a song file obtained as a podcast contains a genre tag, an empty genre will be generated in the genre search. 

![image](https://user-images.githubusercontent.com/27724847/220967879-eaef4e49-6712-464a-931e-4632a5c3bffb.png)

#### Fixes

The Sonic server internally classifies media types to search for songs, videos, and podcasts. This bug is caused by the fact that Podcasts are included in Genre Master registration targets at the time of scanning. This commit fixes an extra registration in case of podcasts.

#### Impact

 - In the case of normal specifications, this bug will be fixed.
 - Podcast genre tags will be indexed if a music directory is registered with the same path as the podcast directory path. This is the current specification.
   - Although not very elegant, it is sometimes used in this manner as the next best for problems such as:
     - If you want to search podcasts locally.
     - If you want to listen to podcasts on the Subsonic app that doesn't have a podcast interface (By the way, Jpsonic's UPnP can use podcasts without taking such a method.)
   - If you want to go back to normal use, enable "Ignore Timestamps" and scan.

___

I know the podcast search implementation might not be kind, but there's a reason it's not fixed soon.

  - Podcast has more significant fixes, and those fixes are planned for later versions. Starting now is not a good idea.
  - To avoid increasing the index size blindly. So even if better search is offered in the future, it should be an optional feature.
