### PR TITLE
Fix not to load inappropriate podcast episodes

### DIFF
--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/PodcastServiceImplTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/PodcastServiceImplTest.java
@@ -19,24 +19,37 @@
 
 package com.tesshu.jpsonic.service.scanner;
 
+import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 
+import com.tesshu.jpsonic.service.MediaFileService;
+import com.tesshu.jpsonic.service.SettingsService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+@SuppressWarnings("PMD.TooManyStaticImports")
 class PodcastServiceImplTest {
 
     private PodcastServiceImpl podcastService;
 
     @BeforeEach
     public void setup() throws ExecutionException {
-        podcastService = new PodcastServiceImpl(null, null, null, null, null, null, null, null, null, null);
+        SettingsService settingsService = mock(SettingsService.class);
+        Mockito.when(settingsService.getMusicFileTypesAsArray()).thenReturn(Arrays.asList(
+                "mp3 ogg oga aac m4a m4b flac wav wma aif aiff aifc ape mpc shn mka opus dsf dsd".split("\\s+")));
+        MediaFileService mediaFlieService = new MediaFileService(settingsService, null, null, null, null, null);
+        podcastService = new PodcastServiceImpl(null, settingsService, null, mediaFlieService, null, null, null, null,
+                null, null);
     }
 
     private ZonedDateTime toJST(String date) {
@@ -80,5 +93,18 @@ class PodcastServiceImplTest {
         assertEquals("1:00", podcastService.formatDuration("60"));
         assertEquals("59:59", podcastService.formatDuration("3599"));
         assertEquals("1:00:00", podcastService.formatDuration("3600"));
+    }
+
+    @Test
+    void testIsAudioEpisode() {
+        assertTrue(podcastService.isAudioEpisode("http://tesshu.com/episode.mp3"));
+        assertTrue(podcastService.isAudioEpisode("http://tesshu.com/episode.m4a"));
+        assertTrue(podcastService.isAudioEpisode("http://tesshu.com/episode.ogg"));
+        assertTrue(podcastService.isAudioEpisode("http://tesshu.com/episode.opus"));
+        assertFalse(podcastService.isAudioEpisode("http://tesshu.com/episode.oma"));
+        assertFalse(podcastService.isAudioEpisode("http://tesshu.com/episode.exe"));
+        assertFalse(podcastService.isAudioEpisode("http://tesshu.com/episode.sh"));
+        assertFalse(podcastService.isAudioEpisode("http://tesshu.com/withoutExtenssion"));
+        assertFalse(podcastService.isAudioEpisode("http://tesshu.com/withoutExtenssion/"));
     }
 }


### PR DESCRIPTION
#### Overview

Podcast episodes will be modified to check the extension before downloading. On the setting page, files other than "extensions set as targets for scanning" will not be downloaded.

Without this check, the following problems would be caused:

##### Files with inappropriate or no extension are automatically deleted when scanned

Causes a situation beyond the user's control. (can be deleted)

> When I click on an episode on the screen or press the play button, nothing happens.
> Is it a problem with settings or something?
> Once we unregister the podcast and add it again, it will return to playable state. However, since it is updated every day, it will be in a state where it can not be played again due to automatic update.

Podcast files that are playable immediately after download, but have not been delivered in the proper format and with an extension, will be deleted during scanning. To avoid this, episodes with inappropriate extensions will not be loaded. A WARN level warning message will be logged in the log. (Fail fast)

##### Files with arbitrary extensions may be executable before scanning

It is not an immediate threat. It will depend on the platform and browser specifications. (Of course such a design is bad.)

#### Goal

Fix not to load Episodes other than "extensions set to be scanned".

 - About the extension, it is described [around here](https://podcasters.apple.com/support/893-audio-requirements) if it is the original Podcast specification.
 - The Google Podcasts specs are clearer than the original. "The fully qualified URL of the episode audio file, including the format extension (.wav, .mp3, etc.)."

In other words, the URL has been expected to describe a file with an extension. If it's a common sense content provider.

#### Non-Goal

 Redirects will not work. at least for now.

A user pointed out that such a phenomenon could be reproduced in a podcast on anchor.fm. (It looks like we're redirecting from a url without an extension and linking to an mp4 etc.) Such a mechanism is currently not supported. 

It's not a simple evolution.

Redirects seem to be avoided by traditional providers or to be avoided switching dynamic content. The use of redirection is not prohibited in Apple's Podcasts, such as by rewriting the source content. However, updating the GUID and issuing redirects for a few weeks seems to be mandated. We are neutral about redirecting external content. It could be added, but probably an Option. The Podcasts feature is currently limited to fixing the problematic parts. In a [later milestone](https://github.com/tesshucom/jpsonic/milestone/63) they will be considered together!

