### PR TITLE
Some follow-ups on scan design changes

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/TopController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/TopController.java
@@ -168,6 +168,7 @@ public class TopController {
             }
         });
         selectedItem.ifPresent(v -> map.put("selectedItem", v));
+        selectedItem.ifPresent(v -> map.put("scanning", scannerStateService.isScanning()));
 
         return new ModelAndView("top", "model", map);
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AlbumDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AlbumDao.java
@@ -409,7 +409,7 @@ public class AlbumDao extends AbstractDao {
     }
 
     public List<Integer> getExpungeCandidates(@NonNull Instant scanDate) {
-        return queryForInts("select id from artist where last_scanned <> ? or not present", scanDate);
+        return queryForInts("select id from album where last_scanned <> ? or not present", scanDate);
     }
 
     public void expunge(@NonNull Instant scanDate) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/JMediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/JMediaFileDao.java
@@ -66,11 +66,6 @@ public class JMediaFileDao extends AbstractDao {
         update("update media_file set media_file_order = -1");
     }
 
-    public void clearArtistReadingOfDirectory() {
-        update("update media_file set artist_reading = null, artist_sort = null where present and type=?",
-                MediaType.DIRECTORY.name());
-    }
-
     public List<MediaFile> getAlbumsByGenre(final int offset, final int count, final List<String> genres,
             final List<MusicFolder> musicFolders) {
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -488,8 +488,11 @@ public class MediaFileDao extends AbstractDao {
                 + "join media_file mf_ar on mf_al.parent_path = mf_ar.path "
                 + "where mf.present and mf.album_artist is not null and mf.type in (:types) and mf.folder in (:folders) "
                 // Diff comparison
-                + "and (mf.album_artist_reading <> ar.reading " // album_artist_reading
-                + "or mf.album_artist_sort <> ar.sort " // album_artist_sort
+                + "and ((mf.album_artist_reading is null and ar.reading is not null) " // album_artist_reading
+                + "or (mf.album_artist_reading is not null and ar.reading is null) "
+                + "or mf.album_artist_reading <> ar.reading "
+                + "or (mf.album_artist_sort is null and ar.sort is not null) " // album_artist_sort
+                + "or (mf.album_artist_sort is not null and ar.sort is null) " + "or mf.album_artist_sort <> ar.sort "
                 + "or (mf_ar.cover_art_path is not null and ar.cover_art_path is null) " // cover_art_path
                 + "or (mf_ar.cover_art_path is null and ar.cover_art_path is not null) "
                 + "or mf_ar.cover_art_path <> ar.cover_art_path) limit :count";

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -65,7 +65,6 @@ public class MediaFileDao extends AbstractDao {
             + "artist_sort_raw, album_sort_raw, album_artist_sort_raw, composer_sort_raw, media_file_order";
     private static final String QUERY_COLUMNS = "id, " + INSERT_COLUMNS;
     private static final String GENRE_COLUMNS = "name, song_count, album_count";
-    private static final String ARTIST_ID3_COLUMNS = "folder, album_artist, album_artist_reading, album_artist_sort, cover_art_path";
 
     // Expected maximum number of album child elements (can be expanded)
     private static final int ALBUM_CHILD_MAX = 10_000;
@@ -479,17 +478,21 @@ public class MediaFileDao extends AbstractDao {
         }
         Map<String, Object> args = LegacyMap.of("types", getValidTypes4ID3(withPodcast), "count", count, "folders",
                 MusicFolder.toPathList(folders));
-        String query = "select distinct " + prefix(ARTIST_ID3_COLUMNS, "mf") + " from media_file mf "
-                + "left join artist ar on ar.name = mf.album_artist join music_folder m_folder on mf.folder = m_folder.path "
-                + "join (select album_artist, min(music_folder.id) as music_folder_id from media_file "
-                + "join music_folder on music_folder.path = folder where album_artist is not null group by album_artist) first_fetch "
+        String query = "select distinct mf.folder, mf.album_artist, mf.album_artist_reading, mf.album_artist_sort, mf_ar.cover_art_path from media_file mf "
+                + "join artist ar on ar.name = mf.album_artist "
+                + "join music_folder m_folder on mf.folder = m_folder.path "
+                + "join (select album_artist, min(music_folder.id) as music_folder_id from media_file join music_folder "
+                + "on music_folder.path = folder where album_artist is not null group by album_artist) first_fetch "
                 + "on first_fetch.music_folder_id = m_folder.id and first_fetch.album_artist = mf.album_artist "
-                + "where mf.present and mf.album_artist is not null and type in (:types) and mf.folder in (:folders) "
+                + "join media_file mf_al on mf.parent_path = mf_al.path "
+                + "join media_file mf_ar on mf_al.parent_path = mf_ar.path "
+                + "where mf.present and mf.album_artist is not null and mf.type in (:types) and mf.folder in (:folders) "
                 // Diff comparison
                 + "and (mf.album_artist_reading <> ar.reading " // album_artist_reading
-                + "or mf.album_artist_sort <> ar.sort) " // album_artist_sort
-                // cover_art_path (pending)
-                + "limit :count";
+                + "or mf.album_artist_sort <> ar.sort " // album_artist_sort
+                + "or (mf_ar.cover_art_path is not null and ar.cover_art_path is null) " // cover_art_path
+                + "or (mf_ar.cover_art_path is null and ar.cover_art_path is not null) "
+                + "or mf_ar.cover_art_path <> ar.cover_art_path) limit :count";
         return namedQuery(query, artistId3Mapper, args);
     }
 
@@ -499,13 +502,15 @@ public class MediaFileDao extends AbstractDao {
         }
         Map<String, Object> args = LegacyMap.of("types", getValidTypes4ID3(withPodcast), "count", count, "folders",
                 MusicFolder.toPathList(folders));
-        String query = "select distinct " + prefix(ARTIST_ID3_COLUMNS, "mf") + " from media_file mf "
+        String query = "select distinct mf.folder, mf.album_artist, mf.album_artist_reading, mf.album_artist_sort, mf_ar.cover_art_path from media_file mf "
                 + "left join artist on artist.name = mf.album_artist "
                 + "join music_folder on mf.folder = music_folder.path "
+                + "join media_file mf_al on mf_al.path = mf.parent_path "
+                + "join media_file mf_ar on mf_ar.path = mf_al.parent_path "
                 + "join (select album_artist, min(music_folder.id) as music_folder_id from media_file join music_folder "
                 + "on music_folder.path = folder where album_artist is not null group by album_artist) first_fetch "
                 + "on first_fetch.music_folder_id = music_folder.id "
-                + "where mf.present and mf.album_artist is not null and type in (:types) "
+                + "where mf.present and mf.album_artist is not null and mf.type in (:types) "
                 + "and artist.name is null and mf.folder in (:folders) limit :count";
         return namedQuery(query, artistId3Mapper, args);
     }
@@ -590,7 +595,8 @@ public class MediaFileDao extends AbstractDao {
                 + "mf_fetched.parent_path <> al.path " // path
                 + "or mf_fetched.changed <> al.created " // changed
                 + "or mf_folder.id <> al.folder_id " // folder_id
-                // cover_art_path (pending)
+                + "or (mf_al.cover_art_path is not null and al.cover_art_path is null) or (mf_al.cover_art_path is null and al.cover_art_path is not null) "
+                + "or mf_al.cover_art_path <> al.cover_art_path " // cover_art_path
                 + "or (mf_fetched.year is not null and al.year is null) or mf_fetched.year <> al.year " // year
                 + "or (mf_fetched.genre is not null and al.genre is null) or mf_fetched.genre <> al.genre " // genre
                 + "or (mf_fetched.album_artist_reading is not null and al.artist_reading is null) or mf_fetched.album_artist_reading <> al.artist_reading " // artist_reading

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PlayerService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PlayerService.java
@@ -160,7 +160,7 @@ public class PlayerService {
         }
     }
 
-    private Player findOrCreatePlayer(HttpServletRequest request, boolean remoteControlEnabled) {
+    private @NonNull Player findOrCreatePlayer(HttpServletRequest request, boolean remoteControlEnabled) {
         String username = securityService.getCurrentUsername(request);
         Player player = findPlayer(request, remoteControlEnabled, username);
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImpl.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImpl.java
@@ -107,20 +107,20 @@ public class MediaScannerServiceImpl implements MediaScannerService {
             procedure.parsePodcast(scanDate);
             procedure.iterateFileStructure(scanDate);
 
-            procedure.parseAlbum(scanDate);
-            procedure.updateSortOfAlbum(scanDate);
-            procedure.updateOrderOfAlbum(scanDate);
-            procedure.updateSortOfArtist(scanDate);
-            procedure.updateOrderOfArtist(scanDate);
+            boolean parsedAlbum = procedure.parseAlbum(scanDate);
+            boolean updatedSortOfAlbum = procedure.updateSortOfAlbum(scanDate);
+            procedure.updateOrderOfAlbum(scanDate, parsedAlbum || updatedSortOfAlbum);
+            boolean updatedSortOfArtist = procedure.updateSortOfArtist(scanDate);
+            procedure.updateOrderOfArtist(scanDate, parsedAlbum || updatedSortOfArtist);
 
             if (LOG.isInfoEnabled()) {
                 LOG.info("Scanned media library with " + scannerState.getScanCount() + " entries.");
             }
 
-            procedure.refleshAlbumID3(scanDate);
-            procedure.updateOrderOfAlbumID3(scanDate);
-            procedure.refleshArtistId3(scanDate);
-            procedure.updateOrderOfArtistId3(scanDate);
+            boolean refleshedAlbumId3 = procedure.refleshAlbumId3(scanDate);
+            procedure.updateOrderOfAlbumId3(scanDate, refleshedAlbumId3);
+            boolean refleshedArtistId3 = procedure.refleshArtistId3(scanDate);
+            procedure.updateOrderOfArtistId3(scanDate, refleshedArtistId3);
 
             procedure.updateAlbumCounts(scanDate);
             procedure.updateGenreMaster(scanDate);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
@@ -155,7 +155,6 @@ public class ScannerProcedureService {
             settingsService.setIgnoreFileTimestampsNext(false);
             settingsService.save();
         } else if (settingsService.isIgnoreFileTimestamps()) {
-            indexManager.expungeGenreOtherThan(Collections.emptyList());
             mediaFileDao.resetLastScanned();
         }
 
@@ -257,8 +256,9 @@ public class ScannerProcedureService {
     }
 
     void expungeFileStructure() {
-        indexManager.expunge(mediaFileDao.getArtistExpungeCandidates(), mediaFileDao.getAlbumExpungeCandidates(),
-                mediaFileDao.getSongExpungeCandidates());
+        mediaFileDao.getArtistExpungeCandidates().forEach(indexManager::expungeArtist);
+        mediaFileDao.getAlbumExpungeCandidates().forEach(indexManager::expungeAlbum);
+        mediaFileDao.getSongExpungeCandidates().forEach(indexManager::expungeSong);
         mediaFileDao.expunge();
     }
 
@@ -296,7 +296,7 @@ public class ScannerProcedureService {
     @Transactional
     public void iterateAlbumId3(@NonNull Instant scanDate, boolean withPodcast) {
         albumDao.iterateLastScanned(scanDate, withPodcast);
-        indexManager.expungeAlbum(albumDao.getExpungeCandidates(scanDate));
+        indexManager.expungeAlbumId3(albumDao.getExpungeCandidates(scanDate));
         albumDao.expunge(scanDate);
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
@@ -611,6 +611,7 @@ public class ScannerProcedureService {
     void afterScan(@NonNull Instant scanDate) {
         mediaFileCache.setEnabled(true);
         indexManager.stopIndexing();
+        indexCache.removeAll();
         sortProcedure.clearMemoryCache();
         createScanEvent(scanDate, ScanEventType.AFTER_SCAN, null);
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
@@ -48,6 +48,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class ScannerProcedureService {
 
+    private static final String MSG_SKIP = "Skipped by the settings.";
+    private static final String MSG_UNNECESSARY = "Skipped as it is not needed.";
+
     private static final Logger LOG = LoggerFactory.getLogger(ScannerProcedureService.class);
 
     private final SettingsService settingsService;
@@ -348,12 +351,14 @@ public class ScannerProcedureService {
         return countNew;
     }
 
-    void parseAlbum(@NonNull Instant scanDate) throws ExecutionException {
+    boolean parseAlbum(@NonNull Instant scanDate) throws ExecutionException {
         List<MusicFolder> folders = musicFolderService.getAllMusicFolders();
         int countUpdate = updateAlbums(scanDate, folders);
         int countNew = createAlbums(scanDate, folders);
+        boolean parsed = countUpdate > 0 || countNew > 0;
         String comment = String.format("Update(%d)/New(%d)", countUpdate, countNew);
         createScanEvent(scanDate, ScanEventType.PARSE_ALBUM, comment);
+        return parsed;
     }
 
     boolean isPodcastInMusicFolders() {
@@ -382,7 +387,7 @@ public class ScannerProcedureService {
         return album;
     }
 
-    void refleshAlbumID3(@NonNull Instant scanDate) throws ExecutionException {
+    boolean refleshAlbumId3(@NonNull Instant scanDate) throws ExecutionException {
 
         boolean withPodcast = isPodcastInMusicFolders();
         iterateAlbumId3(scanDate, withPodcast);
@@ -426,6 +431,8 @@ public class ScannerProcedureService {
 
         String comment = String.format("Update(%d)/New(%d)", countUpdate, countNew);
         createScanEvent(scanDate, ScanEventType.REFRESH_ALBUM_ID3, comment);
+
+        return countUpdate > 0 || countNew > 0;
     }
 
     private Artist artistId3Of(@NonNull Instant scanDate, int folderId, @NonNull MediaFile artistId3,
@@ -449,7 +456,7 @@ public class ScannerProcedureService {
     }
 
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops") // (artist) Not reusable
-    void refleshArtistId3(@NonNull Instant scanDate) throws ExecutionException {
+    boolean refleshArtistId3(@NonNull Instant scanDate) throws ExecutionException {
 
         boolean withPodcast = isPodcastInMusicFolders();
         iterateArtistId3(scanDate, withPodcast);
@@ -492,6 +499,8 @@ public class ScannerProcedureService {
 
         String comment = String.format("Update(%d)/New(%d)", countUpdate, countNew);
         createScanEvent(scanDate, ScanEventType.REFRESH_ARTIST_ID3, comment);
+
+        return countUpdate > 0 || countNew > 0;
     }
 
     void parsePodcast(@NonNull Instant scanDate) throws ExecutionException {
@@ -540,9 +549,11 @@ public class ScannerProcedureService {
         createScanEvent(scanDate, ScanEventType.UPDATE_GENRE_MASTER, null);
     }
 
-    void updateSortOfArtist(@NonNull Instant scanDate) throws ExecutionException {
+    boolean updateSortOfArtist(@NonNull Instant scanDate) throws ExecutionException {
+        boolean parsed = false;
         if (!scannerState.isEnableCleansing()) {
-            return;
+            createScanEvent(scanDate, ScanEventType.UPDATE_SORT_OF_ARTIST, MSG_SKIP);
+            return parsed;
         }
         interruptIfCancelled();
         List<MusicFolder> folders = musicFolderService.getAllMusicFolders();
@@ -554,58 +565,87 @@ public class ScannerProcedureService {
         String comment = String.format("Merged(%d)/Copied(%d)/Compensated(%d)", merged.size(), copied.size(),
                 compensated.size());
         createScanEvent(scanDate, ScanEventType.UPDATE_SORT_OF_ARTIST, comment);
+        return parsed;
     }
 
-    void updateSortOfAlbum(@NonNull Instant scanDate) throws ExecutionException {
+    boolean updateSortOfAlbum(@NonNull Instant scanDate) throws ExecutionException {
+        boolean updated = false;
         if (!scannerState.isEnableCleansing()) {
-            return;
+            createScanEvent(scanDate, ScanEventType.UPDATE_SORT_OF_ALBUM, MSG_SKIP);
+            return updated;
         }
         interruptIfCancelled();
         List<MusicFolder> folders = musicFolderService.getAllMusicFolders();
         List<Integer> merged = sortProcedure.mergeSortOfAlbum(folders);
         List<Integer> copied = sortProcedure.copySortOfAlbum(folders);
         List<Integer> compensated = sortProcedure.compensateSortOfAlbum(folders);
+        updated = !merged.isEmpty() || !copied.isEmpty() || !compensated.isEmpty();
         Stream.concat(Stream.concat(merged.stream(), copied.stream()), compensated.stream())
                 .map(id -> mediaFileService.getMediaFile(id)).forEach(mediaFile -> indexManager.index(mediaFile));
         String comment = String.format("Merged(%d)/Copied(%d)/Compensated(%d)", merged.size(), copied.size(),
                 compensated.size());
         createScanEvent(scanDate, ScanEventType.UPDATE_SORT_OF_ALBUM, comment);
+        return updated;
     }
 
-    void updateOrderOfArtist(@NonNull Instant scanDate) throws ExecutionException {
+    void updateOrderOfArtist(@NonNull Instant scanDate, boolean toBeSorted) throws ExecutionException {
         if (!scannerState.isEnableCleansing() || !settingsService.isSortStrict()) {
+            createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ARTIST, MSG_SKIP);
+            return;
+        }
+        if (!toBeSorted) {
+            createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ARTIST, MSG_UNNECESSARY);
             return;
         }
         interruptIfCancelled();
-        sortProcedure.updateOrderOfArtist();
-        createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ARTIST, null);
+        int count = sortProcedure.updateOrderOfArtist();
+        String comment = String.format("Updated order of (%d) artists", count);
+        createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ARTIST, comment);
     }
 
-    void updateOrderOfAlbum(@NonNull Instant scanDate) throws ExecutionException {
+    void updateOrderOfAlbum(@NonNull Instant scanDate, boolean toBeSorted) throws ExecutionException {
         if (!scannerState.isEnableCleansing() || !settingsService.isSortStrict()) {
+            createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ALBUM, MSG_SKIP);
+            return;
+        }
+        if (!toBeSorted) {
+            createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ALBUM, MSG_UNNECESSARY);
             return;
         }
         interruptIfCancelled();
-        sortProcedure.updateOrderOfAlbum();
-        createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ALBUM, null);
+        int count = sortProcedure.updateOrderOfAlbum();
+        String comment = String.format("Updated order of (%d) albums", count);
+        createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ALBUM, comment);
     }
 
-    void updateOrderOfArtistId3(@NonNull Instant scanDate) throws ExecutionException {
+    void updateOrderOfArtistId3(@NonNull Instant scanDate, boolean toBeSorted) throws ExecutionException {
         if (!scannerState.isEnableCleansing() || !settingsService.isSortStrict()) {
+            createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ARTIST_ID3, MSG_SKIP);
+            return;
+        }
+        if (!toBeSorted) {
+            createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ARTIST_ID3, MSG_UNNECESSARY);
             return;
         }
         interruptIfCancelled();
-        sortProcedure.updateOrderOfArtistID3();
-        createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ARTIST_ID3, null);
+        int count = sortProcedure.updateOrderOfArtistID3();
+        String comment = String.format("Updated order of (%d) ID3 albums.", count);
+        createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ARTIST_ID3, comment);
     }
 
-    void updateOrderOfAlbumID3(@NonNull Instant scanDate) throws ExecutionException {
+    void updateOrderOfAlbumId3(@NonNull Instant scanDate, boolean toBeSorted) throws ExecutionException {
         if (!scannerState.isEnableCleansing() || !settingsService.isSortStrict()) {
+            createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ALBUM_ID3, MSG_SKIP);
+            return;
+        }
+        if (!toBeSorted) {
+            createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ALBUM_ID3, MSG_UNNECESSARY);
             return;
         }
         interruptIfCancelled();
-        sortProcedure.updateOrderOfAlbumID3();
-        createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ALBUM_ID3, null);
+        int count = sortProcedure.updateOrderOfAlbumID3();
+        String comment = String.format("Updated order of (%d) ID3 albums.", count);
+        createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ALBUM_ID3, comment);
     }
 
     void runStats(@NonNull Instant scanDate) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
@@ -121,7 +121,7 @@ public class SortProcedureService {
         return updateSortOfArtist(candidates);
     }
 
-    void updateOrderOfAlbumID3() {
+    int updateOrderOfAlbumID3() {
         List<MusicFolder> folders = musicFolderService.getAllMusicFolders();
         List<Album> albums = jAlbumDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, false, false, folders);
         albums.sort(comparators.albumOrderByAlpha());
@@ -129,9 +129,10 @@ public class SortProcedureService {
         for (Album album : albums) {
             albumDao.updateOrder(album.getArtist(), album.getName(), i++);
         }
+        return i;
     }
 
-    void updateOrderOfArtistID3() {
+    int updateOrderOfArtistID3() {
         List<MusicFolder> folders = musicFolderService.getAllMusicFolders();
         List<Artist> artists = jArtistDao.getAlphabetialArtists(0, Integer.MAX_VALUE, folders);
         artists.sort(comparators.artistOrderByAlpha());
@@ -139,9 +140,10 @@ public class SortProcedureService {
         for (Artist artist : artists) {
             artistDao.updateOrder(artist.getName(), i++);
         }
+        return i;
     }
 
-    void updateOrderOfArtist() {
+    int updateOrderOfArtist() {
         List<MusicFolder> folders = musicFolderService.getAllMusicFolders();
         List<MediaFile> artists = jMediaFileDao.getArtistAll(folders);
         artists.sort(comparators.mediaFileOrderByAlpha());
@@ -150,9 +152,10 @@ public class SortProcedureService {
             artist.setOrder(i++);
             writableMediaFileService.updateOrder(artist);
         }
+        return i;
     }
 
-    void updateOrderOfAlbum() {
+    int updateOrderOfAlbum() {
         List<MusicFolder> folders = musicFolderService.getAllMusicFolders();
         List<MediaFile> albums = mediaFileService.getAlphabeticalAlbums(0, Integer.MAX_VALUE, true, folders);
         albums.sort(comparators.mediaFileOrderByAlpha());
@@ -161,6 +164,7 @@ public class SortProcedureService {
             album.setOrder(i++);
             writableMediaFileService.updateOrder(album);
         }
+        return i;
     }
 
     void updateOrderOfSongs(MediaFile album) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
@@ -227,25 +227,27 @@ public class IndexManager {
     }
 
     @ThreadSafe(enableChecks = false) // False positive. writers#get#deleteDocuments is atomic.
-    public void expunge(List<Integer> artistIds, List<Integer> albumIds, List<Integer> songIds) {
-
-        Term[] primarykeys = artistIds.stream().map(DocumentFactory::createPrimarykey).toArray(Term[]::new);
+    public void expungeArtist(int id) {
         try {
-            writers.get(IndexType.ARTIST).deleteDocuments(primarykeys);
+            writers.get(IndexType.ARTIST).deleteDocuments(DocumentFactory.createPrimarykey(id));
         } catch (IOException e) {
             LOG.error("Failed to delete artist doc.", e);
         }
+    }
 
-        primarykeys = albumIds.stream().map(DocumentFactory::createPrimarykey).toArray(Term[]::new);
+    @ThreadSafe(enableChecks = false) // False positive. writers#get#deleteDocuments is atomic.
+    public void expungeAlbum(int id) {
         try {
-            writers.get(IndexType.ALBUM).deleteDocuments(primarykeys);
+            writers.get(IndexType.ALBUM).deleteDocuments(DocumentFactory.createPrimarykey(id));
         } catch (IOException e) {
             LOG.error("Failed to delete album doc.", e);
         }
+    }
 
-        primarykeys = songIds.stream().map(DocumentFactory::createPrimarykey).toArray(Term[]::new);
+    @ThreadSafe(enableChecks = false) // False positive. writers#get#deleteDocuments is atomic.
+    public void expungeSong(int id) {
         try {
-            writers.get(IndexType.SONG).deleteDocuments(primarykeys);
+            writers.get(IndexType.SONG).deleteDocuments(DocumentFactory.createPrimarykey(id));
         } catch (IOException e) {
             LOG.error("Failed to delete song doc.", e);
         }
@@ -262,7 +264,7 @@ public class IndexManager {
     }
 
     @ThreadSafe(enableChecks = false) // False positive. writers#get#deleteDocuments is atomic.
-    public void expungeAlbum(List<Integer> candidates) {
+    public void expungeAlbumId3(List<Integer> candidates) {
         Term[] primarykeys = candidates.stream().map(DocumentFactory::createPrimarykey).toArray(Term[]::new);
         try {
             writers.get(IndexType.ALBUM_ID3).deleteDocuments(primarykeys);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/AlbumUpnpProcessor.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/AlbumUpnpProcessor.java
@@ -51,7 +51,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Service
 public class AlbumUpnpProcessor extends UpnpContentProcessor<Album, MediaFile> {
 
-    public static final String ALL_BY_ARTIST = "allByArtist";
     public static final String ALL_RECENT_ID3 = "allRecentId3";
 
     private final UpnpProcessorUtil util;
@@ -124,7 +123,7 @@ public class AlbumUpnpProcessor extends UpnpContentProcessor<Album, MediaFile> {
     @Override
     public Album getItemById(String id) {
         Album returnValue;
-        if (id.startsWith(ALL_BY_ARTIST) || ALL_RECENT_ID3.equalsIgnoreCase(id)) {
+        if (ALL_RECENT_ID3.equalsIgnoreCase(id)) {
             returnValue = new Album();
             returnValue.setId(-1);
             returnValue.setComment(id);
@@ -145,11 +144,7 @@ public class AlbumUpnpProcessor extends UpnpContentProcessor<Album, MediaFile> {
                 album.getName());
         if (album.getId() == -1) {
             List<Album> albums;
-            if (album.getComment().startsWith(ALL_BY_ARTIST)) {
-                ArtistUpnpProcessor ap = getDispatcher().getArtistProcessor();
-                albums = ap.getChildren(ap.getItemById(album.getComment().replaceAll(ALL_BY_ARTIST + "_", "")), offset,
-                        maxResults);
-            } else if (ALL_RECENT_ID3.equalsIgnoreCase(album.getComment())) {
+            if (ALL_RECENT_ID3.equalsIgnoreCase(album.getComment())) {
                 albums = getDispatcher().getRecentAlbumId3Processor().getItems(offset, maxResults);
             } else {
                 albums = new ArrayList<>();

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/ArtistUpnpProcessor.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/ArtistUpnpProcessor.java
@@ -102,17 +102,8 @@ public class ArtistUpnpProcessor extends UpnpContentProcessor<Artist, Album> {
 
     @Override
     public List<Album> getChildren(Artist artist, long offset, long maxResults) {
-        List<Album> albums = getDispatcher().getAlbumProcessor().getAlbumsForArtist(artist.getName(),
-                offset > 1 ? offset - 1 : offset, 0L == offset ? maxResults - 1 : maxResults,
+        return getDispatcher().getAlbumProcessor().getAlbumsForArtist(artist.getName(), offset, maxResults,
                 util.isSortAlbumsByYear(artist.getName()), util.getGuestMusicFolders());
-        if (albums.size() > 1 && 0L == offset) {
-            Album firstElement = new Album();
-            firstElement.setName(util.getResource("dlna.element.allalbums"));
-            firstElement.setId(-1);
-            firstElement.setComment(AlbumUpnpProcessor.ALL_BY_ARTIST + "_" + artist.getId());
-            albums.add(0, firstElement);
-        }
-        return albums;
     }
 
     @Override

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/top.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/top.jsp
@@ -213,29 +213,31 @@ window.onOpenDialogVideoPlayer = function(videoUrl) {
         <c:if test="${not empty model.indexedArtists}">
             <ul class="jps-index">
                 <c:forEach items="${model.indexedArtists}" var="entry" varStatus="status">
-                    <c:set var="accesskey" value="${fn:escapeXml(entry.key.index)}" />
-                    <c:if test="${model.assignAccesskeyToNumber}">
-                        <c:set var="accesskey" value="${status.index%5 == 0 ? Integer.toString(status.index/5) : null}" />
+                    <c:if test="${!model.scanning or (model.scanning and entry.key.index ne '#')}">
+                        <c:set var="accesskey" value="${fn:escapeXml(entry.key.index)}" />
+                        <c:if test="${model.assignAccesskeyToNumber}">
+                            <c:set var="accesskey" value="${status.index%5 == 0 ? Integer.toString(status.index/5) : null}" />
+                        </c:if>
+                        <c:choose>
+                            <c:when test="${!empty accesskey}">
+                                <li><a href="#${index.index}" accesskey="${fn:escapeXml(accesskey)}" class="jps-index-key">${fn:escapeXml(entry.key.index)}</a>
+                            </c:when>
+                            <c:otherwise>
+                                <li><a href="#${index.index}" class="jps-index-key">${fn:escapeXml(entry.key.index)}</a>
+                            </c:otherwise>
+                        </c:choose>
+                        <ul>
+                            <c:forEach items="${entry.value}" var="artist" varStatus="loop">
+                                <sub:url value="main.view" var="mainUrl">
+                                    <c:forEach items="${artist.mediaFiles}" var="mediaFile">
+                                        <sub:param name="id" value="${mediaFile.id}" />
+                                    </c:forEach>
+                                </sub:url>
+                                <li><a target="main" href="${mainUrl}" title="${artist.sortableName}"><str:truncateNicely upper="${18}" lower="${25}">${fn:escapeXml(artist.name)}</str:truncateNicely></a></li>
+                            </c:forEach>
+                        </ul>
+                        </li>
                     </c:if>
-                    <c:choose>
-                        <c:when test="${!empty accesskey}">
-                            <li><a href="#${index.index}" accesskey="${fn:escapeXml(accesskey)}" class="jps-index-key">${fn:escapeXml(entry.key.index)}</a>
-                        </c:when>
-                        <c:otherwise>
-                            <li><a href="#${index.index}" class="jps-index-key">${fn:escapeXml(entry.key.index)}</a>
-                        </c:otherwise>
-                    </c:choose>
-                    <ul>
-                        <c:forEach items="${entry.value}" var="artist" varStatus="loop">
-                            <sub:url value="main.view" var="mainUrl">
-                                <c:forEach items="${artist.mediaFiles}" var="mediaFile">
-                                    <sub:param name="id" value="${mediaFile.id}" />
-                                </c:forEach>
-                            </sub:url>
-                            <li><a target="main" href="${mainUrl}" title="${artist.sortableName}"><str:truncateNicely upper="${18}" lower="${25}">${fn:escapeXml(artist.name)}</str:truncateNicely></a></li>
-                        </c:forEach>
-                    </ul>
-                    </li>
                 </c:forEach>
                 <c:if test="${not empty model.singleSongs}">
                     <li><a target="main" href="home.view?listType=index" class="jps-index-key">more</a></li>

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/NowPlayingControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/NowPlayingControllerTest.java
@@ -20,15 +20,27 @@
 package com.tesshu.jpsonic.controller;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.lang.annotation.Documented;
+import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.tesshu.jpsonic.domain.MediaFile;
+import com.tesshu.jpsonic.domain.Player;
+import com.tesshu.jpsonic.domain.TransferStatus;
 import com.tesshu.jpsonic.service.MediaFileService;
 import com.tesshu.jpsonic.service.PlayerService;
+import com.tesshu.jpsonic.service.SecurityService;
 import com.tesshu.jpsonic.service.StatusService;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -36,24 +48,148 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class NowPlayingControllerTest {
 
+    private PlayerService playerService;
+    private StatusService statusService;
+    private MediaFileService mediaFileService;
+    private SecurityService securityService;
+    private NowPlayingController controller;
     private MockMvc mockMvc;
 
     @BeforeEach
     public void setup() throws ExecutionException {
-        mockMvc = MockMvcBuilders.standaloneSetup(new NowPlayingController(mock(PlayerService.class),
-                mock(StatusService.class), mock(MediaFileService.class))).build();
+        playerService = mock(PlayerService.class);
+        statusService = mock(StatusService.class);
+        mediaFileService = mock(MediaFileService.class);
+        securityService = mock(SecurityService.class);
+        controller = new NowPlayingController(playerService, statusService, mediaFileService, securityService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
     }
 
     @Test
     @WithMockUser(username = "admin")
-    void testGet() throws Exception {
+    void testGetToHome() throws Exception {
         MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/nowPlaying.view"))
                 .andExpect(MockMvcResultMatchers.status().isFound())
                 .andExpect(MockMvcResultMatchers.redirectedUrl(ViewName.HOME.value()))
                 .andExpect(MockMvcResultMatchers.status().is3xxRedirection()).andReturn();
-
         assertNotNull(result);
+    }
+
+    @Test
+    @WithMockUser(username = "admin")
+    void testGetToMain() throws Exception {
+        Player player = new Player();
+        Mockito.when(playerService.getPlayer(Mockito.nullable(HttpServletRequest.class),
+                Mockito.nullable(HttpServletResponse.class))).thenReturn(player);
+        TransferStatus status = new TransferStatus();
+        status.setPathString("/dummy");
+        Mockito.when(statusService.getStreamStatusesForPlayer(player)).thenReturn(Arrays.asList(status));
+        Mockito.when(securityService.isReadAllowed(status.toPath())).thenReturn(true);
+        MediaFile nowPlaing = new MediaFile();
+        Mockito.when(mediaFileService.getMediaFile(status.toPath())).thenReturn(nowPlaing);
+        MediaFile parent = new MediaFile();
+        parent.setId(99);
+        Mockito.when(mediaFileService.getParentOf(nowPlaing)).thenReturn(parent);
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/nowPlaying.view"))
+                .andExpect(MockMvcResultMatchers.status().isFound())
+                .andExpect(MockMvcResultMatchers.redirectedUrl("main.view?id=99"))
+                .andExpect(MockMvcResultMatchers.status().is3xxRedirection()).andReturn();
+        assertNotNull(result);
+    }
+
+    @Documented
+    private @interface GetNowPlayingFileDecisions {
+        @interface Conditions {
+            @interface Statuses {
+                @interface Empty {
+                }
+
+                @interface NotEmpty {
+                }
+
+                @interface Path {
+                    @interface ReadAllowed {
+
+                    }
+
+                    @interface NotReadAllowed {
+
+                    }
+                }
+            }
+
+            @interface MediaFile {
+                @interface NonNull {
+                }
+
+                @interface Null {
+                }
+            }
+        }
+
+        @interface Result {
+            @interface Null {
+            }
+
+            @interface NonNull {
+            }
+        }
+    }
+
+    @Nested
+    class GetNowPlayingFileTest {
+
+        @Test
+        @GetNowPlayingFileDecisions.Conditions.Statuses.Empty
+        @GetNowPlayingFileDecisions.Result.Null
+        void c1() {
+            Player player = new Player();
+            assertNull(controller.getNowPlayingFile(player));
+        }
+
+        @Test
+        @GetNowPlayingFileDecisions.Conditions.Statuses.NotEmpty
+        @GetNowPlayingFileDecisions.Conditions.Statuses.Path.NotReadAllowed
+        @GetNowPlayingFileDecisions.Result.Null
+        void c2() {
+            Player player = new Player();
+            TransferStatus status = new TransferStatus();
+            status.setPathString("/dummy");
+            Mockito.when(statusService.getStreamStatusesForPlayer(player)).thenReturn(Arrays.asList(status));
+            Mockito.when(securityService.isReadAllowed(status.toPath())).thenReturn(false);
+            assertNull(controller.getNowPlayingFile(player));
+        }
+
+        @Test
+        @GetNowPlayingFileDecisions.Conditions.Statuses.NotEmpty
+        @GetNowPlayingFileDecisions.Conditions.Statuses.Path.ReadAllowed
+        @GetNowPlayingFileDecisions.Conditions.MediaFile.NonNull
+        @GetNowPlayingFileDecisions.Result.NonNull
+        void c3() {
+            Player player = new Player();
+            TransferStatus status = new TransferStatus();
+            status.setPathString("/dummy");
+            Mockito.when(statusService.getStreamStatusesForPlayer(player)).thenReturn(Arrays.asList(status));
+            Mockito.when(securityService.isReadAllowed(status.toPath())).thenReturn(true);
+            Mockito.when(mediaFileService.getMediaFile(status.toPath())).thenReturn(new MediaFile());
+            assertNotNull(controller.getNowPlayingFile(player));
+        }
+
+        @Test
+        @GetNowPlayingFileDecisions.Conditions.Statuses.NotEmpty
+        @GetNowPlayingFileDecisions.Conditions.Statuses.Path.ReadAllowed
+        @GetNowPlayingFileDecisions.Conditions.MediaFile.Null
+        @GetNowPlayingFileDecisions.Result.Null
+        void c4() {
+            Player player = new Player();
+            TransferStatus status = new TransferStatus();
+            status.setPathString("/dummy");
+            Mockito.when(statusService.getStreamStatusesForPlayer(player)).thenReturn(Arrays.asList(status));
+            Mockito.when(securityService.isReadAllowed(status.toPath())).thenReturn(true);
+            assertNull(controller.getNowPlayingFile(player));
+        }
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/SortProcedureServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/SortProcedureServiceTest.java
@@ -23,6 +23,7 @@ import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -70,6 +71,9 @@ class SortProcedureServiceTest {
 
         @Autowired
         private JArtistDao artistDao;
+
+        @Autowired
+        private ScannerProcedureService scannerProcedureService;
 
         @Autowired
         private SortProcedureService sortProcedureService;
@@ -152,7 +156,11 @@ class SortProcedureServiceTest {
             assertNull(artistID3s.get(3).getSort());
 
             // Execution of Complementary Processing
+            Instant scanDate = scannerStateService.getScanDate();
+            scannerProcedureService.beforeScan(scanDate);
             sortProcedureService.compensateSortOfArtist(musicFolders);
+            scannerProcedureService.refleshArtistId3(scanDate);
+            scannerProcedureService.afterScan(scanDate);
 
             artist = artists.get(0);
             assertEquals("ARTIST", artist.getName());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/ArtistUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/ArtistUpnpProcessorTest.java
@@ -113,19 +113,19 @@ class ArtistUpnpProcessorTest extends AbstractNeedsScan {
         List<Album> children = artistUpnpProcessor.getChildren(artists.get(0), 0, 10);
         for (int i = 0; i < children.size(); i++) {
             if (0 != i) {
-                assertEquals(UpnpProcessorTestUtils.JPSONIC_NATURAL_LIST.get(i - 1), children.get(i).getName());
+                assertEquals(UpnpProcessorTestUtils.JPSONIC_NATURAL_LIST.get(i), children.get(i).getName());
             }
         }
 
         children = artistUpnpProcessor.getChildren(artists.get(0), 10, 10);
         for (int i = 0; i < children.size(); i++) {
-            assertEquals(UpnpProcessorTestUtils.JPSONIC_NATURAL_LIST.get(i + 10 - 1), children.get(i).getName());
+            assertEquals(UpnpProcessorTestUtils.JPSONIC_NATURAL_LIST.get(i + 10), children.get(i).getName());
         }
 
         children = artistUpnpProcessor.getChildren(artists.get(0), 20, 100);
-        assertEquals(12, children.size()); //
+        assertEquals(11, children.size());
         for (int i = 0; i < children.size(); i++) {
-            assertEquals(UpnpProcessorTestUtils.JPSONIC_NATURAL_LIST.get(i + 20 - 1), children.get(i).getName());
+            assertEquals(UpnpProcessorTestUtils.JPSONIC_NATURAL_LIST.get(i + 20), children.get(i).getName());
         }
 
     }
@@ -146,19 +146,19 @@ class ArtistUpnpProcessorTest extends AbstractNeedsScan {
 
         for (int i = 0; i < children.size(); i++) {
             if (0 != i) {
-                assertEquals(reversedByYear.get(i - 1), children.get(i).getName());
+                assertEquals(reversedByYear.get(i), children.get(i).getName());
             }
         }
 
         children = artistUpnpProcessor.getChildren(artists.get(0), 10, 10);
         for (int i = 0; i < children.size(); i++) {
-            assertEquals(reversedByYear.get(i + 10 - 1), children.get(i).getName());
+            assertEquals(reversedByYear.get(i + 10), children.get(i).getName());
         }
 
         children = artistUpnpProcessor.getChildren(artists.get(0), 20, 100);
-        assertEquals(12, children.size()); //
+        assertEquals(11, children.size());
         for (int i = 0; i < children.size(); i++) {
-            assertEquals(reversedByYear.get(i + 20 - 1), children.get(i).getName());
+            assertEquals(reversedByYear.get(i + 20), children.get(i).getName());
         }
 
     }


### PR DESCRIPTION
Prerequisites: #2041

#### Overview

Scan related small fixes set not included in #2041.

___

#### Fixes



 - **Sort tags** 
   - Previously, after scanning, it detected all sort tags that should have been edited and applied updates to the media_file, album, and artist tables. Next version fixes edits to be made to media_file only. The album and artist tables will be diffed and synchronized in subsequent processing.
   - However, whether it contributes to speedup depends on the data pattern.(Depending on the case, the number of issued queries may increase. ) As a result, there is no big difference. It just simplifies the source code somewhat. (Probably little performance impact)
 - **Introduces limited display suppression for Index on web pages**
   - This is not a problem for English users at all.
   - For the multi-byte languages users, most of the artists are classified as "#", which is useless. Jpsonic has a mechanism to avoid this, but indexing a FileStructure can be difficult timing-wise. Strictly speaking, it cannot be processed until Reading is determined by comparing tag values and directory names after scanning is complete.
   - In the past, this was avoided by tentatively deciding how to read a directory when scanning, and overwriting the reading if specified by a tag. This specification will be removed in the next version. This is because there is a disadvantage that the number of processes increases.  (And if you don't know the reason, you can't understand why the data flow like that. Redundant codes.)
   - The problem is that browsing the index while scanning brings back the nightmare #####. To avoid this negative effect, the web page is modified so that the '#' index is not displayed during scanning. It is a specification that some functions cannot be used during scanning. There is nothing wrong with display suppression.
   - This specification does not apply to UPnP and Subaonic Apps other than web pages.
     - In UPnP, all communication is paging, so there is no problem in displaying even if all artists are temporarily classified as #. Update after scanning and it will be restored
     - The Subsonic app is also... no problem.
     - In the case of a web page, displaying too many artists in one index breaks it. This in itself can be improved, but it's a rather minor issue among all the problems with indexing web pages. Should be drastically improved ... ?
 - **Fixed how cover art is determined** : 
   - The process from the start of scanning to the cover art is as follows. The cover art process done in parsedAlbum has been moved to parseFileStructure.
     - procedure.checkMudicFolders
     - procedure.parseFileStructure
     - procedure.parseVideo
     - procedure.parsePodcast
     - procedure.iterateFileStructure
     - procedure.parsedAlbum 
   - Makes sense for the following reasons
     - Fewer open channels by doing the processing (even if more complicated code) in the parseFileStructure path stream.
     - Before iterateFileStructure, processing involving file IO will be finished. 
    - From the next version, ID3Artist and ID3Album's cover art paths will be differentially registered on the DB table. ID3 cover art is already available using BubbleUPnP etc.
 - Other fixes for caches, indexes, and SQL queries
___

#### Other Fixes

Minor fix. Although not directly related to the scan, we fixed the following points found during the operation check.

 - Remove "ALL" from UPnP albumArtists. Clients may have their own implementation of "ALL". Therefore, there is a history that it has been removed to avoid conflict.
 - Fix to avoid Exception page when NowPlaying songs are inaccessible. Originally, NowPlayingController only controls the web page transition destination. (There is no particularly strict security check, etc.) It will link to home if the song is deleted or something.
