### PR TITLE
Split production.yml, for host and for bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,15 +366,15 @@ jobs:
       - name: Boot test for ea (Within 30 sec)
         run: |
           mkdir -p /tmp/${{ matrix.tag }}
-          cp install/docker/production.yml /tmp/${{ matrix.tag }}
+          cp install/docker/production.windows.yml /tmp/${{ matrix.tag }}
           cd /tmp/${{ matrix.tag }}
           mkdir -p /tmp/${{ matrix.tag }}/jpsonic/data /tmp/${{ matrix.tag }}/jpsonic/music /tmp/${{ matrix.tag }}/jpsonic/podcasts /tmp/${{ matrix.tag }}/jpsonic/playlists
-          sed -i -e "s/image: 'jpsonic\/jpsonic:latest'/image: 'jpsonic\/jpsonic:${{ matrix.tag }}'/g" production.yml
-          sed -i -e "s/container_name: 'jpsonic'/container_name: 'jpsonic_${{ matrix.tag }}'/g" production.yml
-          sed -i -e "s/\/c\/tmp\/jpsonic/\/tmp\/${{ matrix.tag }}\/jpsonic/g" production.yml
-          cat production.yml
+          sed -i -e "s/image: 'jpsonic\/jpsonic:latest'/image: 'jpsonic\/jpsonic:${{ matrix.tag }}'/g" production.windows.yml
+          sed -i -e "s/container_name: 'jpsonic'/container_name: 'jpsonic_${{ matrix.tag }}'/g" production.windows.yml
+          sed -i -e "s/\/c\/tmp\/jpsonic/\/tmp\/${{ matrix.tag }}\/jpsonic/g" production.windows.yml
+          cat production.windows.yml
           set -x
-          docker-compose -f production.yml up -d
+          docker-compose -f production.windows.yml up -d
           for i in {1..30};do sleep 1;docker exec jpsonic_${{ matrix.tag }} bash -c "curl http://localhost:4040/rest/ping"&&break;done
   ##########################################################################
   run-docker4ea:
@@ -396,13 +396,13 @@ jobs:
       - name: Boot test for ea (Within 30 sec)
         run: |
           mkdir -p /tmp/${{ matrix.tag }}
-          cp install/docker/production.yml /tmp/${{ matrix.tag }}
+          cp install/docker/production.windows.yml /tmp/${{ matrix.tag }}
           cd /tmp/${{ matrix.tag }}
           mkdir -p /tmp/${{ matrix.tag }}/jpsonic/data /tmp/${{ matrix.tag }}/jpsonic/music /tmp/${{ matrix.tag }}/jpsonic/podcasts /tmp/${{ matrix.tag }}/jpsonic/playlists
-          sed -i -e "s/image: 'jpsonic\/jpsonic:latest'/image: 'jpsonic\/jpsonic:${{ matrix.tag }}'/g" production.yml
-          sed -i -e "s/container_name: 'jpsonic'/container_name: 'jpsonic_${{ matrix.tag }}'/g" production.yml
-          sed -i -e "s/\/c\/tmp\/jpsonic/\/tmp\/${{ matrix.tag }}\/jpsonic/g" production.yml
-          cat production.yml
+          sed -i -e "s/image: 'jpsonic\/jpsonic:latest'/image: 'jpsonic\/jpsonic:${{ matrix.tag }}'/g" production.windows.yml
+          sed -i -e "s/container_name: 'jpsonic'/container_name: 'jpsonic_${{ matrix.tag }}'/g" production.windows.yml
+          sed -i -e "s/\/c\/tmp\/jpsonic/\/tmp\/${{ matrix.tag }}\/jpsonic/g" production.windows.yml
+          cat production.windows.yml
           set -x
-          docker-compose -f production.yml up -d
+          docker-compose -f production.windows.yml up -d
           for i in {1..30};do sleep 1;docker exec jpsonic_${{ matrix.tag }} bash -c "curl http://localhost:4040/rest/ping"&&break;done

--- a/install/docker/production.synology.yml
+++ b/install/docker/production.synology.yml
@@ -1,0 +1,86 @@
+# 
+# This is a JPSONIC boot configuration sample in Synology DS220+ or in Linux with UPnP.
+# You can easily start Jpsonic by changing the volume, port and so on.
+#
+# usege: 
+#   docker-compose -f production.synology.yml up -d
+#
+
+version: '3.9'
+services:
+  app:
+    image: 'jpsonic/jpsonic:latest'
+    container_name: 'jpsonic'
+    network_mode: 'host'
+    hostname: 'SynologyNAS'
+    pid: host
+
+    volumes:
+     # <host>:<internal>
+     # Please rewrite "the path of host" appropriately.
+     - '/volume1/docker/jpsonic-data:/jpsonic/data'
+     - '/volume1/Music:/jpsonic/music'
+     - '/volume1/Podcasts:/jpsonic/podcasts'
+     - '/volume1/Playlists:/jpsonic/playlists'
+
+    environment:
+
+     # Set the jpsonic and upnp ports.
+     # Containers share the host networking name space,
+     # so be careful not to overlap with existing ports.
+     JPSONIC_PORT: '4040'
+     UPNP_PORT: '4041'
+
+     # Set the appropriate UID/GID.
+     USER_ID: '0'
+     GROUP_ID: '0'
+
+     # Please specify the appropriate timezone
+     TIME_ZONE: 'Asia/Tokyo'
+
+     # Jpsonic context path.
+     CONTEXT_PATH: '/'
+
+     # Whether to log the logo at startup. [OFF|CONSOLE|LOG]
+     BANNER_MODE: 'OFF'
+
+     # Granularity of output logs. [ERROR|WARN|INFO|DEBUG|TRACE]
+     LOG_LEVEL: 'WARN'
+
+     # Whether to scan at startup. False is recommended for Docker.
+     SCAN_ON_BOOT: 'false'
+
+     # If false, use the logical font of JRE (JDK) for Cover Art.
+     # If true, preferentially use embedded fonts.
+     EMBEDDED_FONT: 'false'
+
+     # You can override the MIME of DSD according to your device.
+     MIME_DSF: 'audio/x-dsd'
+     MIME_DFF: 'audio/x-dsd'
+
+     # Specify the appropriate Java options.
+     # Currently, Jpsonic will not require extremely large memory.
+     # If you are using 32 bit OS please specify -Xmx256m
+     JAVA_OPTS: '-Xmx512m'
+
+     #　Option example when using JMX. The "ea" tag image is required to use JMX.
+     #　For VisualVM, you need to specify the port in File-Add JMX Connection.
+     #　e.g. localhost:3333
+     #　
+     #JAVA_OPTS: >
+     #  -Xmx512m
+     #  -Dcom.sun.management.jmxremote
+     #  -Dcom.sun.management.jmxremote.port=3333
+     #  -Dcom.sun.management.jmxremote.rmi.port=3333
+     #  -Dcom.sun.management.jmxremote.local.only=false
+     #  -Dcom.sun.management.jmxremote.ssl=false
+     #  -Dcom.sun.management.jmxremote.authenticate=false
+     #  -Djava.rmi.server.hostname=localhost
+
+    # Usually no need to change.
+    # Unlike other Sonic servers, Jpsonic has a graceful shutdown implemented.
+    # After receiving the 'kill 15' of Docker message, it will phase out, and finnaly shut down the database.
+    # In case of emergency shutdown during critical processing,
+    # there may be a wait time of up to 30 seconds to protect data.
+     TINI_SUBREAPER: 'true'
+    stop_grace_period: '30s'

--- a/install/docker/production.windows.yml
+++ b/install/docker/production.windows.yml
@@ -1,5 +1,5 @@
 # 
-# This is a sample of Jpsonic boot configuration (on Win).
+# This is a JPSONIC boot configuration sample in Windows or in Mac or in Linux without UPnP.
 # You can easily start Jpsonic by changing the volume, port and so on.
 #
 # usege: 
@@ -17,6 +17,7 @@ services:
     # or Docker EE for Windows Server.
     # https://docs.docker.com/network/host/
     network_mode: 'bridge'
+    hostname: 'jpsonic'
 
     # <host>:<internal>
     # Please set "the port of host" properly.
@@ -24,11 +25,6 @@ services:
 
      # Port for Jpsonic. 
      - '8080:4040'
-
-     # Port for UPnP. Windows docker does not transfer UDP.
-     # If you want to use UPnP on Windows host, Docker is not recommended.
-     - '4041:4041'
-     - '1900:1900/udp'
 
      # Port for JMX. The "ea" tag image is required to use JMX.
      # - 3333:3333

--- a/install/docker/production.windows.yml
+++ b/install/docker/production.windows.yml
@@ -3,7 +3,7 @@
 # You can easily start Jpsonic by changing the volume, port and so on.
 #
 # usege: 
-#   docker-compose -f production.yml up -d
+#   docker-compose -f production.windows.yml up -d
 #
 
 version: '3.9'


### PR DESCRIPTION
### Overview

production.yml split into one with host-based network configuration and one with bridge-based network configuration. The following two :

 - production.windows.yml
   - A production configuration file for creating containers with a bridge configuration, found in many Docker products.
   - A renamed version of producrion.yml that existed from the beginning.
   - HOST configuration is only available on Linux. For Windows or Mac you have to take advantage of this. The big disadvantage is that you can't use the UPnP protocol, which requires broadcasting. In other words, when using Docker, there are functional restrictions on platforms other than Linux. On Windows and Mac, we recommend deploying standalone or in a container such as Tomcat. However, you can use this configuration even if you don't use UPnP on Linux.
 - production.synology.yml **(New!)**
   - A production configuration file for creating a container with HOST's network configuration.
   - A configuration file that can be applied to many Linuxes and has been confirmed to work on Synology DS220+.

### Goal

Provides a ready-to-use production.yml on Linux. In particular, emphasis is placed on checking the operation on customized Linux, which is adopted by Synology. If you want to run UPnP on Linux, you should use production.synology.yml. Future Jpsonic verification, mainly performance, will be measured and considered based on Synology DS220+.

<details>
<summary>To avoid confusion</summary>
Until now, only the bridge configuration file was published for simple confirmation operation on Windows. Because, those who are familiar with Linux&Docker can rewrite it and use it immediately. However, the behavior of port mapping for host and bridge will vary depending on the docker-compose version( In older versions, port mapping to the host does not cause an error. In newer versions it is an error. Since the amount of rewriting increases after all, the configuration file was divided.). The newly created production.synology.yml will not be port mapped on docker-compose. It will be processed as a parameter to docker when starting the container.
</details>

### Non-Goal

Currently only production.yml is provided. Topics of compose.yml (e.g. running Postgres in parallel) are not covered in this Issues.

### How to use

As noted in the header comments in each file.

```docker-compose -f production.synology.yml up -d```

### For Synology DS220+

Linux commands are slightly different, but the usage of Docker will not change much. Docker GUI also exists, but it may be rather difficult for beginners to control with GUI alone. After all, it is better to have basic knowledge of Docker. I'm assuming that the DS220+ I just purchased will require the following flow:

#### Install Docker

Synology standard Docker environment is provided at `Package center`. Just click.

#### Create a new account to run Jpsonic

It is well known that running Tomcat requires a Tomcat user for secure operation. Jpsonic is exactly the same.

#### Create a shared directory

`File station` can create shared directory. Create jpsonic-data, Music, Podcasts, Playlists, etc. In the GUI, you should be able to see the path from the properties.

     - /volume1/docker/jpsonic-data
     - /volume1/Music
     - /volume1/Podcasts
     - /volume1/Playlists

Give these folders read/write permissions for the previously created Jpsonic account. These operations are also possible from `File station`. You will also be able to set more privileged operations. Perhaps you want to access or deny access to those NAS shared folders from other PCs. I think it's good to use `File station`.

#### Make Docker commands available

Now, this is where the Synology DS220+ is a little inconvenient. docker-compose is not easily usable on initial install. It's a good idea to create a docker group to manage users who use Docker commands. (Otherwise you will be making all changes as root)

Add group.

```
sudo synogroup --add docker

$ Password:
Group Name: [docker]
Group Type: [AUTH_LOCAL]
Group ID:   [65537]
Group Members:
```

Add YourUserName to Group.

```
sudo synogroup --memberadd docker YourUserName

$ Group Name: [docker]
Group Type: [AUTH_LOCAL]
Group ID:   [65537]
Group Members:
0:[YourUserName]
```

Change docker.sock permissions.

```
sudo chown root:docker /var/run/docker.sock
ll /var/run/docker.sock

$ srw-rw---- 1 root docker 0 Apr 30 12:13 /var/run/docker.sock
```

Reconnect, and restart Docker.

```
sudo synopkgctl stop Docker
sudo synopkgctl start Docker
```

#### Edit production.synology.yml

Find the ID of the account to run Jpsonic.

```
$ id jpsonic
uid=1027(jpsonic) gid=100(users) groups=100(users)
```

(uid=1027, gid=100)

Get production.synology.yml.

```
wget ?????/production.synology.yml
vi production.synology.yml
```

Change some settings. **At least the following are required!**

 - USER_ID
 - GROUP_ID
 - TIME_ZONE
 - Check if the path of the directory volume that you have already created is correct.

#### Run docker-compose


```docker-compose -f production.synology.yml up -d```



