### PR TITLE
Suppress TimeoutException in StreamingService

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StreamController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StreamController.java
@@ -28,6 +28,7 @@ import static org.springframework.web.bind.ServletRequestUtils.getIntParameter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.annotation.Nullable;
@@ -362,7 +363,8 @@ public class StreamController {
     }
 
     private static void writeErrorLog(IOException e, HttpServletRequest req) {
-        if (LoggingExceptionResolver.isSuppressedException(e)) {
+        Throwable cause = e.getCause();
+        if (cause != null && cause instanceof TimeoutException || LoggingExceptionResolver.isSuppressedException(e)) {
             if (LOG.isTraceEnabled()) {
                 LOG.trace(req.getRemoteAddr() + ": Client unexpectedly closed connection while loading "
                         + req.getRemoteAddr() + " (" + PlayerUtils.getAnonymizedURLForRequest(req) + ")", e);


### PR DESCRIPTION
## Problem description

Minor fix for verbose logging. Related #2217.

Suppress logs like

`java.io.IOException: java.util.concurrent.TimeoutException: Idle timeout expired: ***/300000 ms`

will be output to TRACE.

### Steps to reproduce

Depends on client app implementation.

## Additional notes

Backports of implementations that allow detailed error tracking for websockets may change the exception scheme in Jetty. I'm assuming this is one of them, but I haven't done any definitive research.






