### PR TITLE
Database scheme changes

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/MusicFolderSettingsCommand.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/MusicFolderSettingsCommand.java
@@ -148,6 +148,7 @@ public class MusicFolderSettingsCommand extends SettingsPageCommons {
         private String path;
         private String name;
         private boolean enabled;
+        private Integer folderOrder;
         private boolean delete;
         private boolean existing;
 
@@ -194,6 +195,14 @@ public class MusicFolderSettingsCommand extends SettingsPageCommons {
 
         public void setEnabled(boolean enabled) {
             this.enabled = enabled;
+        }
+
+        public Integer getFolderOrder() {
+            return folderOrder;
+        }
+
+        public void setFolderOrder(Integer folderOrder) {
+            this.folderOrder = folderOrder;
         }
 
         public boolean isDelete() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MusicFolderSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MusicFolderSettingsController.java
@@ -214,6 +214,7 @@ public class MusicFolderSettingsController {
         if (name == null) {
             name = newPath.getFileName().toString();
         }
-        return Optional.of(new MusicFolder(info.getId(), validated.get(), name, info.isEnabled(), now()));
+        return Optional.of(
+                new MusicFolder(info.getId(), validated.get(), name, info.isEnabled(), now(), info.getFolderOrder()));
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -69,7 +69,7 @@ public class MediaFileDao extends AbstractDao {
     // Expected maximum number of album child elements (can be expanded)
     private static final int ALBUM_CHILD_MAX = 10_000;
 
-    private static final int JP_VERSION = 8;
+    private static final int JP_VERSION = 9;
     public static final int VERSION = 4 + JP_VERSION;
 
     private final RowMapper<MediaFile> rowMapper;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MusicFolderDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MusicFolderDao.java
@@ -41,7 +41,7 @@ import org.springframework.stereotype.Repository;
 public class MusicFolderDao extends AbstractDao {
 
     private static final Logger LOG = LoggerFactory.getLogger(MusicFolderDao.class);
-    private static final String INSERT_COLUMNS = "path, name, enabled, changed";
+    private static final String INSERT_COLUMNS = "path, name, enabled, changed, folder_order";
     private static final String QUERY_COLUMNS = "id, " + INSERT_COLUMNS;
 
     private final MusicFolderRowMapper rowMapper;
@@ -80,7 +80,8 @@ public class MusicFolderDao extends AbstractDao {
      *            The music folder to create.
      */
     public void createMusicFolder(MusicFolder musicFolder) {
-        String sql = "insert into music_folder (" + INSERT_COLUMNS + ") values (?, ?, ?, ?)";
+        String sql = "insert into music_folder (" + INSERT_COLUMNS
+                + ") values (?, ?, ?, ?, (select count(*) from music_folder))";
         update(sql, musicFolder.getPathString(), musicFolder.getName(), musicFolder.isEnabled(),
                 musicFolder.getChanged());
 
@@ -113,9 +114,9 @@ public class MusicFolderDao extends AbstractDao {
      *            The music folder to update.
      */
     public void updateMusicFolder(@NonNull MusicFolder musicFolder) {
-        String sql = "update music_folder set path=?, name=?, enabled=?, changed=? where id=?";
+        String sql = "update music_folder set path=?, name=?, enabled=?, changed=?, folder_order=? where id=?";
         update(sql, musicFolder.getPathString(), musicFolder.getName(), musicFolder.isEnabled(),
-                musicFolder.getChanged(), musicFolder.getId());
+                musicFolder.getChanged(), musicFolder.getFolderOrder(), musicFolder.getId());
     }
 
     public List<MusicFolder> getMusicFoldersForUser(String username) {
@@ -135,7 +136,7 @@ public class MusicFolderDao extends AbstractDao {
         @Override
         public MusicFolder mapRow(ResultSet rs, int rowNum) throws SQLException {
             return new MusicFolder(rs.getInt(1), rs.getString(2), rs.getString(3), rs.getBoolean(4),
-                    nullableInstantOf(rs.getTimestamp(5)));
+                    nullableInstantOf(rs.getTimestamp(5)), rs.getInt(6));
         }
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicFolder.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicFolder.java
@@ -41,17 +41,20 @@ public class MusicFolder implements Serializable {
     private String name;
     private boolean enabled;
     private Instant changed;
+    private Integer folderOrder;
 
-    public MusicFolder(Integer id, String pathString, String name, boolean enabled, Instant changed) {
+    public MusicFolder(Integer id, String pathString, String name, boolean enabled, Instant changed,
+            Integer folderOrder) {
         this.id = id;
         this.pathString = pathString;
         this.name = name;
         this.enabled = enabled;
         this.changed = changed;
+        this.folderOrder = folderOrder;
     }
 
     public MusicFolder(String pathString, String name, boolean enabled, Instant changed) {
-        this(null, pathString, name, enabled, changed);
+        this(null, pathString, name, enabled, changed, null);
     }
 
     public Integer getId() {
@@ -92,6 +95,14 @@ public class MusicFolder implements Serializable {
 
     public void setChanged(Instant changed) {
         this.changed = changed;
+    }
+
+    public int getFolderOrder() {
+        return folderOrder;
+    }
+
+    public void setFolderOrder(int folderOrder) {
+        this.folderOrder = folderOrder;
     }
 
     @Override

--- a/jpsonic-main/src/main/resources/liquibase/db-changelog.xml
+++ b/jpsonic-main/src/main/resources/liquibase/db-changelog.xml
@@ -30,4 +30,5 @@
     <include file="jp109.5.0/changelog.xml" relativeToChangelogFile="true"/>
     <include file="jp110.2.0/changelog.xml" relativeToChangelogFile="true"/>
     <include file="jp111.6.0/changelog.xml" relativeToChangelogFile="true"/>
+    <include file="jp112.0.0/changelog.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/jpsonic-main/src/main/resources/liquibase/jp112.0.0/changelog.xml
+++ b/jpsonic-main/src/main/resources/liquibase/jp112.0.0/changelog.xml
@@ -1,0 +1,20 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="drop-music-file-info" author="tesshucom">  
+        <preConditions onFail="MARK_RAN">
+			<tableExists tableName="music_file_info"/>
+        </preConditions>
+        <dropTable tableName="music_file_info" cascadeConstraints="true"/>
+        <rollback></rollback>
+    </changeSet>
+    <changeSet id="add-folder-order" author="tesshucom">
+        <addColumn tableName="music_folder">
+            <column name="folder_order" type="int" defaultValue="-1">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/MusicFolderTestDataUtils.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/MusicFolderTestDataUtils.java
@@ -61,7 +61,7 @@ public final class MusicFolderTestDataUtils {
 
     public static List<MusicFolder> getTestMusicFolders() {
         return Arrays.asList(
-                new MusicFolder(1, MusicFolderTestDataUtils.resolveMusicFolderPath(), "Music", true, now()),
-                new MusicFolder(2, MusicFolderTestDataUtils.resolveMusic2FolderPath(), "Music2", true, now()));
+                new MusicFolder(1, MusicFolderTestDataUtils.resolveMusicFolderPath(), "Music", true, now(), 0),
+                new MusicFolder(2, MusicFolderTestDataUtils.resolveMusic2FolderPath(), "Music2", true, now(), 1));
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/CoverArtServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/CoverArtServiceTest.java
@@ -63,7 +63,7 @@ class CoverArtServiceTest extends AbstractNeedsScan {
     @Override
     public List<MusicFolder> getMusicFolders() {
         if (isEmpty(musicFolders)) {
-            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now()));
+            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1));
         }
         return musicFolders;
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/MultiServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/MultiServiceTest.java
@@ -65,7 +65,7 @@ class MultiServiceTest extends AbstractNeedsScan {
     @Override
     public List<MusicFolder> getMusicFolders() {
         if (isEmpty(musicFolders)) {
-            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now()));
+            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1));
         }
         return musicFolders;
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/ChangeCoverArtControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/ChangeCoverArtControllerTest.java
@@ -50,7 +50,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 class ChangeCoverArtControllerTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1));
 
     @Autowired
     private MediaFileDao mediaFileDao;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DLNASettingsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DLNASettingsControllerTest.java
@@ -159,7 +159,7 @@ class DLNASettingsControllerTest {
          * Always false if all folders are not allowed. Because the genre count is a statistical result for all
          * directories.
          */
-        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, "", null, true, null));
+        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder("", null, true, null));
         Mockito.when(musicFolderService.getAllMusicFolders()).thenReturn(musicFolders);
         Mockito.when(musicFolderService.getMusicFoldersForUser(User.USERNAME_GUEST)).thenReturn(musicFolders);
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DownloadControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DownloadControllerTest.java
@@ -70,7 +70,7 @@ class DownloadControllerTest extends AbstractNeedsScan {
     @Override
     public List<MusicFolder> getMusicFolders() {
         if (isEmpty(musicFolders)) {
-            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now()));
+            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1));
         }
         return musicFolders;
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/EditTagsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/EditTagsControllerTest.java
@@ -46,7 +46,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 class EditTagsControllerTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1));
 
     private MockMvc mockMvc;
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/ExternalPlayerControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/ExternalPlayerControllerTest.java
@@ -85,7 +85,7 @@ class ExternalPlayerControllerTest {
         mediaFile.setPathString(path.toString());
         List<MediaFile> mediaFiles = Arrays.asList(mediaFile);
 
-        MusicFolder folder = new MusicFolder(0, "", "", true, expires);
+        MusicFolder folder = new MusicFolder("", "", true, expires);
         List<MusicFolder> folders = Arrays.asList(folder);
         Mockito.when(musicFolderService.getMusicFoldersForUser(Mockito.anyString())).thenReturn(folders);
         Mockito.when(shareService.getSharedFiles(shareId, folders)).thenReturn(mediaFiles);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/HomeControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/HomeControllerTest.java
@@ -234,7 +234,7 @@ class HomeControllerTest {
             MockHttpServletRequest req = mock(MockHttpServletRequest.class);
             Mockito.when(req.getParameter(Attributes.Request.LIST_TYPE.value()))
                     .thenReturn(AlbumListType.INDEX.getId());
-            List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, "", "name", false, now()));
+            List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder("", "name", false, now()));
             Mockito.when(musicFolderService.getMusicFoldersForUser(anyString(), Mockito.nullable(Integer.class)))
                     .thenReturn(musicFolders);
             Mockito.when(musicIndexService.getMusicFolderContent(musicFolders))

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MoreControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MoreControllerTest.java
@@ -64,7 +64,7 @@ class MoreControllerTest {
         Mockito.when(searchService.getGenres(false)).thenReturn(Collections.emptyList());
         Mockito.when(playerService.getPlayer(Mockito.any(), Mockito.any())).thenReturn(new Player());
         List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
-                Path.of(MoreControllerTest.class.getResource("/MEDIAS").toURI()).toString(), "MEDIAS", true, now()));
+                Path.of(MoreControllerTest.class.getResource("/MEDIAS").toURI()).toString(), "MEDIAS", true, now(), 1));
         Mockito.when(musicFolderService.getMusicFoldersForUser(ServiceMockUtils.ADMIN_NAME)).thenReturn(musicFolders);
     }
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MusicFolderSettingsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MusicFolderSettingsControllerTest.java
@@ -217,7 +217,7 @@ class MusicFolderSettingsControllerTest {
         assertNotNull(command);
 
         MusicFolder musicFolder1 = new MusicFolder(99, MusicFolderTestDataUtils.resolveMusicFolderPath(), "Music", true,
-                now());
+                now(), 1);
         MusicFolderInfo musicFolderInfo1 = new MusicFolderInfo(musicFolder1);
         musicFolderInfo1.setDelete(true);
         MusicFolder musicFolder2 = new MusicFolder(MusicFolderTestDataUtils.resolveMusic2FolderPath(), "Music2", true,
@@ -369,7 +369,7 @@ class MusicFolderSettingsControllerTest {
         @ToMusicFolderDecisions.Conditions.MusicFolderInfo.Path.NonNull.NonTraversal.OldPathStartWithNewPath
         @ToMusicFolderDecisions.Results.Empty
         void c03() {
-            List<MusicFolder> oldMusicFolders = Arrays.asList(new MusicFolder(0, "/jpsonic", "old", false, null));
+            List<MusicFolder> oldMusicFolders = Arrays.asList(new MusicFolder(0, "/jpsonic", "old", false, null, 0));
             Mockito.when(musicFolderService.getAllMusicFolders(true, true)).thenReturn(oldMusicFolders);
             MusicFolderInfo info = new MusicFolderInfo();
             String path = "/jpsonic/subDirectory";
@@ -382,7 +382,7 @@ class MusicFolderSettingsControllerTest {
         @ToMusicFolderDecisions.Results.Empty
         void c04() {
             List<MusicFolder> oldMusicFolders = Arrays
-                    .asList(new MusicFolder(0, "/jpsonic/subDirectory", "old", false, null));
+                    .asList(new MusicFolder(0, "/jpsonic/subDirectory", "old", false, null, 0));
             Mockito.when(musicFolderService.getAllMusicFolders(true, true)).thenReturn(oldMusicFolders);
             MusicFolderInfo info = new MusicFolderInfo();
             String path = "/jpsonic";
@@ -395,7 +395,7 @@ class MusicFolderSettingsControllerTest {
         @ToMusicFolderDecisions.Conditions.MusicFolderInfo.Name.NonNull
         @ToMusicFolderDecisions.Results.NotEmpty
         void c05() {
-            List<MusicFolder> oldMusicFolders = Arrays.asList(new MusicFolder(0, "/jpsonic", "old", false, null));
+            List<MusicFolder> oldMusicFolders = Arrays.asList(new MusicFolder(0, "/jpsonic", "old", false, null, 0));
             Mockito.when(musicFolderService.getAllMusicFolders(true, true)).thenReturn(oldMusicFolders);
             MusicFolderInfo info = new MusicFolderInfo();
             String path = "foo/bar";
@@ -409,7 +409,7 @@ class MusicFolderSettingsControllerTest {
         @ToMusicFolderDecisions.Conditions.MusicFolderInfo.Name.NonNull
         @ToMusicFolderDecisions.Results.NotEmpty
         void c06() {
-            List<MusicFolder> oldMusicFolders = Arrays.asList(new MusicFolder(0, "/jpsonic", "old", false, null));
+            List<MusicFolder> oldMusicFolders = Arrays.asList(new MusicFolder(0, "/jpsonic", "old", false, null, 0));
             Mockito.when(musicFolderService.getAllMusicFolders(true, true)).thenReturn(oldMusicFolders);
             MusicFolderInfo info = new MusicFolderInfo();
             String path = "/jpsonic";

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/SubsonicRESTControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/SubsonicRESTControllerTest.java
@@ -241,7 +241,7 @@ class SubsonicRESTControllerTest {
     class IntegreationTest extends AbstractNeedsScan {
 
         private final List<MusicFolder> musicFolders = Arrays
-                .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now()));
+                .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1));
 
         @Autowired
         private MockMvc mvc;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/TopControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/TopControllerTest.java
@@ -124,7 +124,7 @@ class TopControllerTest {
         void testWithoutSelectedMusicFolders() throws ServletRequestBindingException, URISyntaxException {
             List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
                     Path.of(TopControllerTest.class.getResource("/MEDIAS/Sort/Pagination/Artists").toURI()).toString(),
-                    "MEDIAS", true, now()));
+                    "MEDIAS", true, now(), 1));
             Mockito.when(musicFolderService.getMusicFoldersForUser(Mockito.anyString())).thenReturn(musicFolders);
 
             MockHttpServletRequest request = mock(MockHttpServletRequest.class);
@@ -136,7 +136,7 @@ class TopControllerTest {
         void testWithSelectedMusicFolders() throws ServletRequestBindingException, URISyntaxException {
             List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
                     Path.of(TopControllerTest.class.getResource("/MEDIAS/Sort/Pagination/Artists").toURI()).toString(),
-                    "MEDIAS", true, now()));
+                    "MEDIAS", true, now(), 1));
             Mockito.when(musicFolderService.getMusicFoldersForUser(Mockito.anyString())).thenReturn(musicFolders);
             Mockito.when(securityService.getSelectedMusicFolder(Mockito.anyString())).thenReturn(musicFolders.get(0));
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/UploadControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/UploadControllerTest.java
@@ -87,7 +87,7 @@ class UploadControllerTest {
     @WithMockUser(username = "admin")
     void testHandleRequestInternalWithFile(@TempDir Path tempDirPath) throws Exception {
 
-        MusicFolder musicFolder = new MusicFolder(Integer.valueOf(0), tempDirPath.toString(), "Incoming1", true, now());
+        MusicFolder musicFolder = new MusicFolder(0, tempDirPath.toString(), "Incoming1", true, now(), 1);
         musicFolderDao.createMusicFolder(musicFolder);
 
         URL url = UploadController.class.getResource(FILE_PATH);
@@ -115,7 +115,7 @@ class UploadControllerTest {
     @WithMockUser(username = "admin")
     void testHandleRequestInternalWithZip(@TempDir Path tempDirPath) throws Exception {
 
-        MusicFolder musicFolder = new MusicFolder(Integer.valueOf(1), tempDirPath.toString(), "Incoming2", true, now());
+        MusicFolder musicFolder = new MusicFolder(1, tempDirPath.toString(), "Incoming2", true, now(), 1);
         musicFolderDao.createMusicFolder(musicFolder);
 
         URL url = UploadController.class.getResource(ZIP_PATH);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/UploadEntryControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/UploadEntryControllerTest.java
@@ -55,7 +55,7 @@ class UploadEntryControllerTest {
     public void setup() throws ExecutionException, URISyntaxException {
         List<MusicFolder> musicFolders = Arrays.asList(
                 new MusicFolder(1, Path.of(UploadEntryControllerTest.class.getResource("/MEDIAS").toURI()).toString(),
-                        "MEDIAS", true, now()));
+                        "MEDIAS", true, now(), 1));
         MusicFolderService musicFolderService = mock(MusicFolderService.class);
         Mockito.when(musicFolderService.getMusicFoldersForUser(ServiceMockUtils.ADMIN_NAME)).thenReturn(musicFolders);
         mockMvc = MockMvcBuilders.standaloneSetup(new UploadEntryController(musicFolderService,

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/JAlbumDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/JAlbumDaoTest.java
@@ -37,7 +37,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class JAlbumDaoTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Compare"), "Albums", true, now()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Compare"), "Albums", true, now(), 1));
 
     @Autowired
     private AlbumDao albumDao;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/JArtistDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/JArtistDaoTest.java
@@ -37,7 +37,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class JArtistDaoTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Compare"), "Artists", true, now()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Compare"), "Artists", true, now(), 1));
 
     @Autowired
     private JArtistDao artistDao;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JpsonicComparatorsTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JpsonicComparatorsTest.java
@@ -72,7 +72,7 @@ class JpsonicComparatorsTest extends AbstractNeedsScan {
     protected static final Logger LOG = LoggerFactory.getLogger(JpsonicComparatorsTest.class);
 
     protected static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Compare"), "test date for sorting", true, now()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Compare"), "test date for sorting", true, now(), 1));
 
     protected static final List<String> INDEX_LIST = Collections.unmodifiableList(Arrays.asList("abcde", "abcいうえおあ", // Turn
                                                                                                                      // over

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MusicIndexServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MusicIndexServiceTest.java
@@ -93,7 +93,7 @@ class MusicIndexServiceTest {
         List<MediaFile> children = Arrays.asList(child1, child2);
         Mockito.when(mediaFileService.getChildrenOf(Mockito.any(MediaFile.class), Mockito.anyBoolean(),
                 Mockito.anyBoolean())).thenReturn(children);
-        MusicFolder folder = new MusicFolder(0, "path", "name", true, now());
+        MusicFolder folder = new MusicFolder(0, "path", "name", true, now(), 0);
 
         SortedMap<MusicIndex, List<MusicIndex.SortableArtistWithMediaFiles>> indexedArtists = musicIndexService
                 .getIndexedArtists(Arrays.asList(folder));
@@ -178,7 +178,7 @@ class MusicIndexServiceTest {
         Mockito.when(mediaFileService.getChildrenOf(Mockito.any(MediaFile.class), Mockito.anyBoolean(),
                 Mockito.anyBoolean())).thenReturn(children).thenReturn(songs).thenThrow(new RuntimeException("Fail"));
         Mockito.when(mediaFileService.getMediaFile(Mockito.any(Path.class))).thenReturn(new MediaFile());
-        MusicFolder folder = new MusicFolder(0, "path", "name", true, now());
+        MusicFolder folder = new MusicFolder(0, "path", "name", true, now(), 0);
 
         MusicFolderContent content = musicIndexService.getMusicFolderContent(Arrays.asList(folder));
         assertEquals(2, content.getIndexedArtists().size());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/RatingServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/RatingServiceTest.java
@@ -61,7 +61,7 @@ class RatingServiceTest {
         album.setPathString(albumPath.toString());
         Mockito.when(mediaFileService.getMediaFile(albumPath)).thenReturn(album);
 
-        MusicFolder musicFolder = new MusicFolder(0, "path", "Music", true, now());
+        MusicFolder musicFolder = new MusicFolder("path", "Music", true, now());
         List<MusicFolder> musicFolders = Arrays.asList(musicFolder);
         List<MediaFile> highestRatedAlbums = ratingService.getHighestRatedAlbums(0, 0, musicFolders);
         assertEquals(1, highestRatedAlbums.size());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImplTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImplTest.java
@@ -397,10 +397,10 @@ class MediaScannerServiceImplTest {
         public List<MusicFolder> getMusicFolders() {
             if (ObjectUtils.isEmpty(musicFolders)) {
                 musicFolders = Arrays.asList(
-                        new MusicFolder(1, resolveBaseMediaPath("Scan/Id3LIFO"), "alphaBeticalProps", true, now()),
-                        new MusicFolder(2, resolveBaseMediaPath("Scan/Null"), "noTagFirstChild", true, now()),
+                        new MusicFolder(1, resolveBaseMediaPath("Scan/Id3LIFO"), "alphaBeticalProps", true, now(), 0),
+                        new MusicFolder(2, resolveBaseMediaPath("Scan/Null"), "noTagFirstChild", true, now(), 1),
                         new MusicFolder(3, resolveBaseMediaPath("Scan/Reverse"), "fileAndPropsNameInReverse", true,
-                                now()));
+                                now(), 2));
             }
             return musicFolders;
         }
@@ -551,7 +551,7 @@ class MediaScannerServiceImplTest {
             assertNotNull(FileUtil.createDirectories(artist));
             this.album = Path.of(artist.toString(), "ALBUM");
             assertNotNull(FileUtil.createDirectories(album));
-            this.musicFolders = Arrays.asList(new MusicFolder(1, tempDir.toString(), "musicFolder", true, now()));
+            this.musicFolders = Arrays.asList(new MusicFolder(1, tempDir.toString(), "musicFolder", true, now(), 1));
 
             // Copy the song file from the test resource. No tags are registered in this file.
             Path sample = Path.of(MediaScannerServiceImplTest.class
@@ -868,7 +868,7 @@ class MediaScannerServiceImplTest {
                 IOUtils.copy(resource, Files.newOutputStream(musicPath));
             }
 
-            MusicFolder musicFolder = new MusicFolder(1, tempDirPath.toString(), "Music", true, now());
+            MusicFolder musicFolder = new MusicFolder(1, tempDirPath.toString(), "Music", true, now(), 1);
             musicFolderDao.createMusicFolder(musicFolder);
             musicFolderService.clearMusicFolderCache();
             TestCaseUtils.execScan(mediaScannerService);
@@ -888,7 +888,7 @@ class MediaScannerServiceImplTest {
 
             // Add the "Music3" folder to the database
             Path musicFolderPath = Path.of(MusicFolderTestDataUtils.resolveMusic3FolderPath());
-            MusicFolder musicFolder = new MusicFolder(1, musicFolderPath.toString(), "Music3", true, now());
+            MusicFolder musicFolder = new MusicFolder(1, musicFolderPath.toString(), "Music3", true, now(), 1);
             musicFolderDao.createMusicFolder(musicFolder);
             musicFolderService.clearMusicFolderCache();
             TestCaseUtils.execScan(mediaScannerService);
@@ -959,8 +959,8 @@ class MediaScannerServiceImplTest {
             assertNotNull(FileUtil.createDirectories(artist));
             this.album = Path.of(artist.toString(), "ALBUM");
             assertNotNull(FileUtil.createDirectories(album));
-            this.musicFolders = Arrays.asList(new MusicFolder(1, tempDir1.toString(), "musicFolder1", true, now()),
-                    new MusicFolder(2, tempDir2.toString(), "musicFolder2", true, now()));
+            this.musicFolders = Arrays.asList(new MusicFolder(1, tempDir1.toString(), "musicFolder1", true, now(), 0),
+                    new MusicFolder(2, tempDir2.toString(), "musicFolder2", true, now(), 1));
 
             Path sample = Path.of(MediaScannerServiceImplTest.class
                     .getResource("/MEDIAS/Scan/Timestamp/ARTIST/ALBUM/sample.mp3").toURI());
@@ -1028,7 +1028,7 @@ class MediaScannerServiceImplTest {
             assertNotNull(FileUtil.createDirectories(artist));
             Path album = Path.of(artist.toString(), "ALBUM");
             assertNotNull(FileUtil.createDirectories(album));
-            this.musicFolders = Arrays.asList(new MusicFolder(1, tempDir.toString(), "musicFolder1", true, now()));
+            this.musicFolders = Arrays.asList(new MusicFolder(1, tempDir.toString(), "musicFolder1", true, now(), 1));
             Path sample = Path.of(MediaScannerServiceImplTest.class
                     .getResource("/MEDIAS/Scan/Timestamp/ARTIST/ALBUM/sample.mp3").toURI());
             this.song = Path.of(album.toString(), "sample.mp3");

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MusicFolderServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MusicFolderServiceTest.java
@@ -65,14 +65,14 @@ class MusicFolderServiceTest {
         musicFolderService = new MusicFolderServiceImpl(musicFolderDao, mock(StaticsDao.class), settingsService,
                 scannerStateService, indexCache);
 
-        MusicFolder m1 = new MusicFolder(1, "/dummy/path", "Disabled&NonExisting", false, null);
-        MusicFolder m2 = new MusicFolder(2, "/dummy/path", "Enabled&NonExisting", true, null);
+        MusicFolder m1 = new MusicFolder(1, "/dummy/path", "Disabled&NonExisting", false, null, 0);
+        MusicFolder m2 = new MusicFolder(2, "/dummy/path", "Enabled&NonExisting", true, null, 1);
         Path existingPath1 = Path.of(MusicFolderServiceTest.class.getResource("/MEDIAS/Music").toURI());
         assertTrue(Files.exists(existingPath1));
-        MusicFolder m3 = new MusicFolder(3, existingPath1.toString(), "Disabled&Existing", false, null);
+        MusicFolder m3 = new MusicFolder(3, existingPath1.toString(), "Disabled&Existing", false, null, 3);
         Path existingPath2 = Path.of(MusicFolderServiceTest.class.getResource("/MEDIAS/Music2").toURI());
         assertTrue(Files.exists(existingPath2));
-        MusicFolder m4 = new MusicFolder(4, existingPath2.toString(), "Enabled&Existing", true, null);
+        MusicFolder m4 = new MusicFolder(4, existingPath2.toString(), "Enabled&Existing", true, null, 4);
         List<MusicFolder> folders = Arrays.asList(m1, m2, m3, m4);
         Mockito.when(musicFolderDao.getAllMusicFolders()).thenReturn(folders);
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/SortProcedureServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/SortProcedureServiceTest.java
@@ -65,7 +65,7 @@ class SortProcedureServiceTest {
     class CompensateSortOfArtistTest extends AbstractNeedsScan {
 
         private final List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
-                resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Compensation"), "Duplicate", true, now()));
+                resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Compensation"), "Duplicate", true, now(), 1));
 
         @Autowired
         private JMediaFileDao mediaFileDao;
@@ -225,8 +225,8 @@ class SortProcedureServiceTest {
     @Order(3)
     class CopySortOfArtistTest extends AbstractNeedsScan {
 
-        private final List<MusicFolder> musicFolders = Arrays.asList(
-                new MusicFolder(1, resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Copy"), "Duplicate", true, now()));
+        private final List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
+                resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Copy"), "Duplicate", true, now(), 1));
 
         @Autowired
         private JMediaFileDao mediaFileDao;
@@ -283,8 +283,8 @@ class SortProcedureServiceTest {
     @Order(1)
     class MergeSortOfArtistTest extends AbstractNeedsScan {
 
-        private final List<MusicFolder> musicFolders = Arrays.asList(
-                new MusicFolder(1, resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Merge"), "Duplicate", true, now()));
+        private final List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
+                resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Merge"), "Duplicate", true, now(), 1));
 
         @Autowired
         private JMediaFileDao jMediaFileDao;
@@ -767,8 +767,8 @@ class SortProcedureServiceTest {
     @Order(4)
     class UpdateSortOfAlbumTest extends AbstractNeedsScan {
 
-        private final List<MusicFolder> musicFolders = Arrays
-                .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Cleansing/AlbumSort"), "Duplicate", true, now()));
+        private final List<MusicFolder> musicFolders = Arrays.asList(
+                new MusicFolder(1, resolveBaseMediaPath("Sort/Cleansing/AlbumSort"), "Duplicate", true, now(), 1));
         @Autowired
         private MediaFileDao mediaFileDao;
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/DocumentFactoryTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/DocumentFactoryTest.java
@@ -155,7 +155,7 @@ class DocumentFactoryTest {
         artist.setSort("sort");
         artist.setFolderId(10);
         MusicFolder musicFolder = new MusicFolder(100, MusicFolderTestDataUtils.resolveMusicFolderPath(), "Music", true,
-                now());
+                now(), 0);
         Document document = documentFactory.createArtistId3Document(artist, musicFolder);
         assertEquals(6, document.getFields().size(), "fields.size");
         assertEquals("1", document.get(FieldNamesConstants.ID));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
@@ -81,7 +81,7 @@ class IndexManagerTest extends AbstractNeedsScan {
     @Override
     public List<MusicFolder> getMusicFolders() {
         if (ObjectUtils.isEmpty(musicFolders)) {
-            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now()));
+            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1));
         }
         return musicFolders;
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/QueryFactoryTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/QueryFactoryTest.java
@@ -62,8 +62,8 @@ class QueryFactoryTest {
     private static final int FID1 = 10;
     private static final int FID2 = 20;
 
-    private static final MusicFolder MUSIC_FOLDER1 = new MusicFolder(FID1, PATH1, "music1", true, now());
-    private static final MusicFolder MUSIC_FOLDER2 = new MusicFolder(FID2, PATH2, "music2", true, now());
+    private static final MusicFolder MUSIC_FOLDER1 = new MusicFolder(FID1, PATH1, "music1", true, now(), 0);
+    private static final MusicFolder MUSIC_FOLDER2 = new MusicFolder(FID2, PATH2, "music2", true, now(), 1);
 
     private static final List<MusicFolder> SINGLE_FOLDERS = Arrays.asList(MUSIC_FOLDER1);
     private static final List<MusicFolder> MULTI_FOLDERS = Arrays.asList(MUSIC_FOLDER1, MUSIC_FOLDER2);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/SearchServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/SearchServiceTest.java
@@ -550,7 +550,7 @@ class SearchServiceTest {
         public List<MusicFolder> getMusicFolders() {
             if (isEmpty(musicFolders)) {
                 musicFolders = Arrays.asList(
-                        new MusicFolder(1, resolveBaseMediaPath("Search/SpecialGenre"), "accessible", true, now()));
+                        new MusicFolder(1, resolveBaseMediaPath("Search/SpecialGenre"), "accessible", true, now(), 1));
             }
             return musicFolders;
         }
@@ -815,11 +815,11 @@ class SearchServiceTest {
             if (isEmpty(musicFolders)) {
                 musicFolders = Arrays.asList(
                         new MusicFolder(1, resolveBaseMediaPath("Search/SpecialPath/accessible"), "accessible", true,
-                                now()),
+                                now(), 0),
                         new MusicFolder(2, resolveBaseMediaPath("Search/SpecialPath/accessible's"), "accessible's",
-                                true, now()),
+                                true, now(), 1),
                         new MusicFolder(3, resolveBaseMediaPath("Search/SpecialPath/accessible+s"), "accessible+s",
-                                true, now()));
+                                true, now(), 2));
             }
             return musicFolders;
         }
@@ -879,7 +879,7 @@ class SearchServiceTest {
         public List<MusicFolder> getMusicFolders() {
             if (isEmpty(musicFolders)) {
                 musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Search/StartWithStopwards"),
-                        "accessible", true, now()));
+                        "accessible", true, now(), 1));
             }
             return musicFolders;
         }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/UPnPSearchCriteriaDirectorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/UPnPSearchCriteriaDirectorTest.java
@@ -244,7 +244,7 @@ public class UPnPSearchCriteriaDirectorTest {
         Mockito.when(settingsService.isSearchComposer()).thenReturn(true);
 
         List<MusicFolder> musicFolders = new ArrayList<>();
-        musicFolders.add(new MusicFolder(1, "dummy", "accessible", true, now()));
+        musicFolders.add(new MusicFolder(1, "dummy", "accessible", true, now(), 1));
         musicFolderService = mock(MusicFolderService.class);
         Mockito.when(musicFolderService.getMusicFoldersForUser(User.USERNAME_GUEST)).thenReturn(musicFolders);
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/AlbumUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/AlbumUpnpProcessorTest.java
@@ -44,7 +44,7 @@ import org.springframework.context.annotation.ComponentScan;
 class AlbumUpnpProcessorTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Albums"), "Albums", true, now()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Albums"), "Albums", true, now(), 1));
 
     @Autowired
     private AlbumUpnpProcessor albumUpnpProcessor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/ArtistUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/ArtistUpnpProcessorTest.java
@@ -46,7 +46,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class ArtistUpnpProcessorTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now(), 1));
 
     @Autowired
     private ArtistUpnpProcessor artistUpnpProcessor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/IndexUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/IndexUpnpProcessorTest.java
@@ -74,7 +74,7 @@ class IndexUpnpProcessorTest {
 
         @Test
         void testRefreshIndex() {
-            List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, "", "name", true, now()));
+            List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, "", "name", true, now(), 0));
             Mockito.when(util.getGuestMusicFolders()).thenReturn(musicFolders);
             Mockito.when(musicIndexService.getMusicFolderContent(musicFolders))
                     .thenReturn(new MusicFolderContent(new TreeMap<>(), Collections.emptyList()));
@@ -88,7 +88,7 @@ class IndexUpnpProcessorTest {
     class IntegrationTest extends AbstractNeedsScan {
 
         private final List<MusicFolder> musicFolders = Arrays
-                .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now()));
+                .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now(), 1));
 
         @Autowired
         private IndexUpnpProcessor indexUpnpProcessor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/MediaFileUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/MediaFileUpnpProcessorTest.java
@@ -75,8 +75,8 @@ class MediaFileUpnpProcessorTest {
             folder1.setMediaType(MediaType.DIRECTORY);
             Mockito.when(mediaFileService.getMediaFile(musicFolderPath1)).thenReturn(folder1);
 
-            Mockito.when(upnpProcessorUtil.getGuestMusicFolders())
-                    .thenReturn(Arrays.asList(new MusicFolder(0, musicFolderPath1.toString(), "Music", true, now())));
+            Mockito.when(upnpProcessorUtil.getGuestMusicFolders()).thenReturn(
+                    Arrays.asList(new MusicFolder(0, musicFolderPath1.toString(), "Music", true, now(), 0)));
             List<MediaFile> result = mediaFileUpnpProcessor.getItems(0, Integer.MAX_VALUE);
             Mockito.verify(mediaFileService, Mockito.times(1)).getMediaFile(Mockito.any(Path.class));
             assertEquals(0, result.size());
@@ -89,8 +89,8 @@ class MediaFileUpnpProcessorTest {
             Mockito.when(mediaFileService.getMediaFile(musicFolderPath2)).thenReturn(folder2);
 
             Mockito.when(upnpProcessorUtil.getGuestMusicFolders())
-                    .thenReturn(Arrays.asList(new MusicFolder(0, musicFolderPath1.toString(), "Music1", true, now()),
-                            new MusicFolder(1, musicFolderPath2.toString(), "Music2", true, now())));
+                    .thenReturn(Arrays.asList(new MusicFolder(0, musicFolderPath1.toString(), "Music1", true, now(), 0),
+                            new MusicFolder(1, musicFolderPath2.toString(), "Music2", true, now(), 1)));
             result = mediaFileUpnpProcessor.getItems(0, Integer.MAX_VALUE);
             Mockito.verify(mediaFileService, Mockito.times(2)).getMediaFile(Mockito.any(Path.class));
             assertEquals(2, result.size());
@@ -117,7 +117,7 @@ class MediaFileUpnpProcessorTest {
             musicFolders = Arrays.asList(new MusicFolder(1,
                     Path.of(MediaFileUpnpProcessorTest.class.getResource("/MEDIAS/Sort/Pagination/Artists").toURI())
                             .toString(),
-                    "Artists", true, now()));
+                    "Artists", true, now(), 1));
 
             setSortStrict(true);
             setSortAlphanum(true);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/PlaylistUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/PlaylistUpnpProcessorTest.java
@@ -51,7 +51,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class PlaylistUpnpProcessorTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now(), 1));
 
     @Autowired
     private PlaylistUpnpProcessor playlistUpnpProcessor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RandomSongByArtistUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RandomSongByArtistUpnpProcessorTest.java
@@ -43,7 +43,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class RandomSongByArtistUpnpProcessorTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now(), 1));
 
     @Autowired
     private RandomSongByArtistUpnpProcessor randomSongByArtistUpnpProcessor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RandomSongByFolderArtistUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RandomSongByFolderArtistUpnpProcessorTest.java
@@ -36,7 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class RandomSongByFolderArtistUpnpProcessorTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now(), 1));
 
     @Autowired
     private RandomSongByFolderArtistUpnpProcessor processor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumId3UpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumId3UpnpProcessorTest.java
@@ -39,7 +39,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class RecentAlbumId3UpnpProcessorTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Albums"), "Albums", true, now()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Albums"), "Albums", true, now(), 1));
 
     @Autowired
     private RecentAlbumId3UpnpProcessor processor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumUpnpProcessorTest.java
@@ -43,7 +43,7 @@ class RecentAlbumUpnpProcessorTest extends AbstractNeedsScan {
     private static final Logger LOG = LoggerFactory.getLogger(RecentAlbumUpnpProcessorTest.class);
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Albums"), "Albums", true, now()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Albums"), "Albums", true, now(), 1));
 
     @Autowired
     private RecentAlbumUpnpProcessor processor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/SongByGenreUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/SongByGenreUpnpProcessorTest.java
@@ -43,7 +43,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class SongByGenreUpnpProcessorTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now()));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now(), 1));
 
     @Autowired
     private SongByGenreUpnpProcessor songByGenreUpnpProcessor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/UpnpProcessorUtilTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/UpnpProcessorUtilTest.java
@@ -98,7 +98,7 @@ class UpnpProcessorUtilTest {
         assertFalse(util.isGenreCountAvailable());
 
         Mockito.when(settingsService.isDlnaGenreCountVisible()).thenReturn(true);
-        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(0, "", null, true, null));
+        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder("", null, true, null));
         Mockito.when(musicFolderService.getAllMusicFolders()).thenReturn(musicFolders);
         Mockito.when(musicFolderService.getMusicFoldersForUser(User.USERNAME_GUEST)).thenReturn(musicFolders);
         assertTrue(util.isGenreCountAvailable());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/WMPProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/WMPProcessorTest.java
@@ -148,7 +148,7 @@ class WMPProcessorTest {
             m.setPathString("path2");
             m.setTitle("dummy title");
             List<MediaFile> songs = Arrays.asList(m);
-            MusicFolder mf = new MusicFolder(0, "path3", "dummy", true, null);
+            MusicFolder mf = new MusicFolder(0, "path3", "dummy", true, null, 0);
             List<MusicFolder> folders = Arrays.asList(mf);
             Mockito.when(util.getGuestMusicFolders()).thenReturn(folders);
             Mockito.when(mediaFileService.getSongs(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyList()))
@@ -193,7 +193,7 @@ class WMPProcessorTest {
             m.setPathString("path5");
             m.setTitle("dummy title");
             List<MediaFile> songs = Arrays.asList(m);
-            MusicFolder mf = new MusicFolder(0, "path6", "dummy", true, null);
+            MusicFolder mf = new MusicFolder(0, "path6", "dummy", true, null, 0);
             List<MusicFolder> folders = Arrays.asList(mf);
             Mockito.when(util.getGuestMusicFolders()).thenReturn(folders);
             Mockito.when(mediaFileService.getVideos(Mockito.anyLong(), Mockito.anyLong(), Mockito.anyList()))


### PR DESCRIPTION
Several database related changes for v112.0.0 will be made together.

 - [x]  Change database scheme for v112.0.0
   - Remove unnecessary tables
     - Related : #1958
   - Add order column for music folder
     - Related : #2102
 - [x] Increment data version (in Java-MediaFileDao)

Since the schema version has increased, MediaFileDao version incremented by one. Scanning will force reparsing, but scanning with IgnoreTimeStamp enabled is preferable.


