### PR TITLE
Full support for artist images with UPnP

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/AlbumUpnpProcessor.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/AlbumUpnpProcessor.java
@@ -97,9 +97,7 @@ public class AlbumUpnpProcessor extends UpnpContentProcessor<Album, MediaFile> {
             container.setId(getRootId() + UpnpProcessDispatcher.OBJECT_ID_SEPARATOR + album.getComment());
         } else {
             container.setId(getRootId() + UpnpProcessDispatcher.OBJECT_ID_SEPARATOR + album.getId());
-            if (album.getCoverArtPath() != null) {
-                container.setAlbumArtURIs(new URI[] { createAlbumArtURI(album) });
-            }
+            container.setAlbumArtURIs(new URI[] { createAlbumArtURI(album) });
             container.setDescription(album.getComment());
         }
         container.setParentID(getRootId());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/ArtistByFolderUpnpProcessor.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/ArtistByFolderUpnpProcessor.java
@@ -113,10 +113,8 @@ public class ArtistByFolderUpnpProcessor
         } else if (item.isAlbum()) {
             MusicAlbum container = new MusicAlbum();
             container.setId(getRootId() + UpnpProcessDispatcher.OBJECT_ID_SEPARATOR + item.getId());
-            if (item.getAlbum().getCoverArtPath() != null) {
-                container.setAlbumArtURIs(
-                        new URI[] { getDispatcher().getAlbumProcessor().createAlbumArtURI(item.getAlbum()) });
-            }
+            container.setAlbumArtURIs(
+                    new URI[] { getDispatcher().getAlbumProcessor().createAlbumArtURI(item.getAlbum()) });
             container.setDescription(item.getAlbum().getComment());
             container.setParentID(getRootId());
             container.setTitle(item.getName());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/Id3Wrapper.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/Id3Wrapper.java
@@ -46,4 +46,6 @@ public interface Id3Wrapper {
 
     int getChildSize();
 
+    String getCoverArtPath();
+
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/IndexId3UpnpProcessor.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/IndexId3UpnpProcessor.java
@@ -151,8 +151,10 @@ public class IndexId3UpnpProcessor extends UpnpContentProcessor<Id3Wrapper, Id3W
             MusicArtist container = new MusicArtist();
             Artist artist = new Artist();
             artist.setId(id);
-            URI uri = getDispatcher().getArtistProcessor().createArtistArtURI(artist);
-            container.setProperties(Arrays.asList(new ALBUM_ART_URI(uri)));
+            if (item.getCoverArtPath() != null) {
+                container.setProperties(Arrays
+                        .asList(new ALBUM_ART_URI(getDispatcher().getArtistProcessor().createArtistArtURI(artist))));
+            }
             applyParentId(item, container);
             applyId(item, container);
             return container;
@@ -264,6 +266,7 @@ public class IndexId3UpnpProcessor extends UpnpContentProcessor<Id3Wrapper, Id3W
                     result.setId(createArtistId(a.getId()));
                     result.setName(a.getName());
                     result.setAlbumCount(a.getAlbumCount());
+                    result.setCoverArt(a.getCoverArtPath());
                     return result;
                 };
                 for (Map.Entry<MusicIndex, List<MusicIndex.SortableArtistWithArtist>> entry : indexedArtists
@@ -329,6 +332,7 @@ public class IndexId3UpnpProcessor extends UpnpContentProcessor<Id3Wrapper, Id3W
         private String artist;
         private String comment;
         private int childCount;
+        private String coverArtPath;
 
         public Id3Content(IndexID3 index) {
             this.id = String.valueOf(getIDAndIncrement());
@@ -342,6 +346,7 @@ public class IndexId3UpnpProcessor extends UpnpContentProcessor<Id3Wrapper, Id3W
             name = a.getName();
             artist = a.getName();
             childCount = a.getAlbumCount();
+            coverArtPath = a.getCoverArt();
         }
 
         public Id3Content(Artist a) {
@@ -349,6 +354,7 @@ public class IndexId3UpnpProcessor extends UpnpContentProcessor<Id3Wrapper, Id3W
             name = a.getName();
             artist = a.getName();
             childCount = a.getAlbumCount();
+            coverArtPath = a.getCoverArtPath();
         }
 
         public Id3Content(Album album) {
@@ -422,6 +428,10 @@ public class IndexId3UpnpProcessor extends UpnpContentProcessor<Id3Wrapper, Id3W
             return childCount;
         }
 
+        @Override
+        public String getCoverArtPath() {
+            return coverArtPath;
+        }
     }
 
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/IndexUpnpProcessor.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/IndexUpnpProcessor.java
@@ -24,6 +24,7 @@ import static org.springframework.util.ObjectUtils.isEmpty;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -46,6 +47,7 @@ import net.sf.ehcache.Ehcache;
 import net.sf.ehcache.Element;
 import org.fourthline.cling.support.model.BrowseResult;
 import org.fourthline.cling.support.model.DIDLContent;
+import org.fourthline.cling.support.model.DIDLObject.Property.UPNP.ALBUM_ART_URI;
 import org.fourthline.cling.support.model.PersonWithRole;
 import org.fourthline.cling.support.model.container.Container;
 import org.fourthline.cling.support.model.container.GenreContainer;
@@ -145,6 +147,8 @@ public class IndexUpnpProcessor extends UpnpContentProcessor<MediaFile, MediaFil
         } else {
             MusicArtist container = new MusicArtist();
             applyId(item, container);
+            item.getCoverArtPath().ifPresent(path -> container.setProperties(Arrays
+                    .asList(new ALBUM_ART_URI(getDispatcher().getMediaFileProcessor().createArtistArtURI(item)))));
             return container;
         }
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/MediaFileUpnpProcessor.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/MediaFileUpnpProcessor.java
@@ -128,6 +128,8 @@ public class MediaFileUpnpProcessor extends UpnpContentProcessor<MediaFile, Medi
             }
             MusicArtist container = new MusicArtist();
             applyId(item, container);
+            item.getCoverArtPath().ifPresent(
+                    path -> container.setProperties(Arrays.asList(new ALBUM_ART_URI(createArtistArtURI(item)))));
             return container;
         }
         return null;
@@ -258,7 +260,7 @@ public class MediaFileUpnpProcessor extends UpnpContentProcessor<MediaFile, Medi
         return StringUtil.formatDurationHMMSS(seconds) + ".0";
     }
 
-    public URI createArtistArtURI(MediaFile artist) {
+    public URI createArtistArtURI(@NonNull MediaFile artist) {
         return util.createURIWithToken(
                 UriComponentsBuilder.fromUriString(util.getBaseUrl() + "/ext/" + ViewName.COVER_ART.value())
                         .queryParam("id", artist.getId()).queryParam("size", CoverArtScheme.LARGE.getSize()));


### PR DESCRIPTION
Prerequisites: #2180, #2181

#### Overview

Until now, UPnP provided only ID3 for Artist images. This pull request will also allow artist images to be used in File Structure browsing. (Folder browsing, and The Index of File Structure browsing)

<details>
<summary>Background</summary>

There is a bug in artist image URI generation of legacy server. As a result, an incorrect URI could be generated and an image different than the intended one would be displayed. Specifically, because the File Structure ID and the ID3 ID were confused in internal processing, there were cases where completely different images were displayed or cache conflicts occurred.

In Jpsonic, the problematic function was temporarily sealed, and maintenance was gradually advanced from ID3. This is because ID3 has a 1:n cardinality between display items and images(ID3 is troublesome because there are duplicate cases. The fix target is scan logic rather than image generation.). This was done up to v112.0.0. Additional fixes are added in v112.1.0, and the problem is mostly converged.

ID3 images can now be processed correctly, so this pull request will add more File Structure image processing. If the UPnP album and artist image processing is working as expected with this version of the fix, we can consider adding subsequent functionality in a future version. (Display on a web page or addition, etc.)

</details>

#### Goal

 - In UPnP, provide an image URI property to all objects for which artist images are available.
 - Change the image properties of UPnP output as follows.
   - Album : Required. If the image does not exist, a substitute image is provided.
   - Artist : Not required. If the image does not exist, property will not be added.

#### Non-Goal

Web page renovation is not included.

#### Expected behavior of the client app

In most cases, users should have saved album cover art properly. That's why Jpsonic treats album cover art as almost mandatory. If the album cover art doesn't exist, a warning will be printed in the log at WARN level and an alternate image will be used. (If the warnings are annoying, change the log level)

On the other hand, it depends on the person whether the music library has artist images such as folder.jpg. Therefore, the artist image is not a mandatory file in Jpsonic. If it doesn't exist, it won't be displayed, that's all.

Artist-Image does not clearly exist in UPnP's DIDL (although I don't know the new specification). So Jpsonic will output urn:schemas-upnp-org:metadata-1-0/upnp/albumArtURI as a property of object.container.person.musicArtist if an artist image is available. The treatment of artist images may differ depending on the app, but in most cases this will be recognized. If folder.jpg doesn't exist, it won't be outputed.

So how does it work! In most cases, a "person icon" will be displayed if there is no image.

For [BubbleUPnP](https://play.google.com/store/apps/details?id=com.bubblesoft.android.bubbleupnp). 

![image](https://github.com/tesshucom/jpsonic/assets/27724847/36285de1-4e69-42c0-8cdb-39a9bbfea37a)


For [Hi-Fi cast](https://play.google.com/store/search?q=Hi+fi+cast&c=apps).

![image](https://github.com/tesshucom/jpsonic/assets/27724847/98bbd299-93b9-4051-bbbe-c14de440a604)



