### PR TITLE
Fix bug with Playque and Playlist sorting on web pages

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/PlayQueueService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/PlayQueueService.java
@@ -626,7 +626,8 @@ public class PlayQueueService {
         return convert(request, player, false);
     }
 
-    public PlayQueueInfo removeMany(int... indexes) throws ServletRequestBindingException {
+    @SuppressWarnings("PMD.UseVarargs") // Don't use varargs in Ajax
+    public PlayQueueInfo removeMany(int[] indexes) throws ServletRequestBindingException {
         HttpServletRequest request = ajaxHelper.getHttpServletRequest();
         HttpServletResponse response = ajaxHelper.getHttpServletResponse();
         Player player = getCurrentPlayer(request, response);
@@ -636,7 +637,8 @@ public class PlayQueueService {
         return convert(request, player, false);
     }
 
-    public PlayQueueInfo rearrange(int... indexes) throws ServletRequestBindingException {
+    @SuppressWarnings("PMD.UseVarargs") // Don't use varargs in Ajax
+    public PlayQueueInfo rearrange(int[] indexes) throws ServletRequestBindingException {
         HttpServletRequest request = ajaxHelper.getHttpServletRequest();
         HttpServletResponse response = ajaxHelper.getHttpServletResponse();
         Player player = getCurrentPlayer(request, response);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/PlaylistService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/PlaylistService.java
@@ -240,7 +240,8 @@ public class PlaylistService {
         return getPlaylist(id);
     }
 
-    public PlaylistInfo rearrange(int id, int... indexes) {
+    @SuppressWarnings("PMD.UseVarargs") // Don't use varargs in Ajax
+    public PlaylistInfo rearrange(int id, int[] indexes) {
         List<MediaFile> files = deligate.getFilesInPlaylist(id, true);
         MediaFile[] newFiles = new MediaFile[files.size()];
         for (int i = 0; i < indexes.length; i++) {


### PR DESCRIPTION
User feedback.

## Problem description

> In the browser, you can change the order of songs in the play queue or playlist by dragging. It is not reflected in the actual playback order.

### Steps to reproduce

>  - For example, if the songs are arranged in the order A→B→C in the play queue, even if you drag C between A and B to rearrange them A→C→B, the playback order will be A→B→C. stay.
>  - Also, if you press "Save as Playlist" in the play queue after sorting A→C→B, the saved playlist will be arranged in A→B→C.
>  - Also, even if you drag the playlist to replace it, even if you press the "play" button of the playlist while it is switched, the order of the replacement will not be reflected.

## System information

This is pretty old. The cause is 2cebb5b.

 * **Jpsonic version**: Since v109.5.0

## Additional notes

DWR does not recognize variable arguments. so it will be reverted to using arrays. There are three reverted points, and the content of the processing matches what the user pointed out.
