### PR TITLE
Change log level of o.e.jetty.io.AbstractConnection to ERROR

### DIFF
--- a/jpsonic-main/src/main/resources/application.properties
+++ b/jpsonic-main/src/main/resources/application.properties
@@ -10,6 +10,7 @@ logging.level.org.airsonic=WARN
 logging.level.com.tesshu=WARN
 logging.level.com.tesshu.jpsonic.util.concurrent=WARN
 logging.level.liquibase=WARN
+logging.level.org.eclipse.jetty.io.AbstractConnection=ERROR
 logging.level.com.tesshu.jpsonic.spring.AirsonicHsqlDatabase=WARN
 logging.level.com.tesshu.jpsonic.Application=INFO
 logging.level.com.tesshu.jpsonic.service.VersionService=INFO

--- a/jpsonic-main/src/test/resources/application.properties
+++ b/jpsonic-main/src/test/resources/application.properties
@@ -9,6 +9,7 @@ logging.level.org.airsonic=WARN
 logging.level.com.tesshu=WARN
 
 logging.level.liquibase=WARN
+logging.level.org.eclipse.jetty.io.AbstractConnection=ERROR
 logging.level.com.tesshu.jpsonic.spring.AirsonicHsqlDatabase=WARN
 logging.pattern.console=%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p){green} %clr(---){faint} %clr(%-40.40logger{32}){blue} %clr(:){faint} %m%n%wEx
 logging.pattern.file=%d{yyyy-MM-dd HH:mm:ss.SSS} %5p --- %-40.40logger{32} : %m%n%wEx


### PR DESCRIPTION
## Problem description

In the latest Jetty, verbose logging is now output, so it will be suppressed.


```
WARN --- o.e.jetty.io.AbstractConnection          : Failed callback

java.io.IOException: Close SendCallback@58f884f9[PENDING][i=null,cb=null] in state PENDING
	at org.eclipse.jetty.util.IteratingCallback.close(IteratingCallback.java:458) ~[jetty-util-10.0.15.jar!/:10.0.15]
	at org.eclipse.jetty.server.HttpConnection.onClose(HttpConnection.java:551) ~[jetty-server-10.0.15.jar!/:10.0.15]
	at org.eclipse.jetty.io.SelectorManager.connectionClosed(SelectorManager.java:330) ~[jetty-io-10.0.15.jar!/:10.0.15]
	at org.eclipse.jetty.io.ManagedSelector$DestroyEndPoint.run(ManagedSelector.java:1113) ~[jetty-io-10.0.15.jar!/:10.0.15]
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:969) ~[jetty-util-10.0.15.jar!/:10.0.15]
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.doRunJob(QueuedThreadPool.java:1194) ~[jetty-util-10.0.15.jar!/:10.0.15]
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1149) ~[jetty-util-10.0.15.jar!/:10.0.15]
```



### Steps to reproduce

Typical examples are as follows :

 - Start playing a different song immediately after it starts playing
 - Client dependent : Use apps that require multiple connections when streaming.
   - I don't know what you're doing unless you look at the client's sorting, but if the client requests GET, reads the headers, and immediately closes it, the server side will be full of logs. By the way, I've never seen a client requesting HEAD. (Because HEAD may not be supported in simplified media servers, it is customary for media-related client apps to use GET to read HEAD.)

## System information

 * **Jpsonic version**: maybe v112.0.0

## Additional notes

Jetty is relatively strict with its error log handling, which has become more pronounced since version 8. It seems that the problem may become apparent due to the increasing number of backports of implementations that enable detailed error tracking of Websockets and the increased speed of Jetty processing. This is a powerful weapon especially when developing a client and server as a set, but in the case of a media server it is impossible to document all the causes. 
Filling up your log files or filling up your DockerUI console is very detrimental given its frequency. Logs that are generally assumed to be harmless are suppressed by default. (The log level can be changed arbitrarily by the user with options at startup.)



