### PR TITLE
Small cleanup of items on the settings page

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/PersonalSettingsCommand.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/PersonalSettingsCommand.java
@@ -75,6 +75,12 @@ public class PersonalSettingsCommand extends SettingsPageCommons {
     private boolean simpleDisplay;
     private boolean queueFollowingSongs;
     private boolean showCurrentSongInfo;
+
+    // Column to be displayed
+    private UserSettings.Visibility mainVisibility;
+    private UserSettings.Visibility playlistVisibility;
+
+    // Additional display features
     private boolean songNotificationEnabled;
     private boolean voiceInputEnabled;
     private SpeechToTextLangScheme speechToTextLangScheme;
@@ -83,12 +89,6 @@ public class PersonalSettingsCommand extends SettingsPageCommons {
     private String ietfDisplayDefault;
     private boolean openDetailStar;
     private boolean openDetailIndex;
-
-    // Column to be displayed
-    private UserSettings.Visibility mainVisibility;
-    private UserSettings.Visibility playlistVisibility;
-
-    // Additional display features
     private boolean nowPlayingAllowed;
     private boolean othersPlayingEnabled;
     private boolean showNowPlayingEnabled;
@@ -359,6 +359,22 @@ public class PersonalSettingsCommand extends SettingsPageCommons {
         this.showCurrentSongInfo = showCurrentSongInfo;
     }
 
+    public UserSettings.Visibility getMainVisibility() {
+        return mainVisibility;
+    }
+
+    public void setMainVisibility(UserSettings.Visibility mainVisibility) {
+        this.mainVisibility = mainVisibility;
+    }
+
+    public UserSettings.Visibility getPlaylistVisibility() {
+        return playlistVisibility;
+    }
+
+    public void setPlaylistVisibility(UserSettings.Visibility playlistVisibility) {
+        this.playlistVisibility = playlistVisibility;
+    }
+
     public void setSongNotificationEnabled(boolean songNotificationEnabled) {
         this.songNotificationEnabled = songNotificationEnabled;
     }
@@ -421,22 +437,6 @@ public class PersonalSettingsCommand extends SettingsPageCommons {
 
     public void setOpenDetailIndex(boolean openDetailIndex) {
         this.openDetailIndex = openDetailIndex;
-    }
-
-    public UserSettings.Visibility getMainVisibility() {
-        return mainVisibility;
-    }
-
-    public void setMainVisibility(UserSettings.Visibility mainVisibility) {
-        this.mainVisibility = mainVisibility;
-    }
-
-    public UserSettings.Visibility getPlaylistVisibility() {
-        return playlistVisibility;
-    }
-
-    public void setPlaylistVisibility(UserSettings.Visibility playlistVisibility) {
-        this.playlistVisibility = playlistVisibility;
     }
 
     public boolean isNowPlayingAllowed() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PersonalSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/PersonalSettingsController.java
@@ -133,6 +133,12 @@ public class PersonalSettingsController {
         command.setSimpleDisplay(userSettings.isSimpleDisplay());
         command.setQueueFollowingSongs(userSettings.isQueueFollowingSongs());
         command.setShowCurrentSongInfo(userSettings.isShowCurrentSongInfo());
+
+        // Column to be displayed
+        command.setMainVisibility(userSettings.getMainVisibility());
+        command.setPlaylistVisibility(userSettings.getPlaylistVisibility());
+
+        // Additional display features
         command.setSongNotificationEnabled(userSettings.isSongNotificationEnabled());
         command.setVoiceInputEnabled(userSettings.isVoiceInputEnabled());
         command.setSpeechToTextLangScheme(SpeechToTextLangScheme.of(userSettings.getSpeechLangSchemeName()));
@@ -153,12 +159,6 @@ public class PersonalSettingsController {
         command.setOpenDetailSetting(userSettings.isOpenDetailSetting());
         command.setOpenDetailIndex(userSettings.isOpenDetailIndex());
         command.setOpenDetailStar(userSettings.isOpenDetailStar());
-
-        // Column to be displayed
-        command.setMainVisibility(userSettings.getMainVisibility());
-        command.setPlaylistVisibility(userSettings.getPlaylistVisibility());
-
-        // Additional display features
         command.setNowPlayingAllowed(userSettings.isNowPlayingAllowed());
         command.setOthersPlayingEnabled(settingsService.isOthersPlayingEnabled());
         command.setShowNowPlayingEnabled(userSettings.isShowNowPlayingEnabled());
@@ -253,6 +253,12 @@ public class PersonalSettingsController {
         settings.setSimpleDisplay(command.isSimpleDisplay());
         settings.setQueueFollowingSongs(command.isQueueFollowingSongs());
         settings.setShowCurrentSongInfo(command.isShowCurrentSongInfo());
+
+        // Column to be displayed
+        settings.setMainVisibility(command.getMainVisibility());
+        settings.setPlaylistVisibility(command.getPlaylistVisibility());
+
+        // Additional display features
         settings.setSongNotificationEnabled(command.isSongNotificationEnabled());
         settings.setVoiceInputEnabled(command.isVoiceInputEnabled());
         settings.setSpeechLangSchemeName(command.getSpeechToTextLangScheme().name());
@@ -261,12 +267,6 @@ public class PersonalSettingsController {
         } else if (StringUtils.isNotBlank(command.getIetf()) && command.getIetf().matches("[a-zA-Z\\-\\_]+")) {
             settings.setIetf(command.getIetf());
         }
-
-        // Column to be displayed
-        settings.setMainVisibility(command.getMainVisibility());
-        settings.setPlaylistVisibility(command.getPlaylistVisibility());
-
-        // Additional display features
         settings.setNowPlayingAllowed(command.isNowPlayingAllowed());
         settings.setShowNowPlayingEnabled(
                 settingsService.isOthersPlayingEnabled() && command.isShowNowPlayingEnabled());

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/generalSettings.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/generalSettings.jsp
@@ -77,7 +77,7 @@ function resetExtension() {
         </dl>
     </details>
 
-    <details open>
+    <details ${isOpen}>
         <summary class="jpsonic"><fmt:message key="generalsettings.indexsettings"/></summary>
         <c:if test="${command.showOutlineHelp}">
             <div class="outlineHelp">

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/personalSettings.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/personalSettings.jsp
@@ -41,12 +41,6 @@ function setSettings4DesktopPC() {
     $('#assignAccesskeyToNumber').prop('checked', ${command.defaultSettings.assignAccesskeyToNumber});
     $('#simpleDisplay').prop('checked', ${command.defaultSettings.simpleDisplay});
     $('#queueFollowingSongs').prop('checked', ${command.defaultSettings.queueFollowingSongs});
-    $('#openDetailSetting').prop('checked', ${command.defaultSettings.openDetailSetting});
-    $('#openDetailStar').prop('checked', ${command.defaultSettings.openDetailStar});
-    $('#openDetailIndex').prop('checked', ${command.defaultSettings.openDetailIndex});
-    $('#voiceInputEnabled').prop('checked', ${command.defaultSettings.voiceInputEnabled});
-    $("#ietf").val('${command.ietfDefault}');
-    $('#songNotificationEnabled').prop('checked', ${command.defaultSettings.songNotificationEnabled});
     $('#showCurrentSongInfo').prop('checked', ${command.defaultSettings.showCurrentSongInfo});
     speechEngineLangSelectEnabled(false);
 }
@@ -64,12 +58,6 @@ function setSettings4Tablet() {
     $('#assignAccesskeyToNumber').prop('checked', ${command.tabletSettings.assignAccesskeyToNumber});
     $('#simpleDisplay').prop('checked', ${command.tabletSettings.simpleDisplay});
     $('#queueFollowingSongs').prop('checked', ${command.tabletSettings.queueFollowingSongs});
-    $('#openDetailSetting').prop('checked', ${command.tabletSettings.openDetailSetting});
-    $('#openDetailStar').prop('checked', ${command.tabletSettings.openDetailStar});
-    $('#openDetailIndex').prop('checked', ${command.tabletSettings.openDetailIndex});
-    $('#voiceInputEnabled').prop('checked', ${command.tabletSettings.voiceInputEnabled});
-    $("#ietf").val('${command.ietfDefault}');
-    $('#songNotificationEnabled').prop('checked', ${command.tabletSettings.songNotificationEnabled});
     $('#showCurrentSongInfo').prop('checked', ${command.tabletSettings.showCurrentSongInfo});
     speechEngineLangSelectEnabled(true);
 }
@@ -87,12 +75,6 @@ function setSettings4Smartphone() {
     $('#assignAccesskeyToNumber').prop('checked', ${command.smartphoneSettings.assignAccesskeyToNumber});
     $('#simpleDisplay').prop('checked', ${command.smartphoneSettings.simpleDisplay});
     $('#queueFollowingSongs').prop('checked', ${command.smartphoneSettings.queueFollowingSongs});
-    $('#openDetailSetting').prop('checked', ${command.smartphoneSettings.openDetailSetting});
-    $('#openDetailStar').prop('checked', ${command.smartphoneSettings.openDetailStar});
-    $('#openDetailIndex').prop('checked', ${command.smartphoneSettings.openDetailIndex});
-    $('#voiceInputEnabled').prop('checked', ${command.smartphoneSettings.voiceInputEnabled});
-    $("#ietf").val('${command.ietfDefault}');
-    $('#songNotificationEnabled').prop('checked', ${command.smartphoneSettings.songNotificationEnabled});
     $('#showCurrentSongInfo').prop('checked', ${command.smartphoneSettings.showCurrentSongInfo});
     speechEngineLangSelectEnabled(true);
 }
@@ -121,6 +103,15 @@ function resetDisplay() {
 }
 
 function resetAdditionalDisplay() {
+    $('[name="songNotificationEnabled"]').prop('checked', ${command.defaultSettings.songNotificationEnabled});
+    $('[name="voiceInputEnabled"]').prop('checked', ${command.defaultSettings.voiceInputEnabled});
+    $("#ietf").val('${command.ietfDefault}');
+    $("#ietf").prop('disabled', true);
+    $("#radio2-DEFAULT").prop('disabled', true);
+    $("#radio2-BCP47").prop('disabled', true);
+    $('[name="openDetailSetting"]').prop('checked', ${command.defaultSettings.openDetailSetting});
+    $('[name="openDetailStar"]').prop('checked', ${command.defaultSettings.openDetailStar});
+    $('[name="openDetailIndex"]').prop('checked', ${command.defaultSettings.openDetailIndex});
     $('[name="showNowPlayingEnabled"]').prop('checked', ${command.defaultSettings.showNowPlayingEnabled});
     $('[name="nowPlayingAllowed"]').prop('checked', ${command.defaultSettings.nowPlayingAllowed});
     $('[name="showArtistInfoEnabled"]').prop('checked', ${command.defaultSettings.showArtistInfoEnabled});
@@ -383,56 +374,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 <form:checkbox path="showCurrentSongInfo" id="showCurrentSongInfo" />
                 <label for="showCurrentSongInfo"><fmt:message key="personalsettings.showcurrentsonginfo"/></label>
             </dd>
-
-            <dt><fmt:message key="personalsettings.notification"/></dt>
-            <dd>
-                <form:checkbox path="songNotificationEnabled" id="songNotificationEnabled" />
-                <label for="songNotificationEnabled"><fmt:message key="personalsettings.songnotification"/></label>
-            </dd>
-
-            <dt><fmt:message key="personalsettings.speechrecognition"/></dt>
-            <dd>
-                <form:checkbox path="voiceInputEnabled" id="voiceInputEnabled" />
-                <label for="voiceInputEnabled"><fmt:message key="personalsettings.voiceinputenabled"/></label>
-                <c:import url="helpToolTip.jsp"><c:param name="topic" value="voiceinputenabled"/></c:import>
-            </dd>
-            <dt><fmt:message key="personalsettings.speechenginelang"/></dt>
-            <dd>
-                <ul class="playerSettings">
-                    <c:forEach items="${SpeechToTextLangScheme.values()}" var="scheme">
-                        <c:set var="speechLangSchemeName">
-                            <fmt:message key="personalsettings.speechenginelang.${fn:toLowerCase(scheme)}"/>
-                        </c:set>
-                        <li>
-                            <form:radiobutton class="technologyRadio" id="radio2-${scheme}" path="speechToTextLangScheme" value="${scheme}"
-                                checked="${scheme eq command.speechToTextLangScheme ? 'checked' : ''}"
-                                disabled="${!command.voiceInputEnabled}"/>
-                            <label for="radio2-${scheme}">${speechLangSchemeName}</label>
-                            <c:if test="${scheme eq 'DEFAULT'}">
-                                  - ${command.ietfDisplayDefault}
-                            </c:if>
-                            <c:if test="${scheme eq 'BCP47'}">                
-                                <form:input path="ietf" id="ietf" disabled="${command.speechToTextLangScheme eq 'DEFAULT'}"/>
-                            </c:if>
-                        </li>
-                    </c:forEach>
-                </ul>
-            </dd>
-            <dt><fmt:message key="personalsettings.summary"/></dt>
-            <dd>
-                <form:checkbox path="openDetailSetting" id="openDetailSetting" />
-                <label for="openDetailSetting"><fmt:message key="personalsettings.summary.opensettings"/></label>
-            </dd>
-            <dt><fmt:message key="personalsettings.summary"/></dt>
-            <dd>
-                <form:checkbox path="openDetailStar" id="openDetailStar" />
-                <label for="openDetailStar"><fmt:message key="personalsettings.summary.openstars"/></label>
-            </dd>
-            <dt><fmt:message key="personalsettings.summary"/></dt>
-            <dd>
-                <form:checkbox path="openDetailIndex" id="openDetailIndex" />
-                <label for="openDetailIndex"><fmt:message key="personalsettings.summary.openindexes"/></label>
-            </dd>
         </dl>
     </details>
 
@@ -529,6 +470,55 @@ document.addEventListener('DOMContentLoaded', function () {
             </div>
         </c:if>
         <dl>
+            <dt><fmt:message key="personalsettings.notification"/></dt>
+            <dd>
+                <form:checkbox path="songNotificationEnabled" id="songNotificationEnabled" />
+                <label for="songNotificationEnabled"><fmt:message key="personalsettings.songnotification"/></label>
+            </dd>
+
+            <dt><fmt:message key="personalsettings.speechrecognition"/></dt>
+            <dd>
+                <form:checkbox path="voiceInputEnabled" id="voiceInputEnabled" />
+                <label for="voiceInputEnabled"><fmt:message key="personalsettings.voiceinputenabled"/></label>
+                <c:import url="helpToolTip.jsp"><c:param name="topic" value="voiceinputenabled"/></c:import>
+            </dd>
+            <dt><fmt:message key="personalsettings.speechenginelang"/></dt>
+            <dd>
+                <ul class="playerSettings">
+                    <c:forEach items="${SpeechToTextLangScheme.values()}" var="scheme">
+                        <c:set var="speechLangSchemeName">
+                            <fmt:message key="personalsettings.speechenginelang.${fn:toLowerCase(scheme)}"/>
+                        </c:set>
+                        <li>
+                            <form:radiobutton class="technologyRadio" id="radio2-${scheme}" path="speechToTextLangScheme" value="${scheme}"
+                                checked="${scheme eq command.speechToTextLangScheme ? 'checked' : ''}"
+                                disabled="${!command.voiceInputEnabled}"/>
+                            <label for="radio2-${scheme}">${speechLangSchemeName}</label>
+                            <c:if test="${scheme eq 'DEFAULT'}">
+                                  - ${command.ietfDisplayDefault}
+                            </c:if>
+                            <c:if test="${scheme eq 'BCP47'}">                
+                                <form:input path="ietf" id="ietf" disabled="${command.speechToTextLangScheme eq 'DEFAULT'}"/>
+                            </c:if>
+                        </li>
+                    </c:forEach>
+                </ul>
+            </dd>
+            <dt><fmt:message key="personalsettings.summary"/></dt>
+            <dd>
+                <form:checkbox path="openDetailSetting" id="openDetailSetting" />
+                <label for="openDetailSetting"><fmt:message key="personalsettings.summary.opensettings"/></label>
+            </dd>
+            <dt><fmt:message key="personalsettings.summary"/></dt>
+            <dd>
+                <form:checkbox path="openDetailStar" id="openDetailStar" />
+                <label for="openDetailStar"><fmt:message key="personalsettings.summary.openstars"/></label>
+            </dd>
+            <dt><fmt:message key="personalsettings.summary"/></dt>
+            <dd>
+                <form:checkbox path="openDetailIndex" id="openDetailIndex" />
+                <label for="openDetailIndex"><fmt:message key="personalsettings.summary.openindexes"/></label>
+            </dd>
             <dt></dt>
             <dd>
                 <form:checkbox path="nowPlayingAllowed" id="nowPlayingAllowed" />

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/transcodingSettings.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/transcodingSettings.jsp
@@ -41,10 +41,11 @@ document.addEventListener('DOMContentLoaded', function () {
 </c:import>
 
 <form method="post" action="transcodingSettings.view">
+    <c:set var="isOpen" value='${model.isOpenDetailSetting ? "open" : ""}' />
     <sec:csrfInput />
 
     <c:if test="${not empty model.transcodings}">
-        <details ${model.isOpenDetailSetting ? "open" : ""}>
+        <details ${isOpen}>
             <summary><fmt:message key="transcodingsettings.registered"/></summary>
 
             <c:if test="${model.showOutlineHelp}">
@@ -99,7 +100,7 @@ document.addEventListener('DOMContentLoaded', function () {
         </details>
     </c:if>
 
-    <details ${empty model.transcodings ? "" : "open"}>
+    <details ${isOpen}>
         <summary class="jpsonic"><fmt:message key="transcodingsettings.preferred"/></summary>
 
         <div class="actions">
@@ -171,7 +172,7 @@ document.addEventListener('DOMContentLoaded', function () {
         </dl>
    </details>
 
-    <details ${model.isOpenDetailSetting ? "open" : ""}>
+    <details ${isOpen}>
         <summary><fmt:message key="transcodingsettings.add"/></summary>
 
         <table class="tabular transcoding">
@@ -202,7 +203,7 @@ document.addEventListener('DOMContentLoaded', function () {
         </table>
     </details>
 
-    <details ${model.isOpenDetailSetting ? "open" : ""}>
+    <details ${isOpen}>
         <summary><fmt:message key="advancedsettings.hlscommand" /></summary>
         <div class="hls">
             <input type="text" name="hlsCommand" value="${model.hlsCommand}" />


### PR DESCRIPTION
#### Overview

There will be some minor tweaks to show less settings by default. There is no change in the items and functions that can be set.

 - Media server and player configuration items tend to be very numerous in general. In order to ease the burden on the user, Jpsonic hides many setting items in the Summary format by default.
 - Some Summaries are `open` by default. 
   - Top-priority setting items that are set immediately after installation
   - Recently Added (Young) Summary Groups
 - These are often rearranged.

#### Fixes

- Change 'Index settings' in General settings pages to default close.
- Change 'Preferred format' in Transcoding settings pages to default close.
- Move some items from 'Options related to display and playing control' to 'Additional display features' in Personal Settings page.

<details>
<summary>Options related to display and playing control</summary>

![image](https://user-images.githubusercontent.com/27724847/222423170-7e73caf7-539c-44a1-ac5e-dfe4012ac2ef.png)

___

The following items are relatively new and were displayed by default in 'Options related to display and playing control'.

 - **Notification** : A function for notifying media playback via the browser's API. In Airsonic, it is enabled by default, but in Jpsonic, it is disabled by default, so the setting items were displayed by default. It is disabled by default because the implementation is strongly dependent on the OS and browser implementation. The notification itself can be done without problems, but how it behaves depends on the environment. Some have advanced controls on the notification bar, like Android, and with annoying notification sounds, like Windows. (Today, the expected functionality for Notification seems to differ depending on the environment)
 - **Speech Recognition** : When enabled, the search button will be changed to a microphone input trigger. It was ON by default on tablets and smartphones. Same interface as [Subsonic Music Streamer](https://play.google.com/store/apps/details?id=net.sourceforge.subsonic.androidapp).
![image](https://user-images.githubusercontent.com/27724847/222433058-801ce603-4836-47f3-aad7-33fd0955a91d.png)
   - Previously, this interface was adopted in [BubbleUPnP](https://play.google.com/store/apps/details?id=com.bubblesoft.android.bubbleupnp). In other words, a similar interface had been realized with browser, Subsonic App, and UPNP App.
   - This feature was removed from BubbleUpnp from a certain time. At present, this interface is not very adopted (Subsonic Music Streamer is becoming more unique). Has many apps excluded audio input from needs? Probably different. 
     - Because it is expected to operate via software such as [TALKBACK](https://play.google.com/store/apps/details?id=com.google.android.marvin.talkback)
     - Because the design to add extra 'app authority' to the app was avoided
   - Therefore, this features is maintained, but it cannot be used unless the user make intentionally enabled.

</details>

By these fixes, only standard input items are displayed without scrolling in common displays.


