### PR TITLE
Add max_thread to scan_event table

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/ScanEvent.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/ScanEvent.java
@@ -33,10 +33,11 @@ public class ScanEvent {
     private long maxMemory;
     private long totalMemory;
     private long freeMemory;
+    private int maxThread;
     private String comment;
 
     public ScanEvent(@NonNull Instant startDate, @NonNull Instant executed, @NonNull ScanEventType type,
-            @Nullable Long maxMemory, @Nullable Long totalMemory, @Nullable Long freeMemory, @Nullable String comment) {
+            @Nullable Long maxMemory, @Nullable Long totalMemory, @Nullable Long freeMemory, @Nullable Integer maxThread, @Nullable String comment) {
         super();
         this.startDate = startDate;
         this.executed = executed;
@@ -44,6 +45,7 @@ public class ScanEvent {
         setMaxMemory(maxMemory);
         setTotalMemory(totalMemory);
         setFreeMemory(freeMemory);
+        setMaxThread(maxThread);
         this.comment = comment;
     }
 
@@ -93,6 +95,14 @@ public class ScanEvent {
 
     public final void setFreeMemory(Long freeMemory) {
         this.freeMemory = freeMemory == null ? -1 : freeMemory;
+    }
+
+    public int getMaxThread() {
+        return maxThread;
+    }
+
+    public final void setMaxThread(Integer maxThread) {
+        this.maxThread = maxThread == null ? -1 : maxThread;
     }
 
     public @Nullable String getComment() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
@@ -186,7 +186,8 @@ public class ScannerProcedureService {
         Long maxMemory = isMeasureMemory ? Runtime.getRuntime().maxMemory() : null;
         Long totalMemory = isMeasureMemory ? Runtime.getRuntime().totalMemory() : null;
         Long freeMemory = isMeasureMemory ? Runtime.getRuntime().freeMemory() : null;
-        ScanEvent scanEvent = new ScanEvent(scanDate, now(), logType, maxMemory, totalMemory, freeMemory, comment);
+        ScanEvent scanEvent = new ScanEvent(scanDate, now(), logType, maxMemory, totalMemory, freeMemory, null,
+                comment);
         staticsDao.createScanEvent(scanEvent);
     }
 

--- a/jpsonic-main/src/main/resources/liquibase/jp112.0.0/changelog.xml
+++ b/jpsonic-main/src/main/resources/liquibase/jp112.0.0/changelog.xml
@@ -41,4 +41,16 @@
             </column>
         </addColumn>
     </changeSet>
+    <changeSet id="add-max-thread-to-scan-event" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="scan_event" columnName="max_thread" />
+            </not>
+        </preConditions>
+        <addColumn tableName="scan_event">
+            <column name="max_thread" type="int" defaultValue="0">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImplTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImplTest.java
@@ -315,7 +315,7 @@ class MediaScannerServiceImplTest {
             void testWithRecords() {
                 assertFalse(mediaScannerService.isScanning());
                 Mockito.when(staticsDao.isNeverScanned()).thenReturn(false);
-                ScanEvent success = new ScanEvent(null, null, ScanEventType.SUCCESS, 0L, 0L, 0L, null);
+                ScanEvent success = new ScanEvent(null, null, ScanEventType.SUCCESS, 0L, 0L, 0L, null, null);
                 Mockito.when(staticsDao.getLastScanAllStatuses()).thenReturn(Arrays.asList(success));
                 assertFalse(mediaScannerService.getLastScanEventType().isEmpty());
                 assertEquals(ScanEventType.SUCCESS, mediaScannerService.getLastScanEventType().get());
@@ -350,7 +350,7 @@ class MediaScannerServiceImplTest {
             void c03() {
                 Mockito.when(settingsService.isIgnoreFileTimestamps()).thenReturn(false);
                 Mockito.when(staticsDao.getLastScanAllStatuses()).thenReturn(
-                        Arrays.asList(new ScanEvent(null, null, ScanEventType.CANCELED, null, null, null, null)));
+                        Arrays.asList(new ScanEvent(null, null, ScanEventType.CANCELED, null, null, null, null, null)));
                 assertFalse(mediaScannerService.isOptionalProcessSkippable());
             }
 
@@ -362,7 +362,7 @@ class MediaScannerServiceImplTest {
             void c04() {
                 Mockito.when(settingsService.isIgnoreFileTimestamps()).thenReturn(false);
                 Mockito.when(staticsDao.getLastScanAllStatuses()).thenReturn(
-                        Arrays.asList(new ScanEvent(null, null, ScanEventType.SUCCESS, null, null, null, null)));
+                        Arrays.asList(new ScanEvent(null, null, ScanEventType.SUCCESS, null, null, null, null, null)));
                 Mockito.when(staticsDao.isfolderChangedSinceLastScan()).thenReturn(true);
                 assertFalse(mediaScannerService.isOptionalProcessSkippable());
             }
@@ -375,7 +375,7 @@ class MediaScannerServiceImplTest {
             void c05() {
                 Mockito.when(settingsService.isIgnoreFileTimestamps()).thenReturn(false);
                 Mockito.when(staticsDao.getLastScanAllStatuses()).thenReturn(
-                        Arrays.asList(new ScanEvent(null, null, ScanEventType.SUCCESS, null, null, null, null)));
+                        Arrays.asList(new ScanEvent(null, null, ScanEventType.SUCCESS, null, null, null, null, null)));
                 Mockito.when(staticsDao.isfolderChangedSinceLastScan()).thenReturn(false);
                 assertTrue(mediaScannerService.isOptionalProcessSkippable());
             }


### PR DESCRIPTION
A column will be added to record information about the thread to the scan log.

This column will be used in the next version. (I don't want to make schema changes for a while if possible)