### PR TITLE
Bump Lucene from 8.11.2 to 9.5.0

### DIFF
--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <chameleon.version>1.2.1-RELEASE</chameleon.version>
         <tomcat.server.scope>provided</tomcat.server.scope>
-        <lucene.version>8.11.2</lucene.version>
+        <lucene.version>9.5.0</lucene.version>
     </properties>
 
     <dependencies>
@@ -149,7 +149,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-analyzers-common</artifactId>
+            <artifactId>lucene-analysis-common</artifactId>
             <version>${lucene.version}</version>
         </dependency>
         <dependency>
@@ -159,7 +159,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-analyzers-kuromoji</artifactId>
+            <artifactId>lucene-analysis-kuromoji</artifactId>
             <version>${lucene.version}</version>
         </dependency>
         <dependency>

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/InternalHelpController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/InternalHelpController.java
@@ -54,7 +54,6 @@ import com.tesshu.jpsonic.service.SecurityService;
 import com.tesshu.jpsonic.service.SettingsService;
 import com.tesshu.jpsonic.service.TranscodingService;
 import com.tesshu.jpsonic.service.VersionService;
-import com.tesshu.jpsonic.service.search.AnalyzerFactory;
 import com.tesshu.jpsonic.service.search.IndexManager;
 import com.tesshu.jpsonic.service.search.IndexType;
 import com.tesshu.jpsonic.spring.DatabaseConfiguration.ProfileNameConstants;
@@ -62,9 +61,9 @@ import com.tesshu.jpsonic.util.FileUtil;
 import com.tesshu.jpsonic.util.LegacyMap;
 import org.apache.commons.io.input.ReversedLinesFileReader;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.util.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
@@ -92,7 +91,6 @@ public class InternalHelpController {
     private final SecurityService securityService;
     private final IndexManager indexManager;
     private final DaoHelper daoHelper;
-    private final AnalyzerFactory analyzerFactory;
     private final MusicFolderDao musicFolderDao;
     private final TranscodingService transcodingService;
     private final Environment environment;
@@ -100,15 +98,14 @@ public class InternalHelpController {
 
     public InternalHelpController(VersionService versionService, SettingsService settingsService,
             SecurityService securityService, IndexManager indexManager, DaoHelper daoHelper,
-            AnalyzerFactory analyzerFactory, MusicFolderDao musicFolderDao, TranscodingService transcodingService,
-            Environment environment, StaticsDao staticsDao) {
+            MusicFolderDao musicFolderDao, TranscodingService transcodingService, Environment environment,
+            StaticsDao staticsDao) {
         super();
         this.versionService = versionService;
         this.settingsService = settingsService;
         this.securityService = securityService;
         this.indexManager = indexManager;
         this.daoHelper = daoHelper;
-        this.analyzerFactory = analyzerFactory;
         this.musicFolderDao = musicFolderDao;
         this.transcodingService = transcodingService;
         this.environment = environment;
@@ -198,10 +195,7 @@ public class InternalHelpController {
             }
         }
         map.put("indexStatistics", indexStats);
-
-        try (Analyzer analyzer = analyzerFactory.getAnalyzer()) {
-            map.put("indexLuceneVersion", analyzer.getVersion().toString());
-        }
+        map.put("indexLuceneVersion", Version.getPackageImplementationVersion());
     }
 
     /**

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
@@ -336,7 +336,7 @@ public class IndexManager {
      * Close Writer of all indexes and update SearcherManager. Called at the end of the Scan flow.
      */
     public void stopIndexing() {
-        Arrays.asList(IndexType.values()).forEach(indexType -> stopIndexing(indexType));
+        Arrays.asList(IndexType.values()).forEach(this::stopIndexing);
         clearMultiGenreMaster();
     }
 
@@ -348,6 +348,9 @@ public class IndexManager {
         boolean isUpdate = false;
         // close
         try (IndexWriter writer = writers.get(type)) {
+            if (writer == null) {
+                return;
+            }
             isUpdate = -1 != writers.get(type).commit();
             writer.close();
             writers.remove(type);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/analysis/ComplementaryFilterFactory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/analysis/ComplementaryFilterFactory.java
@@ -22,8 +22,8 @@ package com.tesshu.jpsonic.service.search.analysis;
 import java.util.Map;
 
 import com.tesshu.jpsonic.service.search.analysis.ComplementaryFilter.Mode;
+import org.apache.lucene.analysis.TokenFilterFactory;
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.util.TokenFilterFactory;
 
 public class ComplementaryFilterFactory extends TokenFilterFactory {
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/analysis/GenreTokenizerFactory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/analysis/GenreTokenizerFactory.java
@@ -24,8 +24,8 @@ import static org.apache.lucene.analysis.standard.StandardTokenizer.MAX_TOKEN_LE
 import java.util.Map;
 
 import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.TokenizerFactory;
 import org.apache.lucene.analysis.util.CharTokenizer;
-import org.apache.lucene.analysis.util.TokenizerFactory;
 import org.apache.lucene.util.AttributeFactory;
 
 public class GenreTokenizerFactory extends TokenizerFactory {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/analysis/Id3ArtistTokenizerFactory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/analysis/Id3ArtistTokenizerFactory.java
@@ -24,8 +24,8 @@ import static org.apache.lucene.analysis.standard.StandardTokenizer.MAX_TOKEN_LE
 import java.util.Map;
 
 import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.TokenizerFactory;
 import org.apache.lucene.analysis.util.CharTokenizer;
-import org.apache.lucene.analysis.util.TokenizerFactory;
 import org.apache.lucene.util.AttributeFactory;
 
 public class Id3ArtistTokenizerFactory extends TokenizerFactory {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/analysis/PunctuationStemFilterFactory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/analysis/PunctuationStemFilterFactory.java
@@ -21,8 +21,8 @@ package com.tesshu.jpsonic.service.search.analysis;
 
 import java.util.Map;
 
+import org.apache.lucene.analysis.TokenFilterFactory;
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.util.TokenFilterFactory;
 
 public class PunctuationStemFilterFactory extends TokenFilterFactory {
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/analysis/ToHiraganaFilterFactory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/analysis/ToHiraganaFilterFactory.java
@@ -21,8 +21,8 @@ package com.tesshu.jpsonic.service.search.analysis;
 
 import java.util.Map;
 
+import org.apache.lucene.analysis.TokenFilterFactory;
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.util.TokenFilterFactory;
 
 public class ToHiraganaFilterFactory extends TokenFilterFactory {
 


### PR DESCRIPTION
Lucene will upgrade to 9.x.

 - [Apache Lucene Migration Guide for 9.0](https://lucene.apache.org/core/9_0_0/MIGRATE.html)
 - [Apache Lucene Migration Guide for 9.1](https://lucene.apache.org/core/9_1_0/MIGRATE.html)


<details>
<summary>Probably okay</summary>

No signs of significant increase in memory usage.

![image](https://user-images.githubusercontent.com/27724847/221630289-e4269604-034a-4e93-94db-9fbe3387236d.png)

</details>

#### It may be incompatible with 32bit Oracle JDK.

 - [JDK-8134468](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8134468)
 - Docker's arm 32bit is OpenJDK, so probably no problem.
