### PR TITLE
Improve path validation when import playlists

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PlaylistService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PlaylistService.java
@@ -290,6 +290,11 @@ public class PlaylistService {
         List<Playlist> allPlaylists = playlistDao.getAllPlaylists();
         try (DirectoryStream<Path> ds = Files.newDirectoryStream(playlistFolder)) {
             for (Path child : ds) {
+
+                if (securityService.isExcluded(child)) {
+                    continue;
+                }
+
                 try {
                     importPlaylistIfUpdated(child, allPlaylists);
                 } catch (ExecutionException e) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
@@ -540,6 +540,6 @@ public class SecurityService implements UserDetailsService {
 
         // Exclude all hidden files starting with a single "." or "@eaDir" (thumbnail dir created on Synology devices).
         return !name.isEmpty() && name.charAt(0) == '.' && !name.startsWith("..") || name.startsWith("@eaDir")
-                || "Thumbs.db".equals(name);
+                || name.startsWith("@tmp") || "Thumbs.db".equals(name);
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
@@ -517,4 +517,29 @@ public class SecurityService implements UserDetailsService {
         }
         return true;
     }
+
+    public boolean isExcluded(Path path) {
+        if (settingsService.isIgnoreSymLinks() && Files.isSymbolicLink(path)) {
+            if (LOG.isInfoEnabled()) {
+                LOG.info("excluding symbolic link " + path);
+            }
+            return true;
+        }
+        Path fileName = path.getFileName();
+        if (fileName == null) {
+            return true;
+        }
+        String name = fileName.toString();
+        if (settingsService.getExcludePattern() != null && settingsService.getExcludePattern().matcher(name).find()) {
+            if (LOG.isInfoEnabled()) {
+                LOG.info("excluding file which matches exclude pattern " + settingsService.getExcludePatternString()
+                        + ": " + path);
+            }
+            return true;
+        }
+
+        // Exclude all hidden files starting with a single "." or "@eaDir" (thumbnail dir created on Synology devices).
+        return !name.isEmpty() && name.charAt(0) == '.' && !name.startsWith("..") || name.startsWith("@eaDir")
+                || "Thumbs.db".equals(name);
+    }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PlaylistServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PlaylistServiceTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import com.tesshu.jpsonic.dao.MediaFileDao;
 import com.tesshu.jpsonic.dao.PlaylistDao;
+import com.tesshu.jpsonic.dao.UserDao;
 import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.domain.Playlist;
 import com.tesshu.jpsonic.service.playlist.DefaultPlaylistExportHandler;
@@ -287,8 +288,10 @@ class PlaylistServiceTest {
             playlistDao = mock(PlaylistDao.class);
             settingsService = mock(SettingsService.class);
             mediaFileService = mock(MediaFileService.class);
+            SecurityService securityService = new SecurityService(mock(UserDao.class), settingsService,
+                    mock(MusicFolderService.class));
             DefaultPlaylistImportHandler importHandler = new DefaultPlaylistImportHandler(mediaFileService);
-            playlistService = new PlaylistService(mock(MediaFileDao.class), playlistDao, mock(SecurityService.class),
+            playlistService = new PlaylistService(mock(MediaFileDao.class), playlistDao, securityService,
                     settingsService, Collections.emptyList(), Arrays.asList(importHandler), null);
         }
 
@@ -338,11 +341,10 @@ class PlaylistServiceTest {
 
             List<Playlist> captored = playlistCatCaptor.getAllValues();
             captored.sort((p1, p2) -> p1.getName().compareTo(p2.getName()));
-            assertEquals(4, playlistCatCaptor.getAllValues().size());
-            assertEquals("Thumbs", captored.get(0).getName());
-            assertEquals("XSPF-mf1", captored.get(1).getName());
-            assertEquals("XSPF-mf2", captored.get(2).getName());
-            assertEquals("XSPF-mf3", captored.get(3).getName());
+            assertEquals(3, playlistCatCaptor.getAllValues().size());
+            assertEquals("XSPF-mf1", captored.get(0).getName());
+            assertEquals("XSPF-mf2", captored.get(1).getName());
+            assertEquals("XSPF-mf3", captored.get(2).getName());
         }
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PlaylistServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PlaylistServiceTest.java
@@ -325,16 +325,24 @@ class PlaylistServiceTest {
             mediaFile.setPathString(mf3.toString());
             Mockito.when(mediaFileService.getMediaFile(mf3)).thenReturn(mediaFile);
 
+            // Assuming Synology environment
+            Files.createDirectories(Path.of(tempDir.toString(), "@eaDir"));
+            Files.createDirectories(Path.of(tempDir.toString(), "@tmp"));
+            // Assuming Windows environment
+            Files.createFile(Path.of(tempDir.toString(), "Thumbs.db"));
+
             ArgumentCaptor<Playlist> playlistCatCaptor = ArgumentCaptor.forClass(Playlist.class);
             Mockito.doNothing().when(playlistDao).createPlaylist(playlistCatCaptor.capture());
+
             playlistService.importPlaylists();
 
             List<Playlist> captored = playlistCatCaptor.getAllValues();
             captored.sort((p1, p2) -> p1.getName().compareTo(p2.getName()));
-            assertEquals(3, playlistCatCaptor.getAllValues().size());
-            assertEquals("XSPF-mf1", captored.get(0).getName());
-            assertEquals("XSPF-mf2", captored.get(1).getName());
-            assertEquals("XSPF-mf3", captored.get(2).getName());
+            assertEquals(4, playlistCatCaptor.getAllValues().size());
+            assertEquals("Thumbs", captored.get(0).getName());
+            assertEquals("XSPF-mf1", captored.get(1).getName());
+            assertEquals("XSPF-mf2", captored.get(2).getName());
+            assertEquals("XSPF-mf3", captored.get(3).getName());
         }
     }
 }


### PR DESCRIPTION

#### Overview

Since Subsonic, the scan has logic to avoid some platform-specific special dirs or files like `@eaDir` for Synology or `Thumbs.db` for Windows. Now,  import of playlists doesn't have it, so it will fail with the error. Therefore the following changes will be made:

 - This checking logic has been used in scan will now also run when importing playlists. 
 - `@tmp` for Synology will be added to the check targets
