### PR TITLE
Change to acquire lock when editing MusicFolder

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MusicFolderSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MusicFolderSettingsController.java
@@ -39,10 +39,10 @@ import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.domain.User;
 import com.tesshu.jpsonic.domain.UserSettings;
 import com.tesshu.jpsonic.service.MediaScannerService;
-import com.tesshu.jpsonic.service.MusicFolderService;
 import com.tesshu.jpsonic.service.SecurityService;
 import com.tesshu.jpsonic.service.SettingsService;
 import com.tesshu.jpsonic.service.ShareService;
+import com.tesshu.jpsonic.service.scanner.MusicFolderServiceImpl;
 import com.tesshu.jpsonic.util.PathValidator;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Controller;
@@ -67,13 +67,13 @@ import org.springframework.web.servlet.view.RedirectView;
 public class MusicFolderSettingsController {
 
     private final SettingsService settingsService;
-    private final MusicFolderService musicFolderService;
+    private final MusicFolderServiceImpl musicFolderService;
     private final SecurityService securityService;
     private final MediaScannerService mediaScannerService;
     private final ShareService shareService;
     private final OutlineHelpSelector outlineHelpSelector;
 
-    public MusicFolderSettingsController(SettingsService settingsService, MusicFolderService musicFolderService,
+    public MusicFolderSettingsController(SettingsService settingsService, MusicFolderServiceImpl musicFolderService,
             SecurityService securityService, MediaScannerService mediaScannerService, ShareService shareService,
             OutlineHelpSelector outlineHelpSelector) {
         super();

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicFolderService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicFolderService.java
@@ -1,136 +1,22 @@
-/*
- * This file is part of Jpsonic.
- *
- * Jpsonic is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * Jpsonic is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- *
- * (C) 2021 tesshucom
- */
-
 package com.tesshu.jpsonic.service;
 
-import java.nio.file.Files;
-import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Collectors;
 
-import com.tesshu.jpsonic.dao.MusicFolderDao;
-import com.tesshu.jpsonic.dao.StaticsDao;
 import com.tesshu.jpsonic.domain.MusicFolder;
-import com.tesshu.jpsonic.domain.ScanEvent.ScanEventType;
-import net.sf.ehcache.Ehcache;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.springframework.stereotype.Service;
 
-/**
- * The class containing MusicFolder-related methods extracted from the legacy server's SettingsService.
- */
-@Service
-public class MusicFolderService {
+public interface MusicFolderService {
 
-    private final ConcurrentMap<String, List<MusicFolder>> cachedUserFolders;
-    private List<MusicFolder> cachedMusicFolders;
+    List<MusicFolder> getAllMusicFolders();
 
-    private final MusicFolderDao musicFolderDao;
-    private final StaticsDao staticsDao;
-    private final SettingsService settingsService;
-    private final Ehcache indexCache;
-    private final Object lock = new Object();
+    List<MusicFolder> getAllMusicFolders(boolean includeDisabled, boolean includeNonExisting);
 
-    public MusicFolderService(MusicFolderDao musicFolderDao, StaticsDao staticsDao, SettingsService settingsService,
-            Ehcache indexCache) {
-        this.musicFolderDao = musicFolderDao;
-        this.staticsDao = staticsDao;
-        this.settingsService = settingsService;
-        this.indexCache = indexCache;
-        cachedUserFolders = new ConcurrentHashMap<>();
-    }
+    List<MusicFolder> getMusicFoldersForUser(@NonNull String username);
 
-    public List<MusicFolder> getAllMusicFolders() {
-        return getAllMusicFolders(false, !settingsService.isRedundantFolderCheck());
-    }
+    List<MusicFolder> getMusicFoldersForUser(@NonNull String username, @Nullable Integer selectedMusicFolderId);
 
-    public List<MusicFolder> getAllMusicFolders(boolean includeDisabled, boolean includeNonExisting) {
-        synchronized (lock) {
-            if (cachedMusicFolders == null) {
-                cachedMusicFolders = musicFolderDao.getAllMusicFolders();
-            }
-            return cachedMusicFolders.stream().filter(folder -> includeDisabled || folder.isEnabled())
-                    .filter(folder -> includeNonExisting || Files.exists(folder.toPath())).collect(Collectors.toList());
-        }
-    }
+    MusicFolder getMusicFolderById(int id);
 
-    public List<MusicFolder> getMusicFoldersForUser(@NonNull String username) {
-        synchronized (lock) {
-            List<MusicFolder> result = cachedUserFolders.get(username);
-            if (result == null) {
-                result = musicFolderDao.getMusicFoldersForUser(username);
-                result.retainAll(getAllMusicFolders());
-                cachedUserFolders.put(username, result);
-            }
-            return result;
-        }
-    }
-
-    public List<MusicFolder> getMusicFoldersForUser(@NonNull String username, @Nullable Integer selectedMusicFolderId) {
-        List<MusicFolder> allowed = getMusicFoldersForUser(username);
-        if (selectedMusicFolderId == null) {
-            return allowed;
-        }
-        MusicFolder selected = getMusicFolderById(selectedMusicFolderId);
-        return allowed.contains(selected) ? Collections.singletonList(selected) : Collections.emptyList();
-    }
-
-    public void setMusicFoldersForUser(@NonNull String username, List<Integer> musicFolderIds) {
-        musicFolderDao.setMusicFoldersForUser(username, musicFolderIds);
-        synchronized (lock) {
-            cachedUserFolders.remove(username);
-        }
-        indexCache.removeAll();
-    }
-
-    public @Nullable MusicFolder getMusicFolderById(int id) {
-        return getAllMusicFolders().stream().filter(folder -> folder.getId().equals(id)).findFirst().orElse(null);
-    }
-
-    public void createMusicFolder(@NonNull Instant executed, @NonNull MusicFolder musicFolder) {
-        musicFolderDao.createMusicFolder(musicFolder);
-        staticsDao.createFolderLog(executed, ScanEventType.FOLDER_CREATE);
-        clearMusicFolderCache();
-    }
-
-    public void deleteMusicFolder(@NonNull Instant executed, int id) {
-        musicFolderDao.deleteMusicFolder(id);
-        staticsDao.createFolderLog(executed, ScanEventType.FOLDER_DELETE);
-        clearMusicFolderCache();
-    }
-
-    public void updateMusicFolder(@NonNull Instant executed, @NonNull MusicFolder musicFolder) {
-        musicFolderDao.updateMusicFolder(musicFolder);
-        staticsDao.createFolderLog(executed, ScanEventType.FOLDER_UPDATE);
-        clearMusicFolderCache();
-    }
-
-    @SuppressWarnings("PMD.NullAssignment") // (cachedMusicFolders) Intentional allocation to clear cache
-    public void clearMusicFolderCache() {
-        synchronized (lock) {
-            cachedMusicFolders = null;
-            cachedUserFolders.clear();
-        }
-        indexCache.removeAll();
-    }
+    void setMusicFoldersForUser(@NonNull String username, List<Integer> musicFolderIds);
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/MusicFolderServiceImpl.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/MusicFolderServiceImpl.java
@@ -1,0 +1,144 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2021 tesshucom
+ */
+
+package com.tesshu.jpsonic.service.scanner;
+
+import java.nio.file.Files;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+import com.tesshu.jpsonic.dao.MusicFolderDao;
+import com.tesshu.jpsonic.dao.StaticsDao;
+import com.tesshu.jpsonic.domain.MusicFolder;
+import com.tesshu.jpsonic.domain.ScanEvent.ScanEventType;
+import com.tesshu.jpsonic.service.MusicFolderService;
+import com.tesshu.jpsonic.service.SettingsService;
+import net.sf.ehcache.Ehcache;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.springframework.stereotype.Service;
+
+/**
+ * The class containing MusicFolder-related methods extracted from the legacy server's SettingsService.
+ */
+@Service("musicFolderService")
+public class MusicFolderServiceImpl implements MusicFolderService {
+
+    private final ConcurrentMap<String, List<MusicFolder>> cachedUserFolders;
+    private List<MusicFolder> cachedMusicFolders;
+
+    private final MusicFolderDao musicFolderDao;
+    private final StaticsDao staticsDao;
+    private final SettingsService settingsService;
+    private final Ehcache indexCache;
+    private final Object lock = new Object();
+
+    public MusicFolderServiceImpl(MusicFolderDao musicFolderDao, StaticsDao staticsDao, SettingsService settingsService,
+            Ehcache indexCache) {
+        this.musicFolderDao = musicFolderDao;
+        this.staticsDao = staticsDao;
+        this.settingsService = settingsService;
+        this.indexCache = indexCache;
+        cachedUserFolders = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public List<MusicFolder> getAllMusicFolders() {
+        return getAllMusicFolders(false, !settingsService.isRedundantFolderCheck());
+    }
+
+    @Override
+    public List<MusicFolder> getAllMusicFolders(boolean includeDisabled, boolean includeNonExisting) {
+        synchronized (lock) {
+            if (cachedMusicFolders == null) {
+                cachedMusicFolders = musicFolderDao.getAllMusicFolders();
+            }
+            return cachedMusicFolders.stream().filter(folder -> includeDisabled || folder.isEnabled())
+                    .filter(folder -> includeNonExisting || Files.exists(folder.toPath())).collect(Collectors.toList());
+        }
+    }
+
+    @Override
+    public List<MusicFolder> getMusicFoldersForUser(@NonNull String username) {
+        synchronized (lock) {
+            List<MusicFolder> result = cachedUserFolders.get(username);
+            if (result == null) {
+                result = musicFolderDao.getMusicFoldersForUser(username);
+                result.retainAll(getAllMusicFolders());
+                cachedUserFolders.put(username, result);
+            }
+            return result;
+        }
+    }
+
+    @Override
+    public List<MusicFolder> getMusicFoldersForUser(@NonNull String username, @Nullable Integer selectedMusicFolderId) {
+        List<MusicFolder> allowed = getMusicFoldersForUser(username);
+        if (selectedMusicFolderId == null) {
+            return allowed;
+        }
+        MusicFolder selected = getMusicFolderById(selectedMusicFolderId);
+        return allowed.contains(selected) ? Collections.singletonList(selected) : Collections.emptyList();
+    }
+
+    @Override
+    public void setMusicFoldersForUser(@NonNull String username, List<Integer> musicFolderIds) {
+        musicFolderDao.setMusicFoldersForUser(username, musicFolderIds);
+        synchronized (lock) {
+            cachedUserFolders.remove(username);
+        }
+        indexCache.removeAll();
+    }
+
+    @Override
+    public @Nullable MusicFolder getMusicFolderById(int id) {
+        return getAllMusicFolders().stream().filter(folder -> folder.getId().equals(id)).findFirst().orElse(null);
+    }
+
+    public void createMusicFolder(@NonNull Instant executed, @NonNull MusicFolder musicFolder) {
+        musicFolderDao.createMusicFolder(musicFolder);
+        staticsDao.createFolderLog(executed, ScanEventType.FOLDER_CREATE);
+        clearMusicFolderCache();
+    }
+
+    public void deleteMusicFolder(@NonNull Instant executed, int id) {
+        musicFolderDao.deleteMusicFolder(id);
+        staticsDao.createFolderLog(executed, ScanEventType.FOLDER_DELETE);
+        clearMusicFolderCache();
+    }
+
+    public void updateMusicFolder(@NonNull Instant executed, @NonNull MusicFolder musicFolder) {
+        musicFolderDao.updateMusicFolder(musicFolder);
+        staticsDao.createFolderLog(executed, ScanEventType.FOLDER_UPDATE);
+        clearMusicFolderCache();
+    }
+
+    @SuppressWarnings("PMD.NullAssignment") // (cachedMusicFolders) Intentional allocation to clear cache
+    public void clearMusicFolderCache() {
+        synchronized (lock) {
+            cachedMusicFolders = null;
+            cachedUserFolders.clear();
+        }
+        indexCache.removeAll();
+    }
+}

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
@@ -49,7 +49,6 @@ import com.tesshu.jpsonic.domain.ScanEvent;
 import com.tesshu.jpsonic.domain.ScanEvent.ScanEventType;
 import com.tesshu.jpsonic.service.MediaFileCache;
 import com.tesshu.jpsonic.service.MediaFileService;
-import com.tesshu.jpsonic.service.MusicFolderService;
 import com.tesshu.jpsonic.service.PlaylistService;
 import com.tesshu.jpsonic.service.SettingsService;
 import com.tesshu.jpsonic.service.search.IndexManager;
@@ -73,7 +72,7 @@ public class ScannerProcedureService {
     private static final Logger LOG = LoggerFactory.getLogger(ScannerProcedureService.class);
 
     private final SettingsService settingsService;
-    private final MusicFolderService musicFolderService;
+    private final MusicFolderServiceImpl musicFolderService;
     private final IndexManager indexManager;
     private final MediaFileService mediaFileService;
     private final WritableMediaFileService wmfs;
@@ -92,7 +91,7 @@ public class ScannerProcedureService {
 
     private final AtomicBoolean cancel = new AtomicBoolean();
 
-    public ScannerProcedureService(SettingsService settingsService, MusicFolderService musicFolderService,
+    public ScannerProcedureService(SettingsService settingsService, MusicFolderServiceImpl musicFolderService,
             IndexManager indexManager, MediaFileService mediaFileService, WritableMediaFileService wmfs,
             PlaylistService playlistService, MediaFileDao mediaFileDao, ArtistDao artistDao, AlbumDao albumDao,
             StaticsDao staticsDao, SortProcedureService sortProcedure, ScannerStateServiceImpl scannerStateService,

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerStateServiceImpl.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerStateServiceImpl.java
@@ -23,6 +23,7 @@ import static com.tesshu.jpsonic.util.PlayerUtils.FAR_PAST;
 import static com.tesshu.jpsonic.util.PlayerUtils.now;
 
 import java.time.Instant;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantLock;
@@ -88,7 +89,16 @@ public class ScannerStateServiceImpl implements ScannerStateService {
         if (!ready.get() || destroy.get()) {
             return false;
         }
-        boolean acquired = scanningLock.tryLock();
+
+        boolean acquired;
+        try {
+            acquired = scanningLock.tryLock(1500L, TimeUnit.MILLISECONDS);
+            if (acquired) {
+                Thread.sleep(1);
+            }
+        } catch (InterruptedException e) {
+            acquired = false;
+        }
         if (acquired) {
             scanDate = now();
             scanCount.reset();

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/AbstractNeedsScan.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/AbstractNeedsScan.java
@@ -33,12 +33,12 @@ import com.tesshu.jpsonic.dao.DaoHelper;
 import com.tesshu.jpsonic.dao.MusicFolderDao;
 import com.tesshu.jpsonic.dao.StaticsDao;
 import com.tesshu.jpsonic.service.MediaScannerService;
-import com.tesshu.jpsonic.service.MusicFolderService;
 import com.tesshu.jpsonic.service.SecurityService;
 import com.tesshu.jpsonic.service.ServiceMockUtils;
 import com.tesshu.jpsonic.service.SettingsService;
 import com.tesshu.jpsonic.service.scanner.ExpungeService;
 import com.tesshu.jpsonic.service.scanner.MediaScannerServiceImpl;
+import com.tesshu.jpsonic.service.scanner.MusicFolderServiceImpl;
 import com.tesshu.jpsonic.service.scanner.ScannerProcedureService;
 import com.tesshu.jpsonic.service.scanner.ScannerStateServiceImpl;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -75,7 +75,7 @@ public abstract class AbstractNeedsScan implements NeedsScan {
     @Autowired
     protected SettingsService settingsService;
     @Autowired
-    protected MusicFolderService musicFolderService;
+    protected MusicFolderServiceImpl musicFolderService;
     @Autowired
     protected SecurityService securityService;
     @Autowired

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MusicFolderSettingsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MusicFolderSettingsControllerTest.java
@@ -41,11 +41,11 @@ import com.tesshu.jpsonic.command.MusicFolderSettingsCommand;
 import com.tesshu.jpsonic.command.MusicFolderSettingsCommand.MusicFolderInfo;
 import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.service.MediaScannerService;
-import com.tesshu.jpsonic.service.MusicFolderService;
 import com.tesshu.jpsonic.service.SecurityService;
 import com.tesshu.jpsonic.service.ServiceMockUtils;
 import com.tesshu.jpsonic.service.SettingsService;
 import com.tesshu.jpsonic.service.ShareService;
+import com.tesshu.jpsonic.service.scanner.MusicFolderServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
@@ -72,7 +72,7 @@ class MusicFolderSettingsControllerTest {
     private static final String VIEW_NAME = "musicFolderSettings";
 
     private SettingsService settingsService;
-    private MusicFolderService musicFolderService;
+    private MusicFolderServiceImpl musicFolderService;
     private MediaScannerService mediaScannerService;
     private MusicFolderSettingsController controller;
     private MockMvc mockMvc;
@@ -80,7 +80,7 @@ class MusicFolderSettingsControllerTest {
     @BeforeEach
     public void setup() throws ExecutionException {
         settingsService = mock(SettingsService.class);
-        musicFolderService = mock(MusicFolderService.class);
+        musicFolderService = mock(MusicFolderServiceImpl.class);
         mediaScannerService = mock(MediaScannerService.class);
         controller = new MusicFolderSettingsController(settingsService, musicFolderService, mock(SecurityService.class),
                 mediaScannerService, mock(ShareService.class), mock(OutlineHelpSelector.class));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImplTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImplTest.java
@@ -67,7 +67,6 @@ import com.tesshu.jpsonic.domain.SearchResult;
 import com.tesshu.jpsonic.service.MediaFileCache;
 import com.tesshu.jpsonic.service.MediaFileService;
 import com.tesshu.jpsonic.service.MediaScannerService;
-import com.tesshu.jpsonic.service.MusicFolderService;
 import com.tesshu.jpsonic.service.PlaylistService;
 import com.tesshu.jpsonic.service.SearchService;
 import com.tesshu.jpsonic.service.SecurityService;
@@ -210,7 +209,7 @@ class MediaScannerServiceImplTest {
             writableMediaFileService = new WritableMediaFileService(mediaFileDao, scannerStateService, mediaFileService,
                     albumDao, mock(MediaFileCache.class), mock(MusicParser.class), mock(VideoParser.class),
                     settingsService, mock(SecurityService.class), null, mock(IndexManager.class));
-            scannerProcedureService = new ScannerProcedureService(settingsService, mock(MusicFolderService.class),
+            scannerProcedureService = new ScannerProcedureService(settingsService, mock(MusicFolderServiceImpl.class),
                     indexManager, mediaFileService, writableMediaFileService, mock(PlaylistService.class), mediaFileDao,
                     artistDao, albumDao, staticsDao, utils, scannerStateService, mock(Ehcache.class),
                     mock(MediaFileCache.class), mock(JapaneseReadingUtils.class));
@@ -712,7 +711,7 @@ class MediaScannerServiceImplTest {
         @Autowired
         private SettingsService settingsService;
         @Autowired
-        private MusicFolderService musicFolderService;
+        private MusicFolderServiceImpl musicFolderService;
         @Autowired
         private MediaFileService mediaFileService;
         @Autowired

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MusicFolderServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MusicFolderServiceTest.java
@@ -17,7 +17,7 @@
  * (C) 2023 tesshucom
  */
 
-package com.tesshu.jpsonic.service;
+package com.tesshu.jpsonic.service.scanner;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
 import static org.junit.Assert.assertNull;
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 import com.tesshu.jpsonic.dao.MusicFolderDao;
 import com.tesshu.jpsonic.dao.StaticsDao;
 import com.tesshu.jpsonic.domain.MusicFolder;
+import com.tesshu.jpsonic.service.SettingsService;
 import com.tesshu.jpsonic.util.PlayerUtils;
 import net.sf.ehcache.Ehcache;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,7 +50,7 @@ class MusicFolderServiceTest {
     private MusicFolderDao musicFolderDao;
     private SettingsService settingsService;
     private Ehcache indexCache;
-    private MusicFolderService musicFolderService;
+    private MusicFolderServiceImpl musicFolderService;
 
     private static final String USER_NAME = "user";
 
@@ -60,7 +61,7 @@ class MusicFolderServiceTest {
         Mockito.when(settingsService.isRedundantFolderCheck()).thenReturn(false);
 
         indexCache = mock(Ehcache.class);
-        musicFolderService = new MusicFolderService(musicFolderDao, mock(StaticsDao.class), settingsService,
+        musicFolderService = new MusicFolderServiceImpl(musicFolderDao, mock(StaticsDao.class), settingsService,
                 indexCache);
 
         MusicFolder m1 = new MusicFolder(1, "/dummy/path", "Disabled&NonExisting", false, null);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MusicFolderServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MusicFolderServiceTest.java
@@ -59,10 +59,11 @@ class MusicFolderServiceTest {
         musicFolderDao = mock(MusicFolderDao.class);
         settingsService = mock(SettingsService.class);
         Mockito.when(settingsService.isRedundantFolderCheck()).thenReturn(false);
-
+        ScannerStateServiceImpl scannerStateService = mock(ScannerStateServiceImpl.class);
+        Mockito.when(scannerStateService.tryScanningLock()).thenReturn(true);
         indexCache = mock(Ehcache.class);
         musicFolderService = new MusicFolderServiceImpl(musicFolderDao, mock(StaticsDao.class), settingsService,
-                indexCache);
+                scannerStateService, indexCache);
 
         MusicFolder m1 = new MusicFolder(1, "/dummy/path", "Disabled&NonExisting", false, null);
         MusicFolder m2 = new MusicFolder(2, "/dummy/path", "Enabled&NonExisting", true, null);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureServiceTest.java
@@ -35,7 +35,6 @@ import com.tesshu.jpsonic.domain.ScanEvent;
 import com.tesshu.jpsonic.domain.ScanEvent.ScanEventType;
 import com.tesshu.jpsonic.service.MediaFileCache;
 import com.tesshu.jpsonic.service.MediaFileService;
-import com.tesshu.jpsonic.service.MusicFolderService;
 import com.tesshu.jpsonic.service.PlaylistService;
 import com.tesshu.jpsonic.service.SecurityService;
 import com.tesshu.jpsonic.service.SettingsService;
@@ -65,7 +64,7 @@ class ScannerProcedureServiceTest {
         WritableMediaFileService writableMediaFileService = new WritableMediaFileService(mediaFileDao, null,
                 mediaFileService, albumDao, null, mock(MusicParser.class), mock(VideoParser.class), settingsService,
                 mock(SecurityService.class), mock(JapaneseReadingUtils.class), mock(IndexManager.class));
-        scannerProcedureService = new ScannerProcedureService(settingsService, mock(MusicFolderService.class),
+        scannerProcedureService = new ScannerProcedureService(settingsService, mock(MusicFolderServiceImpl.class),
                 mock(IndexManager.class), mediaFileService, writableMediaFileService, mock(PlaylistService.class),
                 mediaFileDao, mock(ArtistDao.class), albumDao, staticsDao, mock(SortProcedureService.class),
                 new ScannerStateServiceImpl(staticsDao), mock(Ehcache.class), mock(MediaFileCache.class),

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/ScannerStateServiceImplTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/ScannerStateServiceImplTest.java
@@ -121,13 +121,12 @@ class ScannerStateServiceImplTest {
         @TryScanningLockDecisions.Conditions.Destroy.False
         @TryScanningLockDecisions.Conditions.IsScanning.True
         @TryScanningLockDecisions.Result.False
-        void c03() throws InterruptedException {
+        void c03() throws InterruptedException, ExecutionException {
             scannerStateService.setReady();
             assertFalse(scannerStateService.isDestroy());
             ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
             executor.initialize();
-            executor.submit(() -> scannerStateService.tryScanningLock());
-            Thread.sleep(50);
+            executor.submit(() -> scannerStateService.tryScanningLock()).get();
             assertTrue(scannerStateService.isScanning());
             assertFalse(scannerStateService.tryScanningLock());
             executor.shutdown();
@@ -138,7 +137,7 @@ class ScannerStateServiceImplTest {
         @TryScanningLockDecisions.Conditions.Destroy.False
         @TryScanningLockDecisions.Conditions.IsScanning.False
         @TryScanningLockDecisions.Result.True
-        void c04() throws InterruptedException, ExecutionException {
+        void c04() {
             scannerStateService.setReady();
             assertFalse(scannerStateService.isDestroy());
             assertFalse(scannerStateService.isScanning());
@@ -241,13 +240,12 @@ class ScannerStateServiceImplTest {
         @UnlockScanningDecisions.Conditions.IsScanning.True.OthersLock
         @UnlockScanningDecisions.Result.IllegalMonitorStateException
         // (Unreachable case)
-        void c02() throws InterruptedException {
+        void c02() throws InterruptedException, ExecutionException {
             scannerStateService.setReady();
             assertFalse(scannerStateService.isDestroy());
             ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
             executor.initialize();
-            executor.submit(() -> scannerStateService.tryScanningLock());
-            Thread.sleep(50);
+            executor.submit(() -> scannerStateService.tryScanningLock()).get();
             assertTrue(scannerStateService.isScanning());
             assertThatExceptionOfType(IllegalMonitorStateException.class)
                     .isThrownBy(() -> scannerStateService.unlockScanning()).withNoCause();


### PR DESCRIPTION

### Overview

MusicFolderService methods will be split into ReadOnly methods and Edit methods .

### Fixes

 - Move MusicFolderService from service to service.scanner.MusicFolderServiceImpl
 - Create interface service.MusicFolderService and expose ReadOnly methods. MusicFolderServiceImpl implements MusicFolderService.
 - MusicFolderServiceImpl's create/delete/update will be modified to acquire the lock.
 - Editing of MusicFolder is done only from MusicFolderSettingsController and in scanner package. All others are Read Only.
   - The chances of these actions colliding are realistically low. However, this commit would set a delay of 1,500 milliseconds on lock acquisition. 

### Purpose

Part of a long-term improvement. 

 - Strictly speaking, CUD of MusicFolder is an exclusive relationship with scanning. Simultaneous execution is not possible when processing equivalent to Scan is being performed. (In flow design, not implementation)
 - The executed time of Scan-equivalent processing will always be lined up sequentially in the log table. Or aimed at such architecture design.
 - Editing music folders and scanning concurrency are simple examples. Podcast will later participate in this design. We are still on the way.
   - Podcasts are only designed for download, but in reality they will be more subdivided according to user needs.
   - For example, retry or cleanup on failure. The desired functionality is currently missing. Podcast design will be expressed as a collection of finer features in the future.
   - Even if parallel execution is logically possible, there are times when it is easier and highly reliable to design something that is substantially exclusive. Disk access is sequential.
 - Rather, the process that acquires the lock makes it easier to design **concurrency within it**. Larger blocks of exclusion are implemented to make concurrency independent.

