### PR TITLE
Change scan indicator on web page

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/NowPlayingService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/NowPlayingService.java
@@ -37,6 +37,7 @@ import com.tesshu.jpsonic.service.PlayerService;
 import com.tesshu.jpsonic.service.ScannerStateService;
 import com.tesshu.jpsonic.service.SecurityService;
 import com.tesshu.jpsonic.service.StatusService;
+import com.tesshu.jpsonic.service.scanner.ScannerProcedureService;
 import com.tesshu.jpsonic.util.StringUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
@@ -59,16 +60,19 @@ public class NowPlayingService {
     private final PlayerService playerService;
     private final StatusService statusService;
     private final ScannerStateService scannerStateService;
+    private final ScannerProcedureService scannerProcedureService;
     private final AvatarService avatarService;
     private final AjaxHelper ajaxHelper;
 
     public NowPlayingService(SecurityService securityService, PlayerService playerService, StatusService statusService,
-            ScannerStateService scannerStateService, AvatarService avatarService, AjaxHelper ajaxHelper) {
+            ScannerStateService scannerStateService, ScannerProcedureService scannerProcedureService,
+            AvatarService avatarService, AjaxHelper ajaxHelper) {
         super();
         this.securityService = securityService;
         this.playerService = playerService;
         this.statusService = statusService;
         this.scannerStateService = scannerStateService;
+        this.scannerProcedureService = scannerProcedureService;
         this.avatarService = avatarService;
         this.ajaxHelper = ajaxHelper;
     }
@@ -98,7 +102,14 @@ public class NowPlayingService {
      * Returns media folder scanning status.
      */
     public ScanInfo getScanningStatus() {
-        return new ScanInfo(scannerStateService.isScanning(), (int) scannerStateService.getScanCount());
+        ScanInfo info = new ScanInfo(scannerStateService.isScanning(), (int) scannerStateService.getScanCount());
+        scannerProcedureService.getScanPhaseInfo().ifPresent(phaseInfo -> {
+            info.setPhase(phaseInfo.getPhase());
+            info.setPhaseMax(phaseInfo.getPhaseMax());
+            info.setPhaseName(phaseInfo.getPhaseName());
+            info.setThread(phaseInfo.getThread());
+        });
+        return info;
     }
 
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops") // (NowPlayingInfo) Not reusable

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/ScanInfo.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/ajax/ScanInfo.java
@@ -29,18 +29,55 @@ package com.tesshu.jpsonic.ajax;
 public class ScanInfo {
 
     private final boolean scanning;
-    private final int count;
+    private final int scanningCount;
+    private int phase = -1;
+    private int phaseMax = -1;
+    private String phaseName;
+    private int thread = -1;
 
-    public ScanInfo(boolean scanning, int count) {
+    public ScanInfo(boolean scanning, int scanningCount) {
+        super();
         this.scanning = scanning;
-        this.count = count;
+        this.scanningCount = scanningCount;
     }
 
     public boolean isScanning() {
         return scanning;
     }
 
-    public int getCount() {
-        return count;
+    public int getScanningCount() {
+        return scanningCount;
+    }
+
+    public int getPhase() {
+        return phase;
+    }
+
+    public void setPhase(int phase) {
+        this.phase = phase;
+    }
+
+    public int getPhaseMax() {
+        return phaseMax;
+    }
+
+    public void setPhaseMax(int phaseMax) {
+        this.phaseMax = phaseMax;
+    }
+
+    public String getPhaseName() {
+        return phaseName;
+    }
+
+    public void setPhaseName(String phaseName) {
+        this.phaseName = phaseName;
+    }
+
+    public int getThread() {
+        return thread;
+    }
+
+    public void setThread(int thread) {
+        this.thread = thread;
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerStateServiceImpl.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerStateServiceImpl.java
@@ -33,6 +33,7 @@ import javax.annotation.PreDestroy;
 import com.tesshu.jpsonic.ThreadSafe;
 import com.tesshu.jpsonic.dao.StaticsDao;
 import com.tesshu.jpsonic.service.ScannerStateService;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.springframework.stereotype.Service;
 
 /**
@@ -110,6 +111,7 @@ public class ScannerStateServiceImpl implements ScannerStateService {
      * Use only within the thread that acquired the lock.
      */
     @ThreadSafe(enableChecks = false)
+    @NonNull
     Instant getScanDate() {
         return scanDate;
     }

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/top.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/top.jsp
@@ -112,20 +112,29 @@ window.callPassiveScanningStatus = function() {
 }
 
 function getScanningStatusCallback(scanInfo) {
+    
     let finished = $("#isScanning").prop('checked') && !scanInfo.scanning;
     $("#isScanning").prop('checked', scanInfo.scanning);
-    $("#scanningStatus .message").text(scanInfo.count);
+    $("#scanningStatus .counter").text(' (' + scanInfo.scanningCount + ')');
+    $("#scanningStatus .counter").css("display", scanInfo.phaseName == 'PARSE_FILE_STRUCTURE' ? 'contents' : 'none');
+    if(scanInfo.phase != -1) {
+        $("#scanningStatus .phase").text("[" + scanInfo.phase + "/" + scanInfo.phaseMax + "]");
+        $("#scanningStatus .phaseName").text(scanInfo.phaseName);
+    }
+    $("#scanningStatus .thread").text(scanInfo.thread > 0 ? 'x' + scanInfo.thread : '');
+    const delay = ${model.user.settingsRole ? 4000 : 10000};
     if (scanInfo.scanning) {
-        setTimeout("callScanningStatus()", ${model.user.settingsRole ? "3000" : "10000"});
+       setTimeout("callScanningStatus()", delay);
     } else {
         if (finished) {
             retryCallScanningStatus = false;
+            $("#scanningStatus .phase").text('');
             if (document.getElementById("main").contentDocument.location.pathname.split("/").pop().startsWith("musicFolderSettings")) {
                 document.getElementById("main").contentDocument.location = "musicFolderSettings.view";
             }
             $('#main').toastmessage("showNoticeToast", "<fmt:message key='main.scanend'/>");
         } else if(retryCallScanningStatus) {
-            setTimeout("callScanningStatus()", 1000);
+            setTimeout("callScanningStatus()", 2000);
         }
     }
 }
@@ -333,8 +342,16 @@ window.onOpenDialogVideoPlayer = function(videoUrl) {
         <%-- scanning --%>
         <input type="checkbox" id="isScanning" class="jps-input-scanning"/>
         <div id="scanningStatus">
-            <div class="loader" title="<fmt:message key='main.scanning'/>"></div>
-            <div class="message" title="<fmt:message key='main.scannedfiles'/>"></div>
+            <div class="loader" title="<fmt:message key='main.scanning'/>">
+                <div class="thread"></div>
+            </div>
+            <c:if test="${model.user.adminRole}">
+                <a href="scanlog.view" target="main" title="<fmt:message key='settingsheader.scanlog'/>">
+            </c:if>
+                <span class="phase"></span><span class="phaseName"></span><span class="counter" title="<fmt:message key='main.scannedfiles'/>"></span>
+            <c:if test="${model.user.adminRole}">
+                </a>
+            </c:if>
         </div>
         <%-- search --%>
         <form method="post" action="search.view" target="main" name="searchForm">

--- a/jpsonic-main/src/main/webapp/scss/jpsonic/pages/top/_scanning.scss
+++ b/jpsonic-main/src/main/webapp/scss/jpsonic/pages/top/_scanning.scss
@@ -6,7 +6,7 @@ input[type="checkbox"]#isScanning {
     display: flex;
     align-items: center;
     flex-flow: row nowrap;
-    justify-content: center;
+    justify-content: start;
     width: 360px;
     @media screen and (max-width: #{$jp-supplement-width-threshold}) {
       width: 120px;
@@ -15,11 +15,28 @@ input[type="checkbox"]#isScanning {
 }
 #scanningStatus {
   display: none;
+
+  a {
+    text-decoration: none;
+    &:link,
+    &:active,
+    &:visited,
+    &:link *,
+    &:active *,
+    &:visited * {
+      color: $jp-color-base4;
+    }
+    &:hover,
+    &:hover * {
+      color: $jp-color-complementary3;
+    }
+  }
+
   > .loader {
     position: relative;
-    width: 8px;
-    height: 8px;
-    margin: 0 20px 0 0;
+    width: 6px;
+    height: 6px;
+    margin: 0 20px 0 20px;
     border-radius: 50%;
     color: $jp-color-now-playing;
     font-size: 5px;
@@ -82,17 +99,27 @@ input[type="checkbox"]#isScanning {
         box-shadow: 0 -3em 0 0, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 0, -3em 0 0 0, -2em -2em 0 .2em;
       }
     }
+    .thread {
+      position: relative;
+      margin: -10px 0 0 -6px;
+      font-size: 16px;
+      font-weight: bold;
+    }
   }
-  > .message {
-    width: 3.44rem;
-    padding: 2px;
-    background-color: $jp-color-base3;
-    color: $jp-color-white;
-    font-size: .86rem;
-    text-align: right;
-    user-select: none;
 
-    @include border;
-    @include borderRadius;
+  .phase,
+  .phaseName,
+  .counter {
+    margin: 2px;
+    color: $jp-color-dark-gray;
+    font-size: .86rem;
+    font-weight: bold;
+  }
+
+  .phaseName,
+  .counter {
+    @media screen and (max-width: #{$jp-supplement-width-threshold}) {
+      display: none;
+    }
   }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/NowPlayingServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/NowPlayingServiceTest.java
@@ -30,10 +30,11 @@ import com.tesshu.jpsonic.domain.PlayStatus;
 import com.tesshu.jpsonic.domain.Player;
 import com.tesshu.jpsonic.service.AvatarService;
 import com.tesshu.jpsonic.service.PlayerService;
+import com.tesshu.jpsonic.service.ScannerStateService;
 import com.tesshu.jpsonic.service.SecurityService;
 import com.tesshu.jpsonic.service.ServiceMockUtils;
 import com.tesshu.jpsonic.service.StatusService;
-import com.tesshu.jpsonic.service.scanner.ScannerStateServiceImpl;
+import com.tesshu.jpsonic.service.scanner.ScannerProcedureService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -54,7 +55,8 @@ class NowPlayingServiceTest {
         Mockito.when(statusService.getPlayStatuses()).thenReturn(Arrays.asList(playStatus));
 
         nowPlayingService = new NowPlayingService(mock(SecurityService.class), mock(PlayerService.class), statusService,
-                mock(ScannerStateServiceImpl.class), mock(AvatarService.class), AjaxMockUtils.mock(AjaxHelper.class));
+                mock(ScannerStateService.class), mock(ScannerProcedureService.class), mock(AvatarService.class),
+                AjaxMockUtils.mock(AjaxHelper.class));
     }
 
     @Test

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImplTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImplTest.java
@@ -213,7 +213,7 @@ class MediaScannerServiceImplTest {
             scannerProcedureService = new ScannerProcedureService(settingsService, mock(MusicFolderServiceImpl.class),
                     indexManager, mediaFileService, writableMediaFileService, mock(PlaylistService.class), mediaFileDao,
                     artistDao, albumDao, staticsDao, utils, scannerStateService, mock(Ehcache.class),
-                    mock(MediaFileCache.class), mock(JapaneseReadingUtils.class));
+                    mock(MediaFileCache.class), mock(JapaneseReadingUtils.class), mock(ThreadPoolTaskExecutor.class));
             mediaScannerService = new MediaScannerServiceImpl(settingsService, scannerStateService,
                     scannerProcedureService, mock(ExpungeService.class), staticsDao, executor);
         }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureServiceTest.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @SuppressWarnings("PMD.TooManyStaticImports")
 class ScannerProcedureServiceTest {
@@ -68,7 +69,7 @@ class ScannerProcedureServiceTest {
                 mock(IndexManager.class), mediaFileService, writableMediaFileService, mock(PlaylistService.class),
                 mediaFileDao, mock(ArtistDao.class), albumDao, staticsDao, mock(SortProcedureService.class),
                 new ScannerStateServiceImpl(staticsDao), mock(Ehcache.class), mock(MediaFileCache.class),
-                mock(JapaneseReadingUtils.class));
+                mock(JapaneseReadingUtils.class), mock(ThreadPoolTaskExecutor.class));
     }
 
     @Test


### PR DESCRIPTION
Prerequisites: #2136

#### Overview

With the change in the scan flow of v111.6.0, the contents of the web page indicator will be changed.

<details>
<summary>Goal</summary>

The following points will be added.

 - View scan phases
 - View the number of active threads for scan thread pooling
 - Add link to scan log page

</details>
<details>
<summary>Non-Goal</summary>

The API does not provide a so-called scan progress indicator.

 - The Subsonic API defines a method called getScanStatus. This specification does not change.
   - [getScanStatus](http://www.subsonic.org/pages/api.jsp#getScanStatus)
   - ScanStatus of Subsonic API  defines a numeric property called ScanCount. This is also not changed.
     - This does not originally indicate the processing progress. It has no meaning beyond the scan count. It is inherently impossible to quantify the progress of a scan, and no such definition exists in the first place.

Subsonic and Airsonic were single-threaded, editing records each time a file or directory was encountered. (Therefore, it was possible to grasp the degree of progress to some extent with the scan count) However, **its design is rather limited, and it cannot be extended to achieve differential updates or safe parallelization**.

Jpsonic only performs temporary directory registration and song analysis, at the initial stage. What is done here is the so-called scan counting. After that, video analysis, tag cleansing, album analysis, ID3 difference update, genre master, etc. So, especially for the first scan, overall progress and scan counts will have a much different meaning than previous servers. (Because most of the subsequent processes are lightweight after the second time, Intuitively, Scancount will have a similar ... meaning as before.)

It must be ScanCount, but it can be said that the meaning changes because the processing flow is significantly different.

</details>

#### Fixes

In short, previously only Scan count was used to indicate progress.

![image](https://user-images.githubusercontent.com/27724847/204320710-c4af78c5-b688-47c7-9dd4-dd08658cbe7f.png)

This doesn't fit Jpsonic's scan specification, so it will be changed as follows.

![image](https://user-images.githubusercontent.com/27724847/232325087-01c80f7e-fe91-4dba-aa81-7080d1890525.png)

 - Shows the number of active scan threads. Always "x1" in v112.0.0. Future versions will introduce parallelization options. When enabled, different values are displayed.
 - [ Current phase / Number of all phases ] Phase name (Scan count ... if necessary)
   - For Admin users, this is a link. You can move to the Scan Log page.
   - #2136
