### PR TITLE
Migrate from dbcp2 to HikariCP

### DIFF
--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -80,6 +80,17 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jdbc</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.zaxxer</groupId>
+                    <artifactId>HikariCP</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>5.0.1</version><!--$NO-MVN-MAN-VER$-->
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -194,19 +194,6 @@
             <scope>runtime</scope>
         </dependency>
 
-        <!-- connection pool manager, fixes #860 (external database performance) -->  
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-dbcp2</artifactId>
-            <!-- this wants to pull in commons-logging v1.2 which conflicts with other dependencies -->
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/spring/DatabaseConfigurationTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/spring/DatabaseConfigurationTest.java
@@ -19,80 +19,70 @@
 
 package com.tesshu.jpsonic.spring;
 
-import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.SQLException;
 
 import javax.sql.DataSource;
 
+import com.tesshu.jpsonic.NeedsHome;
+import com.tesshu.jpsonic.service.ServiceMockUtils;
 import com.tesshu.jpsonic.service.SettingsService;
-import org.apache.commons.dbcp2.BasicDataSource;
+import com.zaxxer.hikari.HikariDataSource;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.core.env.Environment;
 
+@ExtendWith(NeedsHome.class)
 class DatabaseConfigurationTest {
 
-    private DatabaseConfiguration configuration = new DatabaseConfiguration(mock(Environment.class));
+    private final DatabaseConfiguration configuration = new DatabaseConfiguration(
+            ServiceMockUtils.mock(Environment.class));
 
     @Test
     void testLegacyDataSource() throws SQLException {
+
         DataSource dataSource = configuration.legacyDataSource();
 
-        // org.apache.commons.dbcp2.BasicDataSource compatible properties
-        try (BasicDataSource basicDataSource = (BasicDataSource) dataSource) {
-
-            assertThatExceptionOfType(UnsupportedOperationException.class)
-                    .isThrownBy(() -> basicDataSource.getLoginTimeout()).withNoCause();
+        // HikariDataSource compatible properties
+        try (HikariDataSource hikariDataSource = (HikariDataSource) dataSource) {
 
             // apps properties
-            assertEquals("org.hsqldb.jdbcDriver", basicDataSource.getDriverClassName());
-            assertEquals(SettingsService.getDefaultJDBCUrl(), basicDataSource.getUrl());
-            assertEquals("sa", basicDataSource.getUsername());
-            assertEquals("", basicDataSource.getPassword());
+            assertEquals("org.hsqldb.jdbc.JDBCDriver", hikariDataSource.getDriverClassName());
+            assertEquals(SettingsService.getDefaultJDBCUrl(), hikariDataSource.getJdbcUrl());
+            assertEquals("sa", hikariDataSource.getUsername());
+            assertEquals("", hikariDataSource.getPassword());
 
-            // default properties
-            assertFalse(basicDataSource.getAbandonedUsageTracking());
-            assertTrue(basicDataSource.getAutoCommitOnReturn());
-            assertTrue(basicDataSource.getCacheState());
-            assertTrue(basicDataSource.getConnectionInitSqls().isEmpty());
-            assertNull(basicDataSource.getDefaultAutoCommit());
-            assertNull(basicDataSource.getDefaultCatalog());
-            assertNull(basicDataSource.getDefaultQueryTimeout());
-            assertNull(basicDataSource.getDefaultReadOnly());
-            assertNull(basicDataSource.getDefaultSchema());
-            assertEquals(-1, basicDataSource.getDefaultTransactionIsolation());
-            assertTrue(basicDataSource.getDisconnectionSqlCodes().isEmpty());
-            assertEquals("org.apache.commons.pool2.impl.DefaultEvictionPolicy",
-                    basicDataSource.getEvictionPolicyClassName());
-            assertFalse(basicDataSource.getFastFailValidation());
-            assertEquals(0, basicDataSource.getInitialSize());
-            assertNull(basicDataSource.getJmxName());
-            assertTrue(basicDataSource.getLifo());
-            assertFalse(basicDataSource.getLogAbandoned());
-            assertTrue(basicDataSource.getLogExpiredConnections());
-            assertEquals(-1, basicDataSource.getMaxConnLifetimeMillis());
-            assertEquals(8, basicDataSource.getMaxIdle());
-            assertEquals(-1, basicDataSource.getMaxOpenPreparedStatements());
-            assertEquals(8, basicDataSource.getMaxTotal());
-            assertEquals(-1, basicDataSource.getMaxWaitMillis());
-            assertEquals(1800000, basicDataSource.getMinEvictableIdleTimeMillis());
-            assertEquals(0, basicDataSource.getMinIdle());
-            assertEquals(0, basicDataSource.getNumActive());
-            assertEquals(0, basicDataSource.getNumIdle());
-            assertEquals(3, basicDataSource.getNumTestsPerEvictionRun());
-            assertFalse(basicDataSource.getRemoveAbandonedOnBorrow());
-            assertFalse(basicDataSource.getRemoveAbandonedOnMaintenance());
-            assertEquals(300, basicDataSource.getRemoveAbandonedTimeout());
-            assertTrue(basicDataSource.getRollbackOnReturn());
-            assertFalse(basicDataSource.getTestWhileIdle());
-            assertEquals(-1, basicDataSource.getTimeBetweenEvictionRunsMillis());
-            assertNull(basicDataSource.getValidationQuery());
-            assertEquals(-1, basicDataSource.getValidationQueryTimeout());
+            assertEquals(60, hikariDataSource.getLoginTimeout());
+            assertNull(hikariDataSource.getCatalog());
+            assertNull(hikariDataSource.getConnectionInitSql());
+            assertEquals(60_000, hikariDataSource.getConnectionTimeout());
+            assertEquals(300_000, hikariDataSource.getIdleTimeout());
+            assertEquals(1_800_000, hikariDataSource.getMaxLifetime());
+            assertEquals(0, hikariDataSource.getKeepaliveTime());
+            assertEquals(0, hikariDataSource.getLeakDetectionThreshold());
+            assertEquals(0, hikariDataSource.getMinimumIdle());
+            assertEquals(8, hikariDataSource.getMaximumPoolSize());
+            assertNull(hikariDataSource.getMetricRegistry());
+            assertEquals("HikariPool-1", hikariDataSource.getPoolName());
+            assertNotNull(hikariDataSource.getHikariPoolMXBean());
+            assertNull(hikariDataSource.getSchema());
+            assertNull(hikariDataSource.getConnectionTestQuery());
+            assertEquals(5_000, hikariDataSource.getValidationTimeout());
+            assertTrue(hikariDataSource.getHealthCheckProperties().isEmpty());
+            assertNull(hikariDataSource.getHealthCheckRegistry());
+            assertNull(hikariDataSource.getTransactionIsolation());
+            assertNull(hikariDataSource.getDataSourceClassName());
+            assertNull(hikariDataSource.getDataSourceJNDI());
+            assertTrue(hikariDataSource.getDataSourceProperties().isEmpty());
+            assertNull(hikariDataSource.getExceptionOverrideClassName());
+            assertNotNull(hikariDataSource.getHikariConfigMXBean());
+            assertNull(hikariDataSource.getScheduledExecutor());
+            assertNull(hikariDataSource.getThreadFactory());
+            assertEquals(1, hikariDataSource.getInitializationFailTimeout());
         }
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/spring/DatabaseConfigurationTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/spring/DatabaseConfigurationTest.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2023 tesshucom
+ */
+
+package com.tesshu.jpsonic.spring;
+
+import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import com.tesshu.jpsonic.service.SettingsService;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.Environment;
+
+class DatabaseConfigurationTest {
+
+    private DatabaseConfiguration configuration = new DatabaseConfiguration(mock(Environment.class));
+
+    @Test
+    void testLegacyDataSource() throws SQLException {
+        DataSource dataSource = configuration.legacyDataSource();
+
+        // org.apache.commons.dbcp2.BasicDataSource compatible properties
+        try (BasicDataSource basicDataSource = (BasicDataSource) dataSource) {
+
+            assertThatExceptionOfType(UnsupportedOperationException.class)
+                    .isThrownBy(() -> basicDataSource.getLoginTimeout()).withNoCause();
+
+            // apps properties
+            assertEquals("org.hsqldb.jdbcDriver", basicDataSource.getDriverClassName());
+            assertEquals(SettingsService.getDefaultJDBCUrl(), basicDataSource.getUrl());
+            assertEquals("sa", basicDataSource.getUsername());
+            assertEquals("", basicDataSource.getPassword());
+
+            // default properties
+            assertFalse(basicDataSource.getAbandonedUsageTracking());
+            assertTrue(basicDataSource.getAutoCommitOnReturn());
+            assertTrue(basicDataSource.getCacheState());
+            assertTrue(basicDataSource.getConnectionInitSqls().isEmpty());
+            assertNull(basicDataSource.getDefaultAutoCommit());
+            assertNull(basicDataSource.getDefaultCatalog());
+            assertNull(basicDataSource.getDefaultQueryTimeout());
+            assertNull(basicDataSource.getDefaultReadOnly());
+            assertNull(basicDataSource.getDefaultSchema());
+            assertEquals(-1, basicDataSource.getDefaultTransactionIsolation());
+            assertTrue(basicDataSource.getDisconnectionSqlCodes().isEmpty());
+            assertEquals("org.apache.commons.pool2.impl.DefaultEvictionPolicy",
+                    basicDataSource.getEvictionPolicyClassName());
+            assertFalse(basicDataSource.getFastFailValidation());
+            assertEquals(0, basicDataSource.getInitialSize());
+            assertNull(basicDataSource.getJmxName());
+            assertTrue(basicDataSource.getLifo());
+            assertFalse(basicDataSource.getLogAbandoned());
+            assertTrue(basicDataSource.getLogExpiredConnections());
+            assertEquals(-1, basicDataSource.getMaxConnLifetimeMillis());
+            assertEquals(8, basicDataSource.getMaxIdle());
+            assertEquals(-1, basicDataSource.getMaxOpenPreparedStatements());
+            assertEquals(8, basicDataSource.getMaxTotal());
+            assertEquals(-1, basicDataSource.getMaxWaitMillis());
+            assertEquals(1800000, basicDataSource.getMinEvictableIdleTimeMillis());
+            assertEquals(0, basicDataSource.getMinIdle());
+            assertEquals(0, basicDataSource.getNumActive());
+            assertEquals(0, basicDataSource.getNumIdle());
+            assertEquals(3, basicDataSource.getNumTestsPerEvictionRun());
+            assertFalse(basicDataSource.getRemoveAbandonedOnBorrow());
+            assertFalse(basicDataSource.getRemoveAbandonedOnMaintenance());
+            assertEquals(300, basicDataSource.getRemoveAbandonedTimeout());
+            assertTrue(basicDataSource.getRollbackOnReturn());
+            assertFalse(basicDataSource.getTestWhileIdle());
+            assertEquals(-1, basicDataSource.getTimeBetweenEvictionRunsMillis());
+            assertNull(basicDataSource.getValidationQuery());
+            assertEquals(-1, basicDataSource.getValidationQueryTimeout());
+        }
+    }
+}


### PR DESCRIPTION
Will be migrated from dbcp2 to HikariCP.


 - Bump HikariCP from 4.0.3 to 5.0.1
 - Migrate from dbcp2 to HikariCP
 - Remove commons-dbcp2

Values previously used for pooling will be inherited for safe migration.

<details>
<summary>Previously Adopted Value</summary>

Main field values of dbcp2. Note that default values are used except for the APP value, but Jpsonic relies on those default values. So the same values will be mapped to timeouts, Idle sizes, etc in this version.  If future adjustments are necessary, they will be considered at that time.


In addition, note that the DefaultQueryTimeout is set to Null. In this case the database default value will be adopted. HSQLDB uses a maximum timeout of 60 seconds if timeout has been specified as zero. So by specifying 60 seconds, we can avoid a lot of confusion.


Fields | Values
-- | --
LoginTimeout | UnsupportedOperationException
DriverClassName | **APP value**
Url | **APP value**
Username | **APP value**
Password | **APP value**
AbandonedUsageTracking | FALSE
AutoCommitOnReturn | TRUE
CacheState | TRUE
ConnectionInitSqls | EMPTY
DefaultAutoCommit | NULL
DefaultCatalog | NULL
DefaultQueryTimeout | NULL
DefaultReadOnly | NULL
DefaultSchema | NULL
DefaultTransactionIsolation | -1
DisconnectionSqlCodes | EMPTY
EvictionPolicyClassName | org.apache.commons.pool2.impl.DefaultEvictionPolicy
FastFailValidation | FALSE
InitialSize | 0
JmxName | NULL
Lifo | TRUE
LogAbandoned | FALSE
LogExpiredConnections | TRUE
MaxConnLifetimeMillis | -1
MaxIdle | 8
MaxOpenPreparedStatements | -1
MaxTotal | 8
MaxWaitMillis | -1
MinEvictableIdleTimeMillis | 1800000
MinIdle | 0
NumActive | 0
NumIdle | 0
NumTestsPerEvictionRun | 3
RemoveAbandonedOnBorrow | FALSE
RemoveAbandonedOnMaintenance | FALSE
RemoveAbandonedTimeout | 300
RollbackOnReturn | TRUE
TestWhileIdle | FALSE
TimeBetweenEvictionRunsMillis | -1
ValidationQuery | NULL
ValidationQueryTimeout | -1
</details>

In this migration, datasource instantiation does not rely on Spring's builder. There is a possibility that it will be tuned when parallel scan execution is introduced in the future, but at that time we will reconsider whether to move to Spring's Builder. 

 - It is smarter to provide default values that rarely need to be changed.
 - JNDI allows the user to configure it however they like. 