### PR TITLE
Fix bug in web page folder selection

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/TopController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/TopController.java
@@ -134,6 +134,8 @@ public class TopController {
 
         String username = securityService.getCurrentUsernameStrict(request);
         List<MusicFolder> allMusicFolders = musicFolderService.getMusicFoldersForUser(username);
+        boolean musicFolderChanged = saveSelectedMusicFolder(request);
+        map.put("musicFolderChanged", musicFolderChanged);
         MusicFolder selectedMusicFolder = securityService.getSelectedMusicFolder(username);
         List<MusicFolder> musicFoldersToUse = selectedMusicFolder == null ? allMusicFolders
                 : Collections.singletonList(selectedMusicFolder);
@@ -144,8 +146,6 @@ public class TopController {
         map.put("shortcuts", musicIndexService.getShortcuts(musicFoldersToUse));
         map.put("partyMode", userSettings.isPartyModeEnabled());
         map.put("alternativeDrawer", userSettings.isAlternativeDrawer());
-        boolean musicFolderChanged = saveSelectedMusicFolder(request);
-        map.put("musicFolderChanged", musicFolderChanged);
 
         if (userSettings.isFinalVersionNotificationEnabled() && versionService.isNewFinalVersionAvailable()) {
             map.put("newVersionAvailable", true);


### PR DESCRIPTION
## Problem description

When multiple music folders are registered, the index is not updated even if a folder is selected.

### Steps to reproduce

Selecting a folder that is not currently selected when multiple music folders are registered. The contents of the main target will be reflected in the corresponding contents of the selected folder. On the other hand, the index and selector on the left side of the web page are not updated.

 - F5 will update it.
 - Or if we make the same selection again it will be updated.

## System information

 * **Jpsonic version**: a long time ago ... When Top and Left of Jpsonic Webpage were integrated.

## Additional notes

Minor glitch of Controller . 

 - Get the folder selected by the user from the database
 - Receive and register folders selected by the user

These two processes exist, but they are executed in reverse order. Therefore, the folder selected by the user is correctly registered in the database, but it is redrawn using the previously selected folder when redisplaying.
