### PR TITLE
Change the spec of Shortcuts acquisition

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicIndexService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MusicIndexService.java
@@ -22,7 +22,6 @@
 package com.tesshu.jpsonic.service;
 
 import java.io.Serializable;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -100,11 +99,13 @@ public class MusicIndexService {
 
     public List<MediaFile> getShortcuts(List<MusicFolder> musicFoldersToUse) {
         List<MediaFile> result = new ArrayList<>();
-        for (String shortcut : settingsService.getShortcutsAsArray()) {
+        for (String shortcuts : settingsService.getShortcutsAsArray()) {
             for (MusicFolder musicFolder : musicFoldersToUse) {
-                Path shortcutPath = Path.of(musicFolder.getPathString(), shortcut);
-                if (Files.exists(shortcutPath)) {
-                    result.add(mediaFileService.getMediaFile(shortcutPath));
+                Path shortcutPath = Path.of(musicFolder.getPathString(), shortcuts);
+                MediaFile shortcut = mediaFileService.getMediaFile(shortcutPath);
+                if (shortcut != null && mediaFileService.getChildrenOf(shortcut, true, true).size() > 0
+                        && !result.contains(shortcut)) {
+                    result.add(shortcut);
                 }
             }
         }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MusicIndexServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MusicIndexServiceTest.java
@@ -218,15 +218,23 @@ class MusicIndexServiceTest {
     void testGetShortcuts() throws URISyntaxException {
         Mockito.when(settingsService.getShortcutsAsArray())
                 .thenReturn(StringUtil.split(SettingsConstants.General.Extension.SHORTCUTS.defaultValue + " Metadata"));
-        MediaFile song = new MediaFile();
-        song.setTitle("Files directly under the shortcut directory");
-        song.setPathString("path");
-        Mockito.when(mediaFileService.getMediaFile(Mockito.any(Path.class))).thenReturn(song);
         MusicFolder folder = new MusicFolder(
-                Path.of(MusicIndexServiceTest.class.getResource("/MEDIAS").toURI()).toString(), "Music", true, now());
+                Path.of(MusicIndexServiceTest.class.getResource("/MEDIAS/Music").toURI()).toString(), "Music", true,
+                now());
+        assertEquals(0, musicIndexService.getShortcuts(Arrays.asList(folder)).size());
 
-        List<MediaFile> shortcuts = musicIndexService.getShortcuts(Arrays.asList(folder));
-        assertEquals(1, shortcuts.size());
+        MediaFile artist = new MediaFile();
+        artist.setPathString("path");
+        Mockito.when(mediaFileService.getMediaFile(Mockito.any(Path.class))).thenReturn(artist);
+        assertEquals(0, musicIndexService.getShortcuts(Arrays.asList(folder)).size());
+
+        artist.setPathString(
+                Path.of(MusicIndexServiceTest.class.getResource("/MEDIAS/Music/_DIR_ Ravel").toURI()).toString());
+        assertEquals(0, musicIndexService.getShortcuts(Arrays.asList(folder)).size());
+
+        List<MediaFile> children = Arrays.asList(new MediaFile());
+        Mockito.when(mediaFileService.getChildrenOf(artist, true, true)).thenReturn(children);
+        assertEquals(1, musicIndexService.getShortcuts(Arrays.asList(folder)).size());
     }
 
     @Test


### PR DESCRIPTION
Prerequisites: #1869

### Overview

Shortcut specifications will change. When the file does not exist directly under the directory pointed to by the shortcut, the Shortcut will be changed so that it will not be fetched. 

### The topic of view specifications

Same as topic below

 - https://github.com/airsonic/airsonic/issues/669

<details>
<summary>Reproduce</summary>

For example, if a shortcut named New Incoming is registered ... 

![image](https://user-images.githubusercontent.com/27724847/229343613-c48ed61f-6d09-4311-8213-340212e97d51.png)

If there is a directory called New Incoming directly under the music folder, the link will be displayed in View. This is part of the Subsonic API index specification. Use cases are assumed ... where **shortcuts can be created by registering a specific artist name**.

![image](https://user-images.githubusercontent.com/27724847/229343753-278e0e68-560b-4e4f-9d34-e5bed3ce97c8.png)

But if there is nothing under the New Incoming directory, the display will be empty when you click on it. Meaningless. Not a bug though.

![image](https://user-images.githubusercontent.com/27724847/229343899-2380ab0c-6715-4203-b41c-0ecf1cc0287d.png)

</details>

In particular, if the download directory and the shortcut point to the same directory, functions with different purposes may conflict and be inconvenient. In any case, it doesn't make much sense to link to an empty directory. This commit will no longer show links to empty directories

### The topic of Internal implementation

In fact, it is also related to the topic below

 - https://github.com/airsonic/airsonic/issues/881

The original source code looks like this :

https://github.com/airsonic/airsonic/blob/5ccca059d5cfe3dd19734c27861b434ea21b43d8/airsonic-main/src/main/java/org/airsonic/player/service/MusicIndexService.java#L78-L89

Considering the previous server specification, it works as follows : 

 - If there is a directory with the same name as Shortcut directly under the directory, get Mediafile
 - If Mediafile is not registered and Fast access mode is OFF, create Mediafile record and return Mediafile

In other words, some degree of real-time processing is assumed, and the implementation is tightly coupled with the hardware(platform). The problem is that it relies on file checking.

 - This check pays a high cost if the target doesn't exist. **JDK version or OS specifics may cause noticeable slowdowns**.
 - There are two shortcuts by default settings.  There will be at least two file checks **regardless of whether the user is using shortcuts or not**.
 - Regardless of the number of songs, it depends on the number of directories directly under the music folder. **Libraries tend to have higher processing costs as they get larger**.

Fast access mode, which had some fatal problems has been removed already in Jpsonic. And redundant file checks are suppressed to achieve non-blocking data access. This commit removes a pointless file check. It is also modified to only query data that has already been scanned.

### Something like a so-called Incoming, new arrival notification

Shortcuts and upload specifications should be considered separately. Essentially the purpose of shortcuts is not to keep track of our recent uploads. Therefore, no indicator functionality is added to shortcuts.

For example, if the current upload can be uploaded by specifying the upload destination instead of Incoming, and only the target can be differentially scanned immediately after uploading, the expected details will change. So new notifications seem like an issue that should be considered separately.
