### PR TITLE
Fixed bug that the image of ID3 was not changed even if the album image was added

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -537,7 +537,7 @@ public class MediaFileDao extends AbstractDao {
                 + "join music_folder on music_folder.path = mf.folder "
                 + "join media_file mf_al on mf_al.path = mf.parent_path) registered "
                 + "join (select album, album_artist, min(file_order) as file_order from "
-                + "(select mf.album, mf.album_artist, mf_al.media_file_order * :childMax + mf.media_file_order + music_folder.folder_order * :childMax as file_order from media_file mf "
+                + "(select mf.album, mf.album_artist, mf_al.media_file_order * :childMax + mf.media_file_order + music_folder.folder_order * :childMax * 10 as file_order from media_file mf "
                 + "join album al on al.name = mf.album and al.artist = mf.album_artist "
                 + "join music_folder on music_folder.path = mf.folder "
                 + "join media_file mf_al on mf_al.path = mf.parent_path "


### PR DESCRIPTION
## Problem description

Adding folder.jpg to artist overwrites the id3 artist order. It's avoidable with full scan.

### Steps to reproduce

1. Scan as normal
2. Add coverart.jpg to any album directory
3. See list of AlbumD3 (with Subsonic API or UPnP). File Structure is updated correctly but ID3 is not.

## System information

 * **Jpsonic version**: v112.0.0

## Additional notes

A small query mistake was discovered :)
