### PR TITLE
Fix that order to not be overwritten when updating ID3Artist images

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/ArtistDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/ArtistDao.java
@@ -79,10 +79,9 @@ public class ArtistDao extends AbstractDao {
 
     public @Nullable Artist updateArtist(Artist artist) {
         String sql = "update artist set cover_art_path=?, album_count=?, last_scanned=?, present=?,"
-                + "folder_id=?, sort=?, reading=?, artist_order=? where name=?";
+                + "folder_id=?, sort=?, reading=? where name=?";
         int c = update(sql, artist.getCoverArtPath(), artist.getAlbumCount(), artist.getLastScanned(),
-                artist.isPresent(), artist.getFolderId(), artist.getSort(), artist.getReading(), artist.getOrder(),
-                artist.getName());
+                artist.isPresent(), artist.getFolderId(), artist.getSort(), artist.getReading(), artist.getName());
         if (c > 0) {
             return artist;
         }


### PR DESCRIPTION
## Problem description

Adding folder.jpg to artist overwrites the id3 artist order. It's avoidable with full scan.

### Steps to reproduce

1. Scan as normal
2. Add folder.jpg to any artist directory
3. See list of ArtistID3 (with Subsonic API or UPnP). Updated artists will be at the top of the list!

## System information

 * **Jpsonic version**: v112.0.0

## Additional notes

Unnecessary fields (order) are excessively null updated when ID3 Artist record is updated. As a result, the initial value -1 is inserted, so it is displayed at the beginning. 
