### PR TITLE
Fix bug that the ID3 search index may not be updated

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AlbumDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AlbumDao.java
@@ -416,8 +416,8 @@ public class AlbumDao extends AbstractDao {
         update("delete from album where last_scanned <> ? or not present", scanDate);
     }
 
-    public void setNonPresentAll() {
-        update("update album set present = ?", false);
+    public void deleteAll() {
+        update("delete from album");
     }
 
     public void starAlbum(int albumId, String username) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/ArtistDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/ArtistDao.java
@@ -208,8 +208,8 @@ public class ArtistDao extends AbstractDao {
         update("delete from artist where last_scanned <> ? or not present", scanDate);
     }
 
-    public void setNonPresentAll() {
-        update("update artist set present = ?", false);
+    public void deleteAll() {
+        update("delete from artist");
     }
 
     public void starArtist(int artistId, String username) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
@@ -179,8 +179,8 @@ public class ScannerProcedureService {
 
         if (settingsService.isIgnoreFileTimestamps()) {
             mediaFileDao.resetLastScanned();
-            artistDao.setNonPresentAll();
-            albumDao.setNonPresentAll();
+            artistDao.deleteAll();
+            albumDao.deleteAll();
             indexManager.deleteAll();
         }
 


### PR DESCRIPTION
## Problem description

There are cases where the ID3 search index is not updated. The database is successfully updated, but the Lucene index is not updated. Therefore, browsing is possible, but ID3 search may not be possible.

### Steps to reproduce

1. Run a normal scan
2. Run a full scan with Ignore TimeStamp enabled

## System information

 * **Jpsonic version**: v111.6.0

## Cause

Dataflow problem. If Ignore TimeStamp is enabled, the data for ID3 will be updated to enable=false at the start of the scan. In fact, all FileStructure updates are completed before the difference update of ID3, so it is not recognized as new ID3 data at the time of the iteration of difference update. There are two approaches to fix.

 - Change ID3 to physical delete instead of soft delete for initial processing when Ignore Timestamp is enabled.
 - Improve iteration at the beginning of ID3 delta update. Currently, data that matches the reusable data conditions is mass updated to enable=true. Change this to update the Lucene index when updating the data that matches the condition. (quite complicated 😓)

Both have advantages and disadvantages. Speed probably won't change much or within a negligible range. "Ignore TimeStamp" is by no means a routinely used feature. Therefore, we choose the former as it is simpler to implement.

## Additional notes

I think v112.0.0 will be released soon, so it won't be released as a hotfix.


