### PR TITLE
Adjust memory settings assuming Synology DS220+ deployment

### DIFF
--- a/install/docker/production.synology.yml
+++ b/install/docker/production.synology.yml
@@ -28,6 +28,21 @@ services:
      - '/volume1/Podcasts:/jpsonic/podcasts'
      - '/volume1/Playlists:/jpsonic/playlists'
 
+     # If you want to add a large number of music folders, please add more volumes
+     # - '/volume1/Music2:/jpsonic/music2'
+     # - '/volume1/Music3:/jpsonic/music3'
+
+    deploy:
+      resources:
+        limits:
+
+          # Jpsonic container is limited to 1Gb so that it can run on DS220+'s standard memory.
+          # Xmx512m is assigned by default, but with these settings,
+          # it is assumed that 100,000 songs can be scanned for music only.
+          # For larger libraries, increase Xmx and this setting by the same value.
+          # ie) memory: 1.5g at -Xmx1024
+          memory: 1g
+
     environment:
 
      # Set the jpsonic and upnp ports.

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
@@ -102,7 +102,7 @@ public class ScannerProcedureService {
     private final JapaneseReadingUtils readingUtils;
     private final ThreadPoolTaskExecutor scanExecutor;
 
-    private static final int ACQUISITION_MAX = 10;
+    private static final int ACQUISITION_MAX = 10_000;
 
     private final AtomicBoolean cancel = new AtomicBoolean();
 


### PR DESCRIPTION
Prerequisites: #2175, #2184, #1808

#### Overview

Memory limit is added to production.synology.yml, assuming Synology DS220+.

 - DS220+ standard memory is 2Gb. Approximately less than 512mb will be consumed for standard OS operation. By the way, DS220j which is a lower model of DS220+ has standard memory of 512mb.
 - Currently being tested, Jpsonic is supposed to be able to scan 100,000 songs at 512Mb. If you allow 512Mb for Alpine running during the scan, add them together for 1Gb. Scanning 100,000 songs with this setting peaked memory usage at around 900Mb. With 100,000 songs possible, it should cover the needs of most users. If it exceeds that, additional memory setting is required. 
 - Of course, it doesn't always occupy 1Gb.

![image](https://github.com/tesshucom/jpsonic/assets/27724847/c7b41955-02f1-4fe1-86a9-87fe2ee4be7c)

#### Goal

Run Jpsonic Docker Image with the standard memory of Synology DS220+. Provide a Docker configuration that allows a sufficient amount of scanning capacity.

#### Non-Goal

A stress test is currently underway. If major issues are found, additional fixes may be made before release.

#### Memo

Subsonic often used '-Xmx256m'. Airsonic is '-Xmx512m'. This is not due to the unreasonable increase in memory usage, but due to the generation difference between the 32-bit era and the 64-bit era. JPsonic is also conscious of this standard. Since the libraries and frameworks used are different, the memory usage cannot be exactly the same. However, I keep in mind that it is desirable to have similar behavior on the PC that has been used so far. 100,000 songs is a rough estimate of the current capacity, calculated backwards from 512Mb.



