### PR TITLE
Organize todo comments

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/Application.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/Application.java
@@ -64,7 +64,7 @@ import org.springframework.util.ReflectionUtils;
 
 @SpringBootApplication(exclude = { JmxAutoConfiguration.class, JdbcTemplateAutoConfiguration.class,
         DataSourceAutoConfiguration.class, DataSourceTransactionManagerAutoConfiguration.class,
-        MultipartAutoConfiguration.class, // TODO: update to use spring boot builtin multipart support
+        MultipartAutoConfiguration.class,
         LiquibaseAutoConfiguration.class }, scanBasePackages = { "com.tesshu.jpsonic", "com.tesshu.jpsonic" })
 @EnableScheduling
 public class Application extends SpringBootServletInitializer

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SubsonicRESTController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SubsonicRESTController.java
@@ -1102,17 +1102,6 @@ public class SubsonicRESTController {
         }
         playlistService.updatePlaylist(playlist);
 
-        // TODO: Add later
-        // for (String usernameToAdd : ServletRequestUtils.getStringParameters(request, "usernameToAdd")) {
-        // if (securityService.getUserByName(usernameToAdd) != null) {
-        // playlistService.addPlaylistUser(id, usernameToAdd);
-        // }
-        // }
-        // for (String usernameToRemove : ServletRequestUtils.getStringParameters(request, "usernameToRemove")) {
-        // if (securityService.getUserByName(usernameToRemove) != null) {
-        // playlistService.deletePlaylistUser(id, usernameToRemove);
-        // }
-        // }
         List<MediaFile> songs = playlistService.getFilesInPlaylist(id);
         int[] toRemove = ServletRequestUtils.getIntParameters(request, Attributes.Request.SONG_INDEX_TO_REMOVE.value());
         int[] toAdd = ServletRequestUtils.getIntParameters(request, Attributes.Request.SONG_ID_TO_ADD.value());
@@ -1286,7 +1275,6 @@ public class SubsonicRESTController {
 
         int size = ServletRequestUtils.getIntParameter(request, Attributes.Request.SIZE.value(), 10);
         size = Math.max(0, Math.min(size, 500));
-        // TODO #252
         List<String> genres = null;
         String genre = ServletRequestUtils.getStringParameter(request, Attributes.Request.GENRE.value());
         if (null != genre) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -760,12 +760,11 @@ public class MediaFileDao extends AbstractDao {
 
         Map<String, Object> args = LegacyMap.of("folders", MusicFolder.toPathList(criteria.getMusicFolders()),
                 "username", username, "fromYear", criteria.getFromYear(), "toYear", criteria.getToYear(), "genres",
-                criteria.getGenres(), // TODO to be revert
-                "minLastPlayed", criteria.getMinLastPlayedDate(), "maxLastPlayed", criteria.getMaxLastPlayedDate(),
-                "minAlbumRating", criteria.getMinAlbumRating(), "maxAlbumRating", criteria.getMaxAlbumRating(),
-                "minPlayCount", criteria.getMinPlayCount(), "maxPlayCount", criteria.getMaxPlayCount(), "starred",
-                criteria.isShowStarredSongs(), "unstarred", criteria.isShowUnstarredSongs(), "format",
-                criteria.getFormat());
+                criteria.getGenres(), "minLastPlayed", criteria.getMinLastPlayedDate(), "maxLastPlayed",
+                criteria.getMaxLastPlayedDate(), "minAlbumRating", criteria.getMinAlbumRating(), "maxAlbumRating",
+                criteria.getMaxAlbumRating(), "minPlayCount", criteria.getMinPlayCount(), "maxPlayCount",
+                criteria.getMaxPlayCount(), "starred", criteria.isShowStarredSongs(), "unstarred",
+                criteria.isShowUnstarredSongs(), "format", criteria.getFormat());
 
         return namedQuery(queryBuilder.build(), rowMapper, args);
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/security/JWTAuthenticationProvider.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/security/JWTAuthenticationProvider.java
@@ -66,7 +66,6 @@ public class JWTAuthenticationProvider implements AuthenticationProvider {
         Claim path = token.getClaim(JWTSecurityService.CLAIM_PATH);
         authentication.setAuthenticated(true);
 
-        // TODO:AD This is super unfortunate, but not sure there is a better way when using JSP
         if (StringUtils.contains(authentication.getRequestedPath(), "/WEB-INF/jsp/")) {
             LOG.warn("BYPASSING AUTH FOR WEB-INF page");
         } else if (!roughlyEqual(path.asString(), authentication.getRequestedPath())) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/JWTSecurityService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/JWTSecurityService.java
@@ -50,7 +50,7 @@ public class JWTSecurityService {
     private static final Logger LOG = LoggerFactory.getLogger(JWTSecurityService.class);
     public static final String JWT_PARAM_NAME = "jwt";
     public static final String CLAIM_PATH = "path";
-    public static final int DEFAULT_DAYS_VALID_FOR = 7; // TODO make this configurable
+    public static final int DEFAULT_DAYS_VALID_FOR = 7;
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
     public static final int WITH_FILE_EXTENSION = 4;
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicIndexService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicIndexService.java
@@ -104,8 +104,7 @@ public class MusicIndexService {
             for (MusicFolder musicFolder : musicFoldersToUse) {
                 Path shortcutPath = Path.of(musicFolder.getPathString(), shortcut);
                 if (Files.exists(shortcutPath)) {
-                    result.add(mediaFileService.getMediaFile(shortcutPath)); // TODO refresh ?
-                    // result.add(mediaFileService.getMediaFile(shortcutPath, true));
+                    result.add(mediaFileService.getMediaFile(shortcutPath));
                 }
             }
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PlaylistService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PlaylistService.java
@@ -204,7 +204,6 @@ public class PlaylistService {
     public Playlist importPlaylist(String username, String playlistName, String fileName, InputStream inputStream,
             Playlist existingPlaylist) throws ExecutionException {
 
-        // TODO: handle other encodings
         SpecificPlaylist inputSpecificPlaylist;
         try {
             inputSpecificPlaylist = SpecificPlaylistFactory.getInstance().readFrom(inputStream, "UTF-8");

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/TranscodingService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/TranscodingService.java
@@ -158,7 +158,6 @@ public class TranscodingService {
      * @return All active transcodings for the player.
      */
     public List<Transcoding> getTranscodingsForPlayer(@NonNull Player player) {
-        // FIXME - This should probably check isTranscodingInstalled()
         return transcodingDao.getTranscodingsForPlayer(player.getId());
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/UPnPService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/UPnPService.java
@@ -204,8 +204,6 @@ public class UPnPService {
      */
     private LocalDevice createMediaServerDevice() throws ExecutionException {
 
-        // TODO: DLNACaps
-
         @SuppressWarnings("unchecked")
         LocalService<CustomContentDirectory> directoryservice = new AnnotationLocalServiceBinder()
                 .read(CustomContentDirectory.class);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
@@ -590,7 +590,7 @@ public class ScannerProcedureService {
         }
     }
 
-    // TODO To be fixed in v111.7.0 #1927
+    // TODO To be fixed in v111.7.0 later #1925
     void scanPodcast(@NonNull Instant scanDate, @NonNull MusicFolder folder, @NonNull MediaFile file) {
         if (isInterrupted()) {
             return;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
@@ -222,14 +222,18 @@ public class ScannerProcedureService {
         createScanEvent(scanDate, ScanEventType.MUSIC_FOLDER_CHECK, comment);
     }
 
-    void parseFileStructure(@NonNull Instant scanDate) {
-        for (MusicFolder musicFolder : musicFolderService.getAllMusicFolders()) {
-            MediaFile root = wmfs.getMediaFile(scanDate, musicFolder.toPath());
-            if (root != null) {
-                mediaFileDao.updateLastScanned(root.getId(), scanDate);
-                scanFile(scanDate, musicFolder, root);
-            }
+    Optional<MediaFile> getRootDirectory(@NonNull Instant scanDate, Path path) {
+        MediaFile root = wmfs.getMediaFile(scanDate, path);
+        if (root != null) {
+            mediaFileDao.updateLastScanned(root.getId(), scanDate);
+            return Optional.of(root);
         }
+        return Optional.empty();
+    }
+
+    void parseFileStructure(@NonNull Instant scanDate) {
+        musicFolderService.getAllMusicFolders().forEach(folder -> getRootDirectory(scanDate, folder.toPath())
+                .ifPresent(root -> scanFile(scanDate, folder, root)));
         if (isInterrupted()) {
             return;
         }
@@ -580,14 +584,12 @@ public class ScannerProcedureService {
         if (settingsService.getPodcastFolder() == null) {
             return;
         }
-        Path podcastFolder = Path.of(settingsService.getPodcastFolder());
-        MediaFile root = wmfs.getMediaFile(scanDate, podcastFolder);
-        if (root != null) {
-            mediaFileDao.updateLastScanned(root.getId(), scanDate);
-            MusicFolder dummy = new MusicFolder(podcastFolder.toString(), null, true, null);
+        Path path = Path.of(settingsService.getPodcastFolder());
+        MusicFolder dummy = new MusicFolder(path.toString(), null, true, null);
+        getRootDirectory(scanDate, path).ifPresent(root -> {
             scanPodcast(scanDate, dummy, root);
             createScanEvent(scanDate, ScanEventType.PARSE_PODCAST, null);
-        }
+        });
     }
 
     // TODO To be fixed in v111.7.0 later #1925

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/WritableMediaFileService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/WritableMediaFileService.java
@@ -493,8 +493,9 @@ public class WritableMediaFileService {
     }
 
     /*
-     * TODO To be fixed in v111.6.0 #1927. Used for some tag updates. Note that it only updates the tags and does not
-     * take into account the completeness of the scan.
+     * TODO To be fixed in v111.7.0 later #1925. Used for some tag updates. Note that it only updates the tags and does
+     * not take into account the completeness of the scan. Strictly speaking, processing equivalent to partial scan is
+     * required.
      */
     @Deprecated
     void refreshMediaFile(@NonNull MediaFile mediaFile) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/WritableMediaFileService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/WritableMediaFileService.java
@@ -106,9 +106,9 @@ public class WritableMediaFileService {
     }
 
     /**
-     * Use of this method suggests imperfect workflow design.
+     * Logic that relies on this method needs to be rewritten since v111.7.0. It suggests imperfect workflow design.
      *
-     * @deprecated Spec subject to change
+     * @deprecated Use the date logged should be used instead of now()
      */
     @Deprecated
     Instant newScanDate() {
@@ -116,7 +116,7 @@ public class WritableMediaFileService {
     }
 
     /**
-     * Will be removed in v111.7.0. Use of this method suggests imperfect workflow design.
+     * Logic that relies on this method needs to be rewritten since v111.7.0. It suggests imperfect workflow design.
      *
      * @deprecated Use MediaFileService#getMediaFile if use the cache, otherwise use
      *             WritableMediaFileService#getMediaFile(Instant, Path)
@@ -128,12 +128,10 @@ public class WritableMediaFileService {
     }
 
     /**
-     * Will be removed in v111.7.0.
-     *
-     * @deprecated Only used on top nodes in scans. So creating a top-level node is necessary and there should be no
-     *             need to provide a multipurpose method.
+     * Returns a Mediafile for the directory or file indicated by path. Logic using this method was used outside of the
+     * normal scan flow in legacy code. Therefore, special data may be created. In particular, the record lifecycle and
+     * format should be scrutinized.
      */
-    @Deprecated
     @Nullable
     MediaFile getMediaFile(@NonNull Instant scanDate, @Nullable Path path) {
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/concurrent/ExecutorConfiguration.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/concurrent/ExecutorConfiguration.java
@@ -35,7 +35,6 @@ import org.springframework.scheduling.concurrent.DefaultManagedAwareThreadFactor
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
-// TODO #833 Scalability considerations
 @Configuration
 @EnableAsync
 public class ExecutorConfiguration {

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/AbstractNeedsScan.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/AbstractNeedsScan.java
@@ -54,7 +54,6 @@ import org.springframework.test.annotation.DirtiesContext;
  */
 @SpringBootTest
 @ExtendWith(NeedsHome.class)
-// TODO Separate classes that require DirtiesContext from those that don't
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public abstract class AbstractNeedsScan implements NeedsScan {
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/TestCaseUtils.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/TestCaseUtils.java
@@ -116,7 +116,6 @@ public final class TestCaseUtils {
      * Scans the music library * @param mediaScannerService
      */
     public static void execScan(MediaScannerService mediaScannerService) {
-        // TODO create a synchronous scan
         mediaScannerService.scanLibrary();
 
         while (mediaScannerService.isScanning()) {

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/QueryFactoryTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/QueryFactoryTest.java
@@ -163,12 +163,9 @@ class QueryFactoryTest {
         assertEquals("(tit:\"cats and dogs\"~1)^6.0 (art:\"cats and dogs\"~1)^4.0 (artR:\"cats and dogs\"~1)^4.2",
                 queryFactory.createPhraseQuery(IndexType.SONG.getFields(), "Cats and Dogs", IndexType.SONG).get()
                         .toString());
-
-        // XXX Yes! Comment out because PMD causes an error!
-
-        // assertEquals(
-        // "(tit:\"いぬ と ねこ\"~1)^6.0 (titR:\"いぬ ぬと とね ねこ\"~1)^6.2 (art:\"いぬ と ねこ\"~1)^4.0 (artR:\"いぬ ぬと とね ねこ\"~1)^4.2",
-        // queryFactory.createPhraseQuery(IndexType.SONG.getFields(), "いぬとねこ", IndexType.SONG).toString());
+        assertEquals(
+                "(tit:\"いぬ と ねこ\"~1)^6.0 (titR:\"いぬ ぬと とね ねこ\"~1)^6.2 (art:\"いぬ と ねこ\"~1)^4.0 (artR:\"いぬ ぬと とね ねこ\"~1)^4.2",
+                queryFactory.createPhraseQuery(IndexType.SONG.getFields(), "いぬとねこ", IndexType.SONG).get().toString());
     }
 
     @Test
@@ -185,25 +182,17 @@ class QueryFactoryTest {
                 queryFactory.searchByPhrase("Cats and Dogs", false, SINGLE_FOLDERS, IndexType.ALBUM_ID3).toString());
         assertEquals("+(art:\"cats and dogs\"~1 (artR:\"cats and dogs\"~1)^2.2) +(fId:" + FID1 + ")",
                 queryFactory.searchByPhrase("Cats and Dogs", false, SINGLE_FOLDERS, IndexType.ARTIST_ID3).toString());
-
-        // XXX Yes! Comment out because PMD causes an error!
-
-        // assertEquals(
-        // "+((tit:\"いぬ と ねこ\"~1)^6.0 (titR:\"いぬ ぬと とね ねこ\"~1)^6.2 (art:\"いぬ と ねこ\"~1)^4.0 (artR:\"いぬ ぬと とね ねこ\"~1)^4.2)
-        // +(f:"
-        // + PATH1 + ")",
-        // queryFactory.searchByPhrase("いぬとねこ", false, SINGLE_FOLDERS, IndexType.SONG).toString());
+        assertEquals(
+                "+((tit:\"いぬ と ねこ\"~1)^6.0 (titR:\"いぬ ぬと とね ねこ\"~1)^6.2 (art:\"いぬ と ねこ\"~1)^4.0 (artR:\"いぬ ぬと とね ねこ\"~1)^4.2)"
+                        + " +(f:" + PATH1 + ")",
+                queryFactory.searchByPhrase("いぬとねこ", false, SINGLE_FOLDERS, IndexType.SONG).toString());
 
         Mockito.when(settingsService.getIndexSchemeName()).thenReturn(IndexScheme.WITHOUT_JP_LANG_PROCESSING.name());
         queryFactory = new QueryFactory(settingsService, new AnalyzerFactory(settingsService));
-
-        // XXX Yes! Comment out because PMD causes an error!
-
-        // assertEquals(
-        // "+((tit:\"い ぬ と ね こ\"~1)^6.0 (titR:\"いぬ ぬと とね ねこ\"~1)^6.2 (art:\"い ぬ と ね こ\"~1)^4.0 (artR:\"いぬ ぬと とね
-        // ねこ\"~1)^4.2) +(f:"
-        // + PATH1 + ")",
-        // queryFactory.searchByPhrase("いぬとねこ", false, SINGLE_FOLDERS, IndexType.SONG).toString());
+        assertEquals(
+                "+((tit:\"い ぬ と ね こ\"~1)^6.0 (titR:\"いぬ ぬと とね ねこ\"~1)^6.2 (art:\"い ぬ と ね こ\"~1)^4.0 (artR:\"いぬ ぬと とね ねこ\"~1)^4.2) +(f:"
+                        + PATH1 + ")",
+                queryFactory.searchByPhrase("いぬとねこ", false, SINGLE_FOLDERS, IndexType.SONG).toString());
 
         Mockito.when(settingsService.getIndexSchemeName()).thenReturn(IndexScheme.ROMANIZED_JAPANESE.name());
         queryFactory = new QueryFactory(settingsService, new AnalyzerFactory(settingsService));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/SearchServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/SearchServiceTest.java
@@ -157,16 +157,7 @@ class SearchServiceTest {
                     IndexType.SONG);
             result = searchService.search(searchCriteria);
 
-            assertEquals(0, // XXX
-                    // Legacy
-                    // ->
-                    // Phrase
-                    // Fix
-                    // for
-                    // missing
-                    // cases
-                    // (#491)
-                    result.getTotalHits(),
+            assertEquals(0, result.getTotalHits(),
                     "(11) Specify album '" + searchCriteria.getQuery() + "' as query, total Hits is");
             assertEquals(0, result.getArtists().size(),
                     "(12) Specify album '" + searchCriteria.getQuery() + "', and get a song. Artist SIZE is");
@@ -174,18 +165,6 @@ class SearchServiceTest {
                     "(13) Specify album '" + searchCriteria.getQuery() + "', and get a song. Album SIZE is");
             assertEquals(0, result.getMediaFiles().size(),
                     "(14) Specify album '" + searchCriteria.getQuery() + "', and get a song. MediaFile SIZE is");
-            // XXX Legacy -> Phrase Fix for missing cases (#491)
-            // assertEquals("(15) Specify album '" + searchCriteria.getQuery() + "', and get songs. The first song is
-            // ", "01 - Gaspard de la Nuit - i. Ondine", result.getMediaFiles().get(0).getTitle());
-            // assertEquals("(16) Specify album '" + searchCriteria.getQuery() + "', and get songs. The second song
-            // is ", "02 - Gaspard de la Nuit - ii. Le Gibet", result.getMediaFiles().get(1).getTitle());
-            // if ("01 - Gaspard de la Nuit - i. Ondine".equals(result.getMediaFiles().get(0).getName())) {
-            // assertEquals("02 - Gaspard de la Nuit - ii. Le Gibet", result.getMediaFiles().get(1).getName());
-            // } else if ("02 - Gaspard de la Nuit - ii. Le Gibet".equals(result.getMediaFiles().get(0).getName())) {
-            // assertEquals("01 - Gaspard de la Nuit - i. Ondine", result.getMediaFiles().get(1).getName());
-            // } else {
-            // fail("Search results are not correct.");
-            // }
 
             // *** testGetRandomSongs() ***
 
@@ -263,25 +242,8 @@ class SearchServiceTest {
             searchCriteria = director.construct("ID 3 ARTIST", offset, count, false, allMusicFolders,
                     IndexType.ARTIST_ID3);
             result = searchService.search(searchCriteria);
-            assertEquals(3, // XXX Legacy(4) ->
-                    // Phrase(3) Accuracy
-                    // was improved by
-                    // considering the
-                    // word order
-                    result.getTotalHits(), "(29) Specify '" + searchCriteria.getQuery() + "', total Hits is");
-            assertEquals(3, // XXX
-                            // Legacy(4)
-                            // ->
-                            // Phrase(3)
-                            // Accuracy
-                            // was
-                            // improved
-                            // by
-                            // considering
-                            // the
-                            // word
-                            // order
-                    result.getArtists().size(),
+            assertEquals(3, result.getTotalHits(), "(29) Specify '" + searchCriteria.getQuery() + "', total Hits is");
+            assertEquals(3, result.getArtists().size(),
                     "(30) Specify '" + searchCriteria.getQuery() + "', and get an artists. Artist SIZE is ");
             assertEquals(0, result.getAlbums().size(),
                     "(31) Specify '" + searchCriteria.getQuery() + "', and get a artists. Album SIZE is ");
@@ -301,11 +263,7 @@ class SearchServiceTest {
              * duplicates. And ALBUMARTIST must be returned correctly.)
              */
             l = result.getArtists().stream().filter(a -> a.getName().startsWith("_ID3_ALBUMARTIST_")).count();
-            assertEquals(0L, l, "(34) Artist whose name is \"_ID3_ARTIST_\" is 1 records."); // XXX Legacy(1L) ->
-                                                                                             // Phrase(0L) Any
-                                                                                             // deficiencies in the
-                                                                                             // test? Healthy on the
-                                                                                             // web.
+            assertEquals(0L, l, "(34) Artist whose name is \"_ID3_ARTIST_\" is 1 records.");
 
             /*
              * Below is a simple loop test. How long is the total time?
@@ -609,7 +567,7 @@ class SearchServiceTest {
          * Legacy can not search all these genres. (Strictly speaking, the genre field is not created at index
          * creation.)
          *
-         * // XXX 3.x -> 8.x : Do the process more strictly.
+         * // 3.x -> 8.x : Do the process more strictly.
          *
          * - Values ​​that can be cross-referenced with DB are stored in the index. - Search is also possible with
          * user's readable value (file tag value). - However, there is an exception in parentheses.
@@ -626,27 +584,27 @@ class SearchServiceTest {
             );
 
             List<MediaFile> songs = searchService.getRandomSongs(simpleStringCriteria.apply("+"));
-            assertEquals(1, songs.size()); // XXX 3.x -> 8.x : Searchable
+            assertEquals(1, songs.size()); // Searchable
             assertEquals("+", songs.get(0).getGenre());
             assertEquals("Query Escape Requires 1", songs.get(0).getTitle());
 
             songs = searchService.getRandomSongs(simpleStringCriteria.apply("-"));
-            assertEquals(1, songs.size()); // XXX 3.x -> 8.x : Searchable
+            assertEquals(1, songs.size()); // Searchable
             assertEquals("-", songs.get(0).getGenre());
             assertEquals("Query Escape Requires 2", songs.get(0).getTitle());
 
             songs = searchService.getRandomSongs(simpleStringCriteria.apply("&&"));
-            assertEquals(1, songs.size()); // XXX 3.x -> 8.x : Searchable
+            assertEquals(1, songs.size()); // Searchable
             assertEquals("&&", songs.get(0).getGenre());
             assertEquals("Query Escape Requires 3", songs.get(0).getTitle());
 
             songs = searchService.getRandomSongs(simpleStringCriteria.apply("||"));
-            assertEquals(1, songs.size()); // XXX 3.x -> 8.x : Searchable
+            assertEquals(1, songs.size()); // Searchable
             assertEquals("||", songs.get(0).getGenre());
             assertEquals("Query Escape Requires 4", songs.get(0).getTitle());
 
             /*
-             * // XXX 3.x -> 8.x : Brackets ()
+             * // 3.x -> 8.x : Brackets ()
              *
              * Lucene can handle these. However, brackets are specially parsed before the index creation process.
              *
@@ -659,91 +617,80 @@ class SearchServiceTest {
             assertEquals(0, songs.size());
 
             /*
-             * // XXX 3.x -> 8.x : Brackets {}[]
+             * // 3.x -> 8.x : Brackets {}[]
              *
              * Lucene can handle these. However, brackets are specially parsed before the index creation process.
              *
              * This can be done with a filter that performs the reverse process on the input values ​​when searching. As
              * a result, the values ​​stored in the file can be retrieved by search.
-             *
-             * @see AnalyzerFactory <<<<<<<
-             * HEAD:jpsonic-main/src/test/java/org/airsonic/player/service/search/SearchServiceSpecialGenreTestCase.java
-             *
-             *
-             * =======
-             *
-             * >>>>> >>>>>>>
-             * ec426fc:airsonic-main/src/test/java/org/airsonic/player/service/search/SearchServiceSpecialGenreTestCase.
-             * java
              */
             songs = searchService.getRandomSongs(simpleStringCriteria.apply("{}"));
-            assertEquals(1, songs.size()); // XXX 3.x -> 8.x : Searchable
+            assertEquals(1, songs.size()); // Searchable
             /*
              * This is the result of the tag parser and domain value. It is different from the tag value in file.
              */
             assertEquals("{ }", songs.get(0).getGenre());
             assertEquals("Query Escape Requires 7", songs.get(0).getTitle());
             songs = searchService.getRandomSongs(simpleStringCriteria.apply("{ }"));
-            assertEquals(1, songs.size()); // XXX 3.x -> 8.x : Searchable
+            assertEquals(1, songs.size()); // Searchable
             assertEquals("Query Escape Requires 7", songs.get(0).getTitle());
 
             songs = searchService.getRandomSongs(simpleStringCriteria.apply("[]"));
-            assertEquals(1, songs.size()); // XXX 3.x -> 8.x : Searchable
+            assertEquals(1, songs.size()); // Searchable
             /*
              * This is the result of the tag parser and domain value. It is different from the tag value in file.
              */
             assertEquals("[ ]", songs.get(0).getGenre());
             assertEquals("Query Escape Requires 8", songs.get(0).getTitle());
             songs = searchService.getRandomSongs(simpleStringCriteria.apply("[ ]"));
-            assertEquals(1, songs.size()); // XXX 3.x -> 8.x : Searchable
+            assertEquals(1, songs.size()); // Searchable
             assertEquals("Query Escape Requires 8", songs.get(0).getTitle());
             // <<<<<
 
             songs = searchService.getRandomSongs(simpleStringCriteria.apply("^"));
-            assertEquals(1, songs.size()); // XXX 3.x -> 8.x : Searchable
+            assertEquals(1, songs.size()); // Searchable
             assertEquals("^", songs.get(0).getGenre());
             assertEquals("Query Escape Requires 9", songs.get(0).getTitle());
 
             songs = searchService.getRandomSongs(simpleStringCriteria.apply("\""));
-            assertEquals(1, songs.size()); // XXX 3.x -> 8.x : Searchable
+            assertEquals(1, songs.size()); // Searchable
             assertEquals("\"", songs.get(0).getGenre());
             assertEquals("Query Escape Requires 10", songs.get(0).getTitle());
 
             songs = searchService.getRandomSongs(simpleStringCriteria.apply("~"));
-            assertEquals(1, songs.size()); // XXX 3.x -> 8.x : Searchable
+            assertEquals(1, songs.size()); // Searchable
             assertEquals("~", songs.get(0).getGenre());
             assertEquals("Query Escape Requires 11", songs.get(0).getTitle());
 
             songs = searchService.getRandomSongs(simpleStringCriteria.apply("*"));
-            assertEquals(1, songs.size()); // XXX 3.x -> 8.x : Searchable
+            assertEquals(1, songs.size()); // Searchable
             assertEquals("*", songs.get(0).getGenre());
             assertEquals("Query Escape Requires 12", songs.get(0).getTitle());
 
             songs = searchService.getRandomSongs(simpleStringCriteria.apply("?"));
-            assertEquals(1, songs.size()); // XXX 3.x -> 8.x : Searchable
+            assertEquals(1, songs.size()); // Searchable
             assertEquals("?", songs.get(0).getGenre());
             assertEquals("Query Escape Requires 13", songs.get(0).getTitle());
 
             songs = searchService.getRandomSongs(simpleStringCriteria.apply(":"));
-            assertEquals(1, songs.size()); // XXX 3.x -> 8.x : Searchable
+            assertEquals(1, songs.size()); // Searchable
             assertEquals(":", songs.get(0).getGenre());
             assertEquals("Query Escape Requires 14", songs.get(0).getTitle());
 
             songs = searchService.getRandomSongs(simpleStringCriteria.apply("\\"));
-            assertEquals(1, songs.size()); // XXX 3.x -> 8.x : Searchable
+            assertEquals(1, songs.size()); // Searchable
             assertEquals("\\", songs.get(0).getGenre());
             assertEquals("Query Escape Requires 15", songs.get(0).getTitle());
 
             songs = searchService.getRandomSongs(simpleStringCriteria.apply("/"));
-            assertEquals(1, songs.size()); // XXX 3.x -> 8.x : Searchable
+            assertEquals(1, songs.size()); // Searchable
             assertEquals("/", songs.get(0).getGenre());
             assertEquals("Query Escape Requires 16", songs.get(0).getTitle());
 
         }
 
         /*
-         * Jaudiotagger applies special treatment to bracket (FILE17). XXX 3.x -> 8.x : Specification of genre search
-         * became more natural.
+         * 3.x -> 8.x : Specification of genre search. Jaudiotagger applies special treatment to bracket (FILE17).
          */
         @Test
         void testBrackets() {
@@ -828,7 +775,7 @@ class SearchServiceTest {
                     getMusicFolders() // musicFolders
             );
 
-            // XXX 3.x -> 8.x : Do the process more strictly.
+            // 3.x -> 8.x : Do the process more strictly.
             List<MediaFile> songs = searchService
                     .getRandomSongs(simpleStringCriteria.apply("{'“『【【】】[︴○◎@ $〒→+]ＦＵＬＬ－ＷＩＤＴＨCæsar's"));
             assertEquals(1, songs.size());
@@ -955,32 +902,31 @@ class SearchServiceTest {
             // search rather than a term prefix match.
             assertEquals(0, result.getTotalHits(), "Williams hit by \"will\" ");
 
-            // XXX legacy -> phrase
             criteria = director.construct("williams", offset, count, false, folders, IndexType.ARTIST_ID3);
             result = searchService.search(criteria);
             assertEquals(1, result.getTotalHits(), "Williams hit by \"williams\" ");
 
             criteria = director.construct("the", offset, count, false, folders, IndexType.SONG);
             result = searchService.search(criteria);
-            // XXX 3.x -> 8.x : The filter is properly applied to the input(Stopward)
+            // 3.x -> 8.x : The filter is properly applied to the input(Stopward)
             assertEquals(0, result.getTotalHits(), "Theater hit by \"the\" ");
 
             criteria = director.construct("willi", offset, count, false, folders, IndexType.ARTIST_ID3);
             result = searchService.search(criteria);
-            // XXX 3.x -> 8.x : Normal forward matching => This case does not hit because it is a phrase search rather
+            // 3.x -> 8.x : Normal forward matching => This case does not hit because it is a phrase search rather
             // than
             // a term prefix match.
             assertEquals(0, result.getTotalHits(), "Williams hit by \"Williams\" ");
 
             criteria = director.construct("thea", offset, count, false, folders, IndexType.SONG);
             result = searchService.search(criteria);
-            // XXX 3.x -> 8.x : Normal forward matching
+            // 3.x -> 8.x : Normal forward matching
             assertEquals(0, result.getTotalHits(), "Theater hit by \"thea\" "); // => This case does not hit
                                                                                 // because
             // it is a phrase search rather than
             // a term prefix match.
 
-            // XXX legacy -> phrase
+            // legacy -> phrase
             criteria = director.construct("theater", offset, count, false, folders, IndexType.SONG);
             result = searchService.search(criteria);
             assertEquals(1, result.getTotalHits(), "Theater hit by \"theater\" ");


### PR DESCRIPTION
Most comments containing `TODO` or `XXX` are removed. (`TODO` or `XXX` are keywords used for listing in Eclipse's task view.)

 - Most of these are now noise or related issues have already been published. 
 - A few simple TODO, such as test fixes, were resolved in this commit

As few comments as possible seems ideal ...