### PR TITLE
Add new Docker tag variations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,12 @@ jobs:
           mvn -DdockerTag=${{ env.DOCKER_TAG }} package
           docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
           docker buildx build --push --platform linux/amd64 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }} .
+          mvn -DdockerTag=${DOCKER_TAG%.*}-sandbox package
+          docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+          docker buildx build --push --platform linux/amd64 -t jpsonic/jpsonic:${DOCKER_TAG%.*} .
+          mvn -DdockerTag=${DOCKER_TAG%.*.*} package
+          docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+          docker buildx build --push --platform linux/amd64 -t jpsonic/jpsonic:${DOCKER_TAG%.*.*} .
       - name: Release with Latest Tag
         if: github.ref == 'refs/heads/master'
         run: |
@@ -330,6 +336,12 @@ jobs:
           mvn -DdockerTag=${{ env.DOCKER_TAG }}-jammy package
           docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
           docker buildx build --push --platform linux/arm64,linux/amd64,linux/arm/v7 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-jammy .
+          mvn -DdockerTag={DOCKER_TAG%.*}-jammy package
+          docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+          docker buildx build --push --platform linux/arm64,linux/amd64,linux/arm/v7 -t jpsonic/jpsonic:${DOCKER_TAG%.*}-jammy .
+          mvn -DdockerTag=${DOCKER_TAG%.*.*}-jammy package
+          docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+          docker buildx build --push --platform linux/arm64,linux/amd64,linux/arm/v7 -t jpsonic/jpsonic:${DOCKER_TAG%.*.*}-jammy .
       - name: Release with Latest Tag
         if: github.ref == 'refs/heads/master'
         run: |


### PR DESCRIPTION

#### Overview

Docker image version numbering will be added to make it easier for users to take advantage of automatic updates.

 - Patch version images that have not been provided until now will be released
 - Major and minor transitive version images that were not previously available will be provided

#### Concrete example

`fixed`  : Github's semantic versioning. It will match the version in pom.xml and the hash is fixed . 
`transitive`  :  Will always be overwritten by the latest version in the lower segment's version.

 - latest (transitive) means Latest of all versions
 - 113 (transitive) means 113.x.x latest
 - 113.0.0 (fixed)
 - 112.2 (transitive) means 112.2.x latest
 - 112.2.1 (fixed)
 - 112.2.0 (fixed)
 - 112.1 (transitive) means 112.1.x latest
 - 112.1.2 (fixed)
 - 112.1.1 (fixed)
 - 112.1.0 (fixed)
 - 112 (transitive) means 112.x.x latest
 - 112.0.0 (fixed)

The user's real concern is whether the latest, major, or minor transitional version is available. Because it's impractical not to take advantage of automatic updates. 

Users would probably prefer an operation that allows users to choose "to what extent automatic updates are allowed?" In short, would use any `transitive`. 



