### PR TITLE
Refactoring of Sort key generation 

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AlbumDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AlbumDao.java
@@ -130,8 +130,8 @@ public class AlbumDao extends AbstractDao {
         return null;
     }
 
-    public void updateOrder(String artist, String name, int order) {
-        update("update album set album_order = ? where artist=? and name=?", order, artist, name);
+    public int updateOrder(String artist, String name, int order) {
+        return update("update album set album_order = ? where artist=? and name=?", order, artist, name);
     }
 
     public void updateCoverArtPath(String artist, String name, String coverArtPath) {
@@ -155,7 +155,7 @@ public class AlbumDao extends AbstractDao {
             orderBy = byArtist ? "LOWER(artist_reading), album_order, LOWER(name_reading)"
                     : "album_order, LOWER(name_reading)";
         } else {
-            orderBy = byArtist ? "artist_reading, album_order, name_reading" : "album_order, name_reading";
+            orderBy = byArtist ? "artist_reading, album_order" : "album_order";
         }
 
         return namedQuery("select " + QUERY_COLUMNS + " from album where present and folder_id in (:folders) "

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/ArtistDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/ArtistDao.java
@@ -100,8 +100,8 @@ public class ArtistDao extends AbstractDao {
         return null;
     }
 
-    public void updateOrder(String name, int order) {
-        update("update artist set artist_order=? where name=?", order, name);
+    public int updateOrder(String name, int order) {
+        return update("update artist set artist_order=? where name=?", order, name);
     }
 
     public List<Artist> getAlphabetialArtists(final int offset, final int count, final List<MusicFolder> musicFolders) {
@@ -112,7 +112,7 @@ public class ArtistDao extends AbstractDao {
                 offset);
 
         return namedQuery("select " + QUERY_COLUMNS + " from artist where present and folder_id in (:folders) "
-                + "order by artist_order, reading, name limit :count offset :offset", rowMapper, args);
+                + "order by artist_order limit :count offset :offset", rowMapper, args);
     }
 
     public List<Artist> getStarredArtists(final int offset, final int count, final String username,

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Album.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Album.java
@@ -23,7 +23,7 @@ package com.tesshu.jpsonic.domain;
 
 import java.time.Instant;
 
-public class Album {
+public class Album implements Orderable {
 
     private int id;
     private String path;
@@ -247,10 +247,12 @@ public class Album {
         this.nameReading = nameReading;
     }
 
+    @Override
     public int getOrder() {
         return order;
     }
 
+    @Override
     public void setOrder(int order) {
         this.order = order;
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Artist.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Artist.java
@@ -23,7 +23,7 @@ package com.tesshu.jpsonic.domain;
 
 import java.time.Instant;
 
-public class Artist {
+public class Artist implements Orderable {
 
     private int id;
     private String name;
@@ -125,10 +125,12 @@ public class Artist {
         this.reading = reading;
     }
 
+    @Override
     public int getOrder() {
         return order;
     }
 
+    @Override
     public void setOrder(int order) {
         this.order = order;
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/JpsonicComparators.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/JpsonicComparators.java
@@ -19,6 +19,8 @@
 
 package com.tesshu.jpsonic.domain;
 
+import static org.apache.commons.lang3.StringUtils.defaultString;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
 import java.text.Collator;
@@ -62,11 +64,13 @@ public class JpsonicComparators {
      * @return Comparator
      */
     public Comparator<Album> albumOrderByAlpha() {
-        return (o1, o2) -> {
-            if (-1 != o1.getOrder() && -1 != o2.getOrder()) {
-                return o1.getOrder() - o2.getOrder();
+        return new Comparator<Album>() {
+            private Collator collator = createCollator();
+
+            @Override
+            public int compare(Album o1, Album o2) {
+                return collator.compare(defaultString(o1.getNameReading()), defaultString(o2.getNameReading()));
             }
-            return createCollator().compare(o1.getNameReading(), o2.getNameReading());
         };
     }
 
@@ -76,11 +80,13 @@ public class JpsonicComparators {
      * @return Comparator
      */
     public Comparator<Artist> artistOrderByAlpha() {
-        return (o1, o2) -> {
-            if (-1 != o1.getOrder() && -1 != o2.getOrder()) {
-                return o1.getOrder() - o2.getOrder();
+        return new Comparator<Artist>() {
+            private Collator collator = createCollator();
+
+            @Override
+            public int compare(Artist o1, Artist o2) {
+                return collator.compare(defaultString(o1.getReading()), defaultString(o2.getReading()));
             }
-            return createCollator().compare(o1.getReading(), o2.getReading());
         };
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaFile.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaFile.java
@@ -40,7 +40,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * @author Sindre Mehus
  */
-public class MediaFile {
+public class MediaFile implements Orderable {
 
     private int id;
     private String pathString;
@@ -579,10 +579,12 @@ public class MediaFile {
         this.composerSortRaw = composerSortRaw;
     }
 
+    @Override
     public int getOrder() {
         return order;
     }
 
+    @Override
     public void setOrder(int order) {
         this.order = order;
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Orderable.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Orderable.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2023 tesshucom
+ */
+
+package com.tesshu.jpsonic.domain;
+
+public interface Orderable {
+
+    int getOrder();
+
+    void setOrder(int order);
+}

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
@@ -132,10 +132,8 @@ public class SortProcedureService {
         List<MusicFolder> folders = musicFolderService.getAllMusicFolders();
         List<Album> albums = albumDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, false, false, folders);
         LongAdder count = new LongAdder();
-        getToBeOrderUpdate(albums, comparators.albumOrderByAlpha()).forEach(album -> {
-            albumDao.updateOrder(album.getArtist(), album.getName(), album.getOrder());
-            count.increment();
-        });
+        getToBeOrderUpdate(albums, comparators.albumOrderByAlpha()).forEach(
+                album -> count.add(albumDao.updateOrder(album.getArtist(), album.getName(), album.getOrder())));
         return count.intValue();
     }
 
@@ -143,10 +141,8 @@ public class SortProcedureService {
         List<MusicFolder> folders = musicFolderService.getAllMusicFolders();
         List<Artist> artists = artistDao.getAlphabetialArtists(0, Integer.MAX_VALUE, folders);
         LongAdder count = new LongAdder();
-        getToBeOrderUpdate(artists, comparators.artistOrderByAlpha()).forEach(artist -> {
-            artistDao.updateOrder(artist.getName(), artist.getOrder());
-            count.increment();
-        });
+        getToBeOrderUpdate(artists, comparators.artistOrderByAlpha())
+                .forEach(artist -> count.add(artistDao.updateOrder(artist.getName(), artist.getOrder())));
         return count.intValue();
     }
 
@@ -154,31 +150,29 @@ public class SortProcedureService {
         List<MusicFolder> folders = musicFolderService.getAllMusicFolders();
         List<MediaFile> artists = mediaFileDao.getArtistAll(folders);
         LongAdder count = new LongAdder();
-        getToBeOrderUpdate(artists, comparators.mediaFileOrderByAlpha()).forEach(artist -> {
-            writableMediaFileService.updateOrder(artist);
-            count.increment();
-        });
+        getToBeOrderUpdate(artists, comparators.mediaFileOrderByAlpha())
+                .forEach(artist -> count.add(writableMediaFileService.updateOrder(artist)));
         return count.intValue();
     }
 
     int updateOrderOfAlbum() {
         List<MusicFolder> folders = musicFolderService.getAllMusicFolders();
-        List<MediaFile> albums = mediaFileService.getAlphabeticalAlbums(0, Integer.MAX_VALUE, true, folders);
+        List<MediaFile> albums = mediaFileService.getAlphabeticalAlbums(0, Integer.MAX_VALUE, false, folders);
         LongAdder count = new LongAdder();
-        getToBeOrderUpdate(albums, comparators.mediaFileOrderByAlpha()).forEach(album -> {
-            writableMediaFileService.updateOrder(album);
-            count.increment();
-        });
+        getToBeOrderUpdate(albums, comparators.mediaFileOrderByAlpha())
+                .forEach(album -> count.add(writableMediaFileService.updateOrder(album)));
         return count.intValue();
     }
 
-    void updateOrderOfSongs(MediaFile parent) {
-        List<MediaFile> songs = mediaFileDao.getChildrenOf(parent.getPathString()).stream()
+    int updateOrderOfSongs(MediaFile parent) {
+        List<MediaFile> songs = mediaFileDao.getChildrenWithOrderOf(parent.getPathString()).stream()
                 .filter(child -> mediaFileService.isAudioFile(child.getFormat())
                         || mediaFileService.isVideoFile(child.getFormat()))
                 .collect(Collectors.toList());
+        LongAdder count = new LongAdder();
         getToBeOrderUpdate(songs, comparators.songsDefault())
-                .forEach(song -> writableMediaFileService.updateOrder(song));
+                .forEach(song -> count.add(writableMediaFileService.updateOrder(song)));
+        return count.intValue();
     }
 
     private List<Integer> updateSortOfAlbums(@NonNull List<SortCandidate> candidates) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
@@ -19,8 +19,11 @@
 
 package com.tesshu.jpsonic.service.scanner;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
 
 import com.tesshu.jpsonic.dao.AlbumDao;
@@ -32,6 +35,7 @@ import com.tesshu.jpsonic.domain.JapaneseReadingUtils;
 import com.tesshu.jpsonic.domain.JpsonicComparators;
 import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.domain.MusicFolder;
+import com.tesshu.jpsonic.domain.Orderable;
 import com.tesshu.jpsonic.domain.SortCandidate;
 import com.tesshu.jpsonic.service.MediaFileService;
 import com.tesshu.jpsonic.service.MusicFolderService;
@@ -111,50 +115,61 @@ public class SortProcedureService {
         return updateSortOfArtist(candidates);
     }
 
+    <T extends Orderable> List<T> getToBeOrderUpdate(List<T> list, Comparator<T> comparator) {
+        List<Integer> rawOrders = list.stream().map(Orderable::getOrder).collect(Collectors.toList());
+        Collections.sort(list, comparator);
+        List<T> result = new ArrayList<>();
+        for (int i = 0; i < list.size(); i++) {
+            if (i + 1 != rawOrders.get(i)) {
+                list.get(i).setOrder(i + 1);
+                result.add(list.get(i));
+            }
+        }
+        return result;
+    }
+
     int updateOrderOfAlbumID3() {
         List<MusicFolder> folders = musicFolderService.getAllMusicFolders();
         List<Album> albums = albumDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, false, false, folders);
-        albums.sort(comparators.albumOrderByAlpha());
-        int i = 0;
-        for (Album album : albums) {
-            albumDao.updateOrder(album.getArtist(), album.getName(), i++);
-        }
-        return i;
+        LongAdder count = new LongAdder();
+        getToBeOrderUpdate(albums, comparators.albumOrderByAlpha()).forEach(album -> {
+            albumDao.updateOrder(album.getArtist(), album.getName(), album.getOrder());
+            count.increment();
+        });
+        return count.intValue();
     }
 
     int updateOrderOfArtistID3() {
         List<MusicFolder> folders = musicFolderService.getAllMusicFolders();
         List<Artist> artists = artistDao.getAlphabetialArtists(0, Integer.MAX_VALUE, folders);
-        artists.sort(comparators.artistOrderByAlpha());
-        int i = 0;
-        for (Artist artist : artists) {
-            artistDao.updateOrder(artist.getName(), i++);
-        }
-        return i;
+        LongAdder count = new LongAdder();
+        getToBeOrderUpdate(artists, comparators.artistOrderByAlpha()).forEach(artist -> {
+            artistDao.updateOrder(artist.getName(), artist.getOrder());
+            count.increment();
+        });
+        return count.intValue();
     }
 
     int updateOrderOfArtist() {
         List<MusicFolder> folders = musicFolderService.getAllMusicFolders();
         List<MediaFile> artists = mediaFileDao.getArtistAll(folders);
-        artists.sort(comparators.mediaFileOrderByAlpha());
-        int i = 0;
-        for (MediaFile artist : artists) {
-            artist.setOrder(i++);
+        LongAdder count = new LongAdder();
+        getToBeOrderUpdate(artists, comparators.mediaFileOrderByAlpha()).forEach(artist -> {
             writableMediaFileService.updateOrder(artist);
-        }
-        return i;
+            count.increment();
+        });
+        return count.intValue();
     }
 
     int updateOrderOfAlbum() {
         List<MusicFolder> folders = musicFolderService.getAllMusicFolders();
         List<MediaFile> albums = mediaFileService.getAlphabeticalAlbums(0, Integer.MAX_VALUE, true, folders);
-        albums.sort(comparators.mediaFileOrderByAlpha());
-        int i = 0;
-        for (MediaFile album : albums) {
-            album.setOrder(i++);
+        LongAdder count = new LongAdder();
+        getToBeOrderUpdate(albums, comparators.mediaFileOrderByAlpha()).forEach(album -> {
             writableMediaFileService.updateOrder(album);
-        }
-        return i;
+            count.increment();
+        });
+        return count.intValue();
     }
 
     void updateOrderOfSongs(MediaFile parent) {
@@ -162,10 +177,8 @@ public class SortProcedureService {
                 .filter(child -> mediaFileService.isAudioFile(child.getFormat())
                         || mediaFileService.isVideoFile(child.getFormat()))
                 .collect(Collectors.toList());
-        Collections.sort(songs, comparators.songsDefault());
-        for (int i = 0; i < songs.size(); i++) {
-            mediaFileDao.updateOrder(songs.get(i).getPathString(), i);
-        }
+        getToBeOrderUpdate(songs, comparators.songsDefault())
+                .forEach(song -> writableMediaFileService.updateOrder(song));
     }
 
     private List<Integer> updateSortOfAlbums(@NonNull List<SortCandidate> candidates) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/WritableMediaFileService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/WritableMediaFileService.java
@@ -453,8 +453,8 @@ public class WritableMediaFileService {
         return registered;
     }
 
-    void updateOrder(@NonNull final MediaFile file) {
-        mediaFileDao.updateOrder(file.getPathString(), file.getOrder());
+    int updateOrder(@NonNull final MediaFile file) {
+        return mediaFileDao.updateOrder(file.getPathString(), file.getOrder());
     }
 
     /*

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/SortProcedureServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/SortProcedureServiceTest.java
@@ -19,6 +19,7 @@
 
 package com.tesshu.jpsonic.service.scanner;
 
+import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
 import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -35,9 +36,14 @@ import com.tesshu.jpsonic.dao.ArtistDao;
 import com.tesshu.jpsonic.dao.MediaFileDao;
 import com.tesshu.jpsonic.domain.Album;
 import com.tesshu.jpsonic.domain.Artist;
+import com.tesshu.jpsonic.domain.JapaneseReadingUtils;
+import com.tesshu.jpsonic.domain.JpsonicComparators;
 import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.domain.ScanLog.ScanLogType;
+import com.tesshu.jpsonic.service.MediaFileService;
+import com.tesshu.jpsonic.service.MusicFolderService;
+import com.tesshu.jpsonic.service.SettingsService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.Nested;
@@ -801,5 +807,60 @@ class SortProcedureServiceTest {
             assertEquals(2L, albumId3s.stream().filter(a -> "albumD".equals(a.getNameSort())).count()); // merged
             assertEquals(1L, albumId3s.stream().filter(a -> "ニホンゴノアルバムメイ".equals(a.getNameSort())).count()); // compensated
         }
+    }
+
+    @Test
+    void testGetToBeOrderUpdate() {
+
+        MediaFile m1 = new MediaFile();
+        m1.setPathString("path1");
+        m1.setPresent(true);
+        m1.setOrder(1);
+        MediaFile m2 = new MediaFile();
+        m2.setPathString("path2");
+        m2.setPresent(true);
+        m2.setOrder(2);
+        MediaFile m3 = new MediaFile();
+        m3.setPathString("path3");
+        m3.setPresent(true);
+        m3.setOrder(3);
+
+        JapaneseReadingUtils readingUtils = mock(JapaneseReadingUtils.class);
+        JpsonicComparators comparators = new JpsonicComparators(mock(SettingsService.class), readingUtils);
+
+        SortProcedureService sortProcedureService = new SortProcedureService(mock(MusicFolderService.class),
+                mock(MediaFileService.class), mock(WritableMediaFileService.class), mock(MediaFileDao.class),
+                mock(ArtistDao.class), mock(AlbumDao.class), readingUtils, comparators);
+
+        List<MediaFile> result = sortProcedureService.getToBeOrderUpdate(Arrays.asList(m2, m3, m1),
+                comparators.songsDefault());
+        assertEquals(3, result.size());
+        assertEquals("path1", result.get(0).getPathString());
+        assertEquals("path2", result.get(1).getPathString());
+        assertEquals("path3", result.get(2).getPathString());
+        result = sortProcedureService.getToBeOrderUpdate(result, comparators.songsDefault());
+        assertEquals(0, result.size());
+
+        m1.setOrder(3);
+        m2.setOrder(2);
+        m3.setOrder(1);
+        result = sortProcedureService.getToBeOrderUpdate(Arrays.asList(m1, m2, m3), comparators.songsDefault());
+        assertEquals(2, result.size());
+        assertEquals("path1", result.get(0).getPathString());
+        assertEquals(1, result.get(0).getOrder());
+        assertEquals("path3", result.get(1).getPathString());
+        assertEquals(3, result.get(1).getOrder());
+
+        result = sortProcedureService.getToBeOrderUpdate(result, comparators.songsDefault());
+        assertEquals(1, result.size());
+        assertEquals("path3", result.get(0).getPathString());
+        assertEquals(2, result.get(0).getOrder());
+
+        result = sortProcedureService.getToBeOrderUpdate(result, comparators.songsDefault());
+        assertEquals(1, result.size());
+        assertEquals(1, result.get(0).getOrder());
+
+        result = sortProcedureService.getToBeOrderUpdate(result, comparators.songsDefault());
+        assertEquals(0, result.size());
     }
 }


### PR DESCRIPTION
### Overview

Sort key generation will be improved. The speed when doing a new scan does not change. For subsequent scans, the number of updates may be reduced somewhat.

### Fixed

Processing will be improved, but the data registered in the database will not change.

 - Elimination of redundant update queries
   - When updating the order field that exists in the media_file, artist, album table, it will be fixed so that the query is not issued if it is equal to the already registered data. 
 - Change the query conditions for retrieving all records and the sort conditions performed on the Java side
   - There are some remnants of the database-dependent sorting done in the legacy server. Some of them have been removed.
 - Fix scan log comments
   - Fix to show the return value (real counts of updates) of Update query

![image](https://github.com/tesshucom/jpsonic/assets/27724847/b0b90dbd-3ad8-4eba-b533-94017ca66605)


