### PR TITLE
Provide automatic updates for Docker images

### DIFF
--- a/install/docker/docker-compose.watchtower.yml
+++ b/install/docker/docker-compose.watchtower.yml
@@ -1,0 +1,27 @@
+# 
+# This is a JPSONIC image auto-update sample in Synology DS220+ or in Linux with UPnP.
+# After starting Jpsonic with production.synology.yml,
+# you can easily update Jpsonic automatically by additionally setting up watchtower.
+#
+# usege: 
+#   docker-compose -f docker-compose.watchtower.yml up -d
+#
+
+version: "3"
+services:
+  watchtower:
+    image: containrrr/watchtower
+    container_name: 'watchtower'
+    environment:
+      - WATCHTOWER_INCLUDE_STOPPED=true
+      - WATCHTOWER_REVIVE_STOPPED=false
+      - WATCHTOWER_LABEL_ENABLE=1
+
+      # Please specify the appropriate timezone
+      - TZ=Asia/Tokyo
+
+      # At one o'clock every day. Write the appropriate value in cron style.
+      - WATCHTOWER_SCHEDULE=0 0 1 * * *
+
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/install/docker/production.synology.yml
+++ b/install/docker/production.synology.yml
@@ -15,6 +15,11 @@ services:
     hostname: 'SynologyNAS'
     pid: host
 
+    # This image is automatically updated by watchtower.
+    # See docker-compose.watchtower.yml
+    labels:
+     - "com.centurylinklabs.watchtower.enable=true"
+
     volumes:
      # <host>:<internal>
      # Please rewrite "the path of host" appropriately.


### PR DESCRIPTION
Prerequisites: #2175

Targeting a Synology DS220+ or general Linux, docker-compose.yml from watchtower will be provided for automatic Docker updates. If Docker is started as per #2175, you can schedule automatic updates with one command.
