### PR TITLE
Fix to change DangerZone value even if scan schema is not changed

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/AdvancedSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/AdvancedSettingsController.java
@@ -204,13 +204,6 @@ public class AdvancedSettingsController {
     private void setDangerZone(AdvancedSettingsCommand command) {
 
         IndexScheme scheme = command.getIndexScheme();
-        boolean changed = scheme != IndexScheme.valueOf(settingsService.getIndexSchemeName());
-
-        if (!changed) {
-            return;
-        }
-
-        settingsService.setIgnoreFileTimestamps(true);
         settingsService.setIndexSchemeName(scheme.name());
 
         if (scheme == IndexScheme.NATIVE_JAPANESE) {


### PR DESCRIPTION
## Problem description

Of the `Advanced Settings pages > Danger Zone' items, 'Sort considering serial number' and 'Resolve sorting when scanning'cannot be changed.

### Steps to reproduce

1. Do not change 'Sort tag processing method', change 'Sort considering serial number' or 'Resolve sorting when scanning'

## System information

 * **Jpsonic version**: v111.6.0

## Additional notes

 - 'Sort tag processing method' is an item that originally existed on this page.
 - Since this item is a rather special feature (requires full scan), 'Ignore timstamp' was automatically enabled when it was changed.
   - If not changed, 'Ignore timstamp' **will not be enabled**.
 - In v111.6.0 two items that were originally on the General Settings page have been moved here (no functionality change).
   - It was then simply added to the existing logic. It works by itself, but a bug that it was not updated unless the 'Sort tag processing method' was changed was born.
 - This commit removes obscure controls across multiple pages. It will be saved as selected. 'Ignore timestamps' on the other hand is no longer automatically enabled.

![image](https://github.com/tesshucom/jpsonic/assets/27724847/290fbca6-efba-4334-b94a-49b1ade5cb54)