### PR TITLE
Improve skip scan process

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MusicFolderSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MusicFolderSettingsController.java
@@ -25,6 +25,7 @@ import static com.tesshu.jpsonic.util.PlayerUtils.now;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -157,18 +158,21 @@ public class MusicFolderSettingsController {
     protected ModelAndView post(@ModelAttribute(Attributes.Model.Command.VALUE) MusicFolderSettingsCommand command,
             RedirectAttributes redirectAttributes) {
 
+        Instant executed = now();
+
         // Specify folder
         for (MusicFolderSettingsCommand.MusicFolderInfo musicFolderInfo : command.getMusicFolders()) {
             if (musicFolderInfo.isDelete()) {
-                musicFolderService.deleteMusicFolder(musicFolderInfo.getId());
+                musicFolderService.deleteMusicFolder(executed, musicFolderInfo.getId());
             } else {
-                toMusicFolder(musicFolderInfo).ifPresent(folder -> musicFolderService.updateMusicFolder(folder));
+                toMusicFolder(musicFolderInfo)
+                        .ifPresent(folder -> musicFolderService.updateMusicFolder(executed, folder));
             }
         }
         toMusicFolder(command.getNewMusicFolder()).ifPresent(newFolder -> {
             if (musicFolderService.getAllMusicFolders(false, true).stream()
                     .noneMatch(oldFolder -> oldFolder.getPathString().equals(newFolder.getPathString()))) {
-                musicFolderService.createMusicFolder(newFolder);
+                musicFolderService.createMusicFolder(executed, newFolder);
             }
         });
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/ScanEvent.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/ScanEvent.java
@@ -108,6 +108,10 @@ public class ScanEvent {
         DESTROYED,
         CANCELED,
 
+        FOLDER_CREATE,
+        FOLDER_DELETE,
+        FOLDER_UPDATE,
+        
         BEFORE_SCAN,
         MUSIC_FOLDER_CHECK,
         PARSE_FILE_STRUCTURE,

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
@@ -213,9 +213,7 @@ public class ScannerProcedureService {
         });
         String comment = "All registered music folders exist.";
         if (notExist.intValue() > 0) {
-            comment = String.format(
-                    "(%d) music folders that do not exist are registered. (%d) music folders changed to enabled.",
-                    notExist.intValue(), enabled.intValue());
+            comment = String.format("(%d) music folders changed to enabled.", notExist.intValue());
             if (LOG.isWarnEnabled()) {
                 LOG.warn(comment);
             }
@@ -611,11 +609,11 @@ public class ScannerProcedureService {
         }
     }
 
-    void updateAlbumCounts(@NonNull Instant scanDate, boolean toBeCounted) {
+    void updateAlbumCounts(@NonNull Instant scanDate, boolean skippable) {
         if (isInterrupted()) {
             return;
         }
-        if (!toBeCounted) {
+        if (skippable) {
             createScanEvent(scanDate, ScanEventType.UPDATE_ALBUM_COUNTS, MSG_UNNECESSARY);
             return;
         }
@@ -711,7 +709,7 @@ public class ScannerProcedureService {
         return updated;
     }
 
-    void updateOrderOfArtist(@NonNull Instant scanDate, boolean toBeSorted) {
+    void updateOrderOfArtist(@NonNull Instant scanDate, boolean skippable) {
         if (isInterrupted()) {
             return;
         }
@@ -719,7 +717,7 @@ public class ScannerProcedureService {
             createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ARTIST, MSG_SKIP);
             return;
         }
-        if (!toBeSorted) {
+        if (skippable) {
             createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ARTIST, MSG_UNNECESSARY);
             return;
         }
@@ -728,7 +726,7 @@ public class ScannerProcedureService {
         createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ARTIST, comment);
     }
 
-    void updateOrderOfAlbum(@NonNull Instant scanDate, boolean toBeSorted) {
+    void updateOrderOfAlbum(@NonNull Instant scanDate, boolean skippable) {
         if (isInterrupted()) {
             return;
         }
@@ -736,7 +734,7 @@ public class ScannerProcedureService {
             createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ALBUM, MSG_SKIP);
             return;
         }
-        if (!toBeSorted) {
+        if (skippable) {
             createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ALBUM, MSG_UNNECESSARY);
             return;
         }
@@ -745,7 +743,7 @@ public class ScannerProcedureService {
         createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ALBUM, comment);
     }
 
-    void updateOrderOfArtistId3(@NonNull Instant scanDate, boolean toBeSorted) {
+    void updateOrderOfArtistId3(@NonNull Instant scanDate, boolean skippable) {
         if (isInterrupted()) {
             return;
         }
@@ -753,7 +751,7 @@ public class ScannerProcedureService {
             createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ARTIST_ID3, MSG_SKIP);
             return;
         }
-        if (!toBeSorted) {
+        if (skippable) {
             createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ARTIST_ID3, MSG_UNNECESSARY);
             return;
         }
@@ -762,7 +760,7 @@ public class ScannerProcedureService {
         createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ARTIST_ID3, comment);
     }
 
-    void updateOrderOfAlbumId3(@NonNull Instant scanDate, boolean toBeSorted) {
+    void updateOrderOfAlbumId3(@NonNull Instant scanDate, boolean skippable) {
         if (isInterrupted()) {
             return;
         }
@@ -770,7 +768,7 @@ public class ScannerProcedureService {
             createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ALBUM_ID3, MSG_SKIP);
             return;
         }
-        if (!toBeSorted) {
+        if (skippable) {
             createScanEvent(scanDate, ScanEventType.UPDATE_ORDER_OF_ALBUM_ID3, MSG_UNNECESSARY);
             return;
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
@@ -146,7 +146,8 @@ public class ScannerProcedureService {
     }
 
     void createScanLog(@NonNull Instant scanDate, @NonNull ScanLogType logType) {
-        if (logType == ScanLogType.SCAN_ALL || logType == ScanLogType.EXPUNGE || settingsService.isUseScanLog()) {
+        if (logType == ScanLogType.SCAN_ALL || logType == ScanLogType.EXPUNGE || logType == ScanLogType.FOLDER_CHANGED
+                || settingsService.isUseScanLog()) {
             staticsDao.createScanLog(scanDate, logType);
         }
     }
@@ -205,7 +206,7 @@ public class ScannerProcedureService {
                 if (folder.isEnabled()) {
                     folder.setEnabled(false);
                     folder.setChanged(scanDate);
-                    musicFolderService.updateMusicFolder(folder);
+                    musicFolderService.updateMusicFolder(scanDate, folder);
                     enabled.increment();
                 }
             }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
@@ -157,9 +157,7 @@ public class IndexManager {
         try {
             writers.get(IndexType.ALBUM_ID3).updateDocument(primarykey, document);
         } catch (IOException e) {
-            if (LOG.isErrorEnabled()) {
-                LOG.error("Failed to create search index for " + album, e);
-            }
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -169,10 +167,8 @@ public class IndexManager {
         Document document = documentFactory.createArtistId3Document(artist, musicFolder);
         try {
             writers.get(IndexType.ARTIST_ID3).updateDocument(primarykey, document);
-        } catch (IOException x) {
-            if (LOG.isErrorEnabled()) {
-                LOG.error("Failed to create search index for " + artist, x);
-            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -196,10 +192,8 @@ public class IndexManager {
                 Document document = documentFactory.createGenreDocument(mediaFile);
                 writers.get(IndexType.GENRE).updateDocument(genrekey, document);
             }
-        } catch (IOException x) {
-            if (LOG.isErrorEnabled()) {
-                LOG.error("Failed to create search index for " + mediaFile, x);
-            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -210,7 +204,7 @@ public class IndexManager {
                 writers.put(indexType, createIndexWriter(indexType));
             }
         } catch (IOException e) {
-            LOG.error("Failed to create search index.", e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -231,7 +225,7 @@ public class IndexManager {
         try {
             writers.get(IndexType.ARTIST).deleteDocuments(DocumentFactory.createPrimarykey(id));
         } catch (IOException e) {
-            LOG.error("Failed to delete artist doc.", e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -240,7 +234,7 @@ public class IndexManager {
         try {
             writers.get(IndexType.ALBUM).deleteDocuments(DocumentFactory.createPrimarykey(id));
         } catch (IOException e) {
-            LOG.error("Failed to delete album doc.", e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -249,7 +243,7 @@ public class IndexManager {
         try {
             writers.get(IndexType.SONG).deleteDocuments(DocumentFactory.createPrimarykey(id));
         } catch (IOException e) {
-            LOG.error("Failed to delete song doc.", e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -259,7 +253,7 @@ public class IndexManager {
         try {
             writers.get(IndexType.ARTIST_ID3).deleteDocuments(primarykeys);
         } catch (IOException e) {
-            LOG.error("Failed to delete artistId3 doc.", e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -269,7 +263,7 @@ public class IndexManager {
         try {
             writers.get(IndexType.ALBUM_ID3).deleteDocuments(primarykeys);
         } catch (IOException e) {
-            LOG.error("Failed to delete albumId3 doc.", e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -287,7 +281,7 @@ public class IndexManager {
                     return;
                 }
             } catch (IOException e) {
-                LOG.error("Failed to clear genre index.", e);
+                throw new UncheckedIOException(e);
             }
 
             // Stop indexing to get Searcher.
@@ -310,15 +304,14 @@ public class IndexManager {
                         .collect(Collectors.toList());
                 List<String> existingNames = existing.stream().map(g -> g.getName()).collect(Collectors.toList());
                 Term[] primarykeys = indexedNames.stream().filter(name -> !existingNames.contains(name))
-                        .map(name -> name.hashCode())
-                        .map(DocumentFactory::createPrimarykey).toArray(Term[]::new);
+                        .map(name -> name.hashCode()).map(DocumentFactory::createPrimarykey).toArray(Term[]::new);
 
                 // Reopen Writer for editing.
                 writers.put(IndexType.GENRE, createIndexWriter(IndexType.GENRE));
                 writers.get(IndexType.GENRE).deleteDocuments(primarykeys);
 
             } catch (IOException e) {
-                LOG.error("Failed to expunge genre index.", e);
+                throw new UncheckedIOException(e);
             } catch (Exception e) {
                 LOG.info("The genre field may not exist.");
             } finally {
@@ -345,38 +338,28 @@ public class IndexManager {
             "RCN_REDUNDANT_NULLCHECK_OF_NULL_VALU" }, justification = "spotbugs/spotbugs#1338")
     private void stopIndexing(IndexType type) {
 
-        boolean isUpdate = false;
         // close
         try (IndexWriter writer = writers.get(type)) {
             if (writer == null) {
                 return;
             }
-            isUpdate = -1 != writers.get(type).commit();
+            writers.get(type).commit();
             writer.close();
             writers.remove(type);
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("Success to create or update search index : [" + type + "]");
-            }
         } catch (IOException e) {
             writers.remove(type);
-            LOG.error("Failed to create search index.", e);
+            throw new UncheckedIOException(e);
         }
 
         // refresh reader as index may have been written
-        if (isUpdate && searchers.containsKey(type)) {
+        if (searchers.containsKey(type)) {
             try {
                 searchers.get(type).maybeRefresh();
-                if (LOG.isTraceEnabled()) {
-                    LOG.trace("SearcherManager has been refreshed : [" + type + "]");
-                }
             } catch (IOException e) {
-                if (LOG.isErrorEnabled()) {
-                    LOG.error("Failed to refresh SearcherManager : [" + type + "]", e);
-                }
                 searchers.remove(type);
+                throw new UncheckedIOException(e);
             }
         }
-
     }
 
     /**
@@ -428,8 +411,8 @@ public class IndexManager {
                 try {
                     searchers.get(indexType).release(indexSearcher);
                 } catch (IOException e) {
-                    LOG.error("Failed to release IndexSearcher.", e);
                     searchers.remove(indexType);
+                    throw new UncheckedIOException(e);
                 }
             } else {
                 try {
@@ -441,7 +424,7 @@ public class IndexManager {
                         indexSearcher.getIndexReader().close();
                     }
                 } catch (IOException e) {
-                    LOG.warn("Failed to release. IndexSearcher has been closed.", e);
+                    throw new UncheckedIOException(e);
                 }
             }
         }
@@ -561,7 +544,7 @@ public class IndexManager {
                 }
             }
         } catch (IOException e) {
-            LOG.error("Failed to execute Lucene search.", e);
+            throw new UncheckedIOException(e);
         } finally {
             release(IndexType.GENRE, searcher);
         }
@@ -659,7 +642,7 @@ public class IndexManager {
                 }
             }
         } catch (IOException e) {
-            LOG.error("Failed to execute Lucene search.", e);
+            throw new UncheckedIOException(e);
         } finally {
             release(IndexType.GENRE, genreSearcher);
             release(IndexType.SONG, songSearcher);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
@@ -192,7 +192,7 @@ public class IndexManager {
             }
             String genre = mediaFile.getGenre();
             if (!isEmpty(genre) && mediaFile.getMediaType() != MediaType.PODCAST) {
-                Term genrekey = DocumentFactory.createPrimarykey(genre);
+                Term genrekey = DocumentFactory.createPrimarykey(genre.hashCode());
                 Document document = documentFactory.createGenreDocument(mediaFile);
                 writers.get(IndexType.GENRE).updateDocument(genrekey, document);
             }
@@ -310,6 +310,7 @@ public class IndexManager {
                         .collect(Collectors.toList());
                 List<String> existingNames = existing.stream().map(g -> g.getName()).collect(Collectors.toList());
                 Term[] primarykeys = indexedNames.stream().filter(name -> !existingNames.contains(name))
+                        .map(name -> name.hashCode())
                         .map(DocumentFactory::createPrimarykey).toArray(Term[]::new);
 
                 // Reopen Writer for editing.

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/AbstractNeedsScan.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/AbstractNeedsScan.java
@@ -93,8 +93,8 @@ public abstract class AbstractNeedsScan implements NeedsScan {
 
     @PostConstruct
     public void init() {
-        mediaScannerService = new MediaScannerServiceImpl(scannerStateService, procedure, expungeService, staticsDao,
-                scanExecutor);
+        mediaScannerService = new MediaScannerServiceImpl(settingsService, scannerStateService, procedure,
+                expungeService, staticsDao, scanExecutor);
     }
 
     public interface BeforeScan extends Supplier<Boolean> {

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MusicFolderSettingsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MusicFolderSettingsControllerTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.lang.annotation.Documented;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -190,7 +191,7 @@ class MusicFolderSettingsControllerTest {
 
         // success case
         ArgumentCaptor<MusicFolder> captor = ArgumentCaptor.forClass(MusicFolder.class);
-        Mockito.doNothing().when(musicFolderService).createMusicFolder(captor.capture());
+        Mockito.doNothing().when(musicFolderService).createMusicFolder(Mockito.any(Instant.class), captor.capture());
         controller.post(command, Mockito.mock(RedirectAttributes.class));
         assertEquals(captor.getValue(), musicFolder);
 
@@ -198,7 +199,8 @@ class MusicFolderSettingsControllerTest {
         Mockito.clearInvocations(musicFolderService);
         Mockito.when(musicFolderService.getAllMusicFolders(false, true)).thenReturn(Arrays.asList(musicFolder));
         controller.post(command, Mockito.mock(RedirectAttributes.class));
-        Mockito.verify(musicFolderService, Mockito.never()).createMusicFolder(Mockito.nullable(MusicFolder.class));
+        Mockito.verify(musicFolderService, Mockito.never()).createMusicFolder(Mockito.any(Instant.class),
+                Mockito.nullable(MusicFolder.class));
     }
 
     @Test
@@ -236,9 +238,11 @@ class MusicFolderSettingsControllerTest {
         command.setMusicFolders(Arrays.asList(musicFolderInfo1, musicFolderInfo2, musicFolderInfo3, musicFolderInfo4));
 
         ArgumentCaptor<Integer> captorDelete = ArgumentCaptor.forClass(int.class);
-        Mockito.doNothing().when(musicFolderService).deleteMusicFolder(captorDelete.capture());
+        Mockito.doNothing().when(musicFolderService).deleteMusicFolder(Mockito.any(Instant.class),
+                captorDelete.capture());
         ArgumentCaptor<MusicFolder> captorUpdate = ArgumentCaptor.forClass(MusicFolder.class);
-        Mockito.doNothing().when(musicFolderService).updateMusicFolder(captorUpdate.capture());
+        Mockito.doNothing().when(musicFolderService).updateMusicFolder(Mockito.any(Instant.class),
+                captorUpdate.capture());
 
         RedirectAttributes redirectAttributes = Mockito.mock(RedirectAttributes.class);
         controller.post(command, redirectAttributes);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MusicFolderServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MusicFolderServiceTest.java
@@ -34,7 +34,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import com.tesshu.jpsonic.dao.MusicFolderDao;
+import com.tesshu.jpsonic.dao.StaticsDao;
 import com.tesshu.jpsonic.domain.MusicFolder;
+import com.tesshu.jpsonic.util.PlayerUtils;
 import net.sf.ehcache.Ehcache;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -58,7 +60,8 @@ class MusicFolderServiceTest {
         Mockito.when(settingsService.isRedundantFolderCheck()).thenReturn(false);
 
         indexCache = mock(Ehcache.class);
-        musicFolderService = new MusicFolderService(musicFolderDao, settingsService, indexCache);
+        musicFolderService = new MusicFolderService(musicFolderDao, mock(StaticsDao.class), settingsService,
+                indexCache);
 
         MusicFolder m1 = new MusicFolder(1, "/dummy/path", "Disabled&NonExisting", false, null);
         MusicFolder m2 = new MusicFolder(2, "/dummy/path", "Enabled&NonExisting", true, null);
@@ -303,21 +306,21 @@ class MusicFolderServiceTest {
 
     @Test
     void testCreateMusicFolder() {
-        musicFolderService.createMusicFolder(null);
+        musicFolderService.createMusicFolder(PlayerUtils.now(), null);
         Mockito.verify(musicFolderDao, Mockito.times(1)).createMusicFolder(Mockito.nullable(MusicFolder.class));
         Mockito.verify(indexCache, Mockito.times(1)).removeAll();
     }
 
     @Test
     void testDeleteMusicFolder() {
-        musicFolderService.deleteMusicFolder(-1);
+        musicFolderService.deleteMusicFolder(PlayerUtils.now(), -1);
         Mockito.verify(musicFolderDao, Mockito.times(1)).deleteMusicFolder(Mockito.nullable(Integer.class));
         Mockito.verify(indexCache, Mockito.times(1)).removeAll();
     }
 
     @Test
     void testUpdateMusicFolder() {
-        musicFolderService.updateMusicFolder(null);
+        musicFolderService.updateMusicFolder(PlayerUtils.now(), null);
         Mockito.verify(musicFolderDao, Mockito.times(1)).updateMusicFolder(Mockito.nullable(MusicFolder.class));
         Mockito.verify(indexCache, Mockito.times(1)).removeAll();
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImplTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImplTest.java
@@ -944,13 +944,13 @@ class MediaScannerServiceImplTest {
 
             MusicFolder folder = musicFolders.get(0);
             folder.setEnabled(false);
-            musicFolderService.updateMusicFolder(folder);
+            musicFolderService.updateMusicFolder(now(), folder);
             TestCaseUtils.execScan(mediaScannerService);
 
             assertNull(mediaFileDao.getMediaFile(this.song.toString()));
 
             folder.setEnabled(true);
-            musicFolderService.updateMusicFolder(folder);
+            musicFolderService.updateMusicFolder(now(), folder);
             TestCaseUtils.execScan(mediaScannerService);
 
             song = mediaFileDao.getMediaFile(this.song.toString());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImplTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImplTest.java
@@ -130,6 +130,54 @@ class MediaScannerServiceImplTest {
         }
     }
 
+    @Documented
+    private @interface IsOptionalProcessSkippableDecisions {
+
+        @interface Conditions {
+            @interface IgnoreFileTimestamps {
+                @interface False {
+                }
+
+                @interface True {
+                }
+            }
+
+            @interface LastScanEventType {
+                @interface NotPresent {
+
+                }
+
+                @interface Present {
+                    @interface ScanEventType {
+                        @interface EqFinished {
+                        }
+
+                        @interface NeFinished {
+                        }
+                    }
+                }
+            }
+
+            @interface FolderChangedSinceLastScan {
+                @interface True {
+                }
+
+                @interface False {
+                }
+            }
+
+        }
+
+        @interface Result {
+            @interface False {
+            }
+
+            @interface True {
+            }
+        }
+
+    }
+
     @Nested
     class UnitTest {
 
@@ -166,8 +214,8 @@ class MediaScannerServiceImplTest {
                     indexManager, mediaFileService, writableMediaFileService, mock(PlaylistService.class), mediaFileDao,
                     artistDao, albumDao, staticsDao, utils, scannerStateService, mock(Ehcache.class),
                     mock(MediaFileCache.class), mock(JapaneseReadingUtils.class));
-            mediaScannerService = new MediaScannerServiceImpl(scannerStateService, scannerProcedureService,
-                    mock(ExpungeService.class), staticsDao, executor);
+            mediaScannerService = new MediaScannerServiceImpl(settingsService, scannerStateService,
+                    scannerProcedureService, mock(ExpungeService.class), staticsDao, executor);
         }
 
         @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert") // It doesn't seem to be able to capture
@@ -187,8 +235,8 @@ class MediaScannerServiceImplTest {
             poolConf.setMaxPoolSize("1");
             ExecutorConfiguration executorConf = new ExecutorConfiguration(poolConf);
             final ThreadPoolTaskExecutor executor = executorConf.scanExecutor();
-            mediaScannerService = new MediaScannerServiceImpl(scannerStateService, scannerProcedureService,
-                    mock(ExpungeService.class), mock(StaticsDao.class), executor);
+            mediaScannerService = new MediaScannerServiceImpl(settingsService, scannerStateService,
+                    scannerProcedureService, mock(ExpungeService.class), mock(StaticsDao.class), executor);
             mediaScannerService.scanLibrary();
             executor.shutdown();
         }
@@ -235,7 +283,7 @@ class MediaScannerServiceImplTest {
         }
 
         @Nested
-        class GetLastScanAllEventTypeTest {
+        class GetLastScanEventTypeTest {
 
             /* If scanning is in progress, recovery is expected, so previous results are not returned. */
             @Test
@@ -271,6 +319,65 @@ class MediaScannerServiceImplTest {
                 Mockito.when(staticsDao.getLastScanAllStatuses()).thenReturn(Arrays.asList(success));
                 assertFalse(mediaScannerService.getLastScanEventType().isEmpty());
                 assertEquals(ScanEventType.FINISHED, mediaScannerService.getLastScanEventType().get());
+            }
+        }
+
+        @Nested
+        class IsOptionalProcessSkippableTest {
+
+            @Test
+            @IsOptionalProcessSkippableDecisions.Conditions.IgnoreFileTimestamps.True
+            @IsOptionalProcessSkippableDecisions.Result.False
+            void c01() {
+                Mockito.when(settingsService.isIgnoreFileTimestamps()).thenReturn(true);
+                assertFalse(mediaScannerService.isOptionalProcessSkippable());
+            }
+
+            @Test
+            @IsOptionalProcessSkippableDecisions.Conditions.IgnoreFileTimestamps.False
+            @IsOptionalProcessSkippableDecisions.Conditions.LastScanEventType.NotPresent
+            @IsOptionalProcessSkippableDecisions.Result.False
+            void c02() {
+                Mockito.when(settingsService.isIgnoreFileTimestamps()).thenReturn(false);
+                Mockito.when(staticsDao.isNeverScanned()).thenReturn(true);
+                assertFalse(mediaScannerService.isOptionalProcessSkippable());
+            }
+
+            @Test
+            @IsOptionalProcessSkippableDecisions.Conditions.IgnoreFileTimestamps.False
+            @IsOptionalProcessSkippableDecisions.Conditions.LastScanEventType.Present.ScanEventType.NeFinished
+            @IsOptionalProcessSkippableDecisions.Result.False
+            void c03() {
+                Mockito.when(settingsService.isIgnoreFileTimestamps()).thenReturn(false);
+                Mockito.when(staticsDao.getLastScanAllStatuses()).thenReturn(
+                        Arrays.asList(new ScanEvent(null, null, ScanEventType.CANCELED, null, null, null, null)));
+                assertFalse(mediaScannerService.isOptionalProcessSkippable());
+            }
+
+            @Test
+            @IsOptionalProcessSkippableDecisions.Conditions.IgnoreFileTimestamps.False
+            @IsOptionalProcessSkippableDecisions.Conditions.LastScanEventType.Present.ScanEventType.EqFinished
+            @IsOptionalProcessSkippableDecisions.Conditions.FolderChangedSinceLastScan.True
+            @IsOptionalProcessSkippableDecisions.Result.False
+            void c04() {
+                Mockito.when(settingsService.isIgnoreFileTimestamps()).thenReturn(false);
+                Mockito.when(staticsDao.getLastScanAllStatuses()).thenReturn(
+                        Arrays.asList(new ScanEvent(null, null, ScanEventType.FINISHED, null, null, null, null)));
+                Mockito.when(staticsDao.isfolderChangedSinceLastScan()).thenReturn(true);
+                assertFalse(mediaScannerService.isOptionalProcessSkippable());
+            }
+
+            @Test
+            @IsOptionalProcessSkippableDecisions.Conditions.IgnoreFileTimestamps.False
+            @IsOptionalProcessSkippableDecisions.Conditions.LastScanEventType.Present.ScanEventType.EqFinished
+            @IsOptionalProcessSkippableDecisions.Conditions.FolderChangedSinceLastScan.False
+            @IsOptionalProcessSkippableDecisions.Result.True
+            void c05() {
+                Mockito.when(settingsService.isIgnoreFileTimestamps()).thenReturn(false);
+                Mockito.when(staticsDao.getLastScanAllStatuses()).thenReturn(
+                        Arrays.asList(new ScanEvent(null, null, ScanEventType.FINISHED, null, null, null, null)));
+                Mockito.when(staticsDao.isfolderChangedSinceLastScan()).thenReturn(false);
+                assertTrue(mediaScannerService.isOptionalProcessSkippable());
             }
         }
     }
@@ -602,7 +709,8 @@ class MediaScannerServiceImplTest {
         private MusicFolderDao musicFolderDao;
         @Autowired
         private DaoHelper daoHelper;
-
+        @Autowired
+        private SettingsService settingsService;
         @Autowired
         private MusicFolderService musicFolderService;
         @Autowired
@@ -627,8 +735,8 @@ class MediaScannerServiceImplTest {
         @BeforeEach
         public void setup() {
             ThreadPoolTaskExecutor scanExecutor = ServiceMockUtils.mockNoAsyncTaskExecutor();
-            mediaScannerService = new MediaScannerServiceImpl(scannerStateService, procedure, expungeService,
-                    staticsDao, scanExecutor);
+            mediaScannerService = new MediaScannerServiceImpl(settingsService, scannerStateService, procedure,
+                    expungeService, staticsDao, scanExecutor);
         }
 
         /**
@@ -945,12 +1053,14 @@ class MediaScannerServiceImplTest {
             MusicFolder folder = musicFolders.get(0);
             folder.setEnabled(false);
             musicFolderService.updateMusicFolder(now(), folder);
+            Thread.sleep(10);
             TestCaseUtils.execScan(mediaScannerService);
 
             assertNull(mediaFileDao.getMediaFile(this.song.toString()));
 
             folder.setEnabled(true);
             musicFolderService.updateMusicFolder(now(), folder);
+            Thread.sleep(10);
             TestCaseUtils.execScan(mediaScannerService);
 
             song = mediaFileDao.getMediaFile(this.song.toString());


### PR DESCRIPTION
#### Overview

 - The scanning process has been subdivided in v111.6.0, but some processes can be skipped if the prerequisites are met. This pull request strictly implements the conditions to allow skipping.
 - Small fix for IndexManager

#### The specification of Process skip

 - The ability to skip is unique to Jpsonic... Primarily editing sort tags and creating sort keys.
 - Simply put, "We can skip processing if the relevant data has not been updated!"
 - In practice, cancellations and scan failures are considered. This means that determining whether the associated data has been updated crosses the scan cycle. It's not actually generationally managed, so reversing the way of thinking works. "There are conditions that cannot be skipped!"
 - The following judgments can be checked only once at the start of scanning : 

<table cellspacing="1" cellpadding="10" border="1">
<tr>
<td class="s0" dir="ltr" colspan="6">Conditions</td></tr>

<tr>
<td>IgnoreFileTimestamps disabled</td>
<td>N</td>
<td>Y</td>
<td>Y</td>
<td>Y</td>
<td>Y</td>
</tr>

<tr>
<td>First scan</td>
<td>-</td>
<td>Y</td>
<td>N</td>
<td>N</td>
<td>N</td></tr>
<tr>
<td>Last scan completed successfully</td>
<td>-</td>
<td>-</td>
<td>N</td>
<td>Y</td>
<td>Y</td></tr>
<tr>
<td>No changes in music folder since last scan</td>
<td>-</td>
<td>-</td>
<td>-</td>
<td>N</td>
<td>Y</td></tr>
<tr>
<td class="s0" dir="ltr" colspan="6">Result</td></tr>
<tr>
<td>Skippable</td>
<td>N</td>
<td>N</td>
<td>N</td>
<td>N</td>
<td>Y</td></tr></tbody></table>

If the table above is skippable and there are no changes in the relevant records, the corresponding process is skippable. It's actually a lot more demanding than you'd expect, but when the library wasn't changed anything (such as a scheduled scan), the processing is considerably reduced.

#### Small fix for IndexManager

 - 0fb5365 degradation fix. (develop branch)
 - Essentially, the genre index requires a numeric PK. Substituted by hashCode. It is assumed that there will be no collisions in most cases. Accurate design modifications may require table changes. In this version it will not be done.

