### PR TITLE
Minor fixes related to Order by

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SubsonicRESTController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SubsonicRESTController.java
@@ -672,7 +672,7 @@ public class SubsonicRESTController {
         String username = user.getUsername();
         List<com.tesshu.jpsonic.domain.MusicFolder> musicFolders = musicFolderService.getMusicFoldersForUser(username);
         ArtistWithAlbumsID3 result = createJaxbArtist(new ArtistWithAlbumsID3(), artist, username);
-        for (Album album : albumDao.getAlbumsForArtist(artist.getName(), musicFolders)) {
+        for (Album album : albumDao.getAlbumsForArtist(0L, Integer.MAX_VALUE, artist.getName(), false, musicFolders)) {
             result.getAlbum().add(createJaxbAlbum(new AlbumID3(), album, username));
         }
 
@@ -735,7 +735,8 @@ public class SubsonicRESTController {
         Player player = playerService.getPlayer(request, response);
         String username = securityService.getCurrentUsername(request);
         AlbumWithSongsID3 result = createJaxbAlbum(new AlbumWithSongsID3(), album, username);
-        for (MediaFile mediaFile : mediaFileDao.getSongsForAlbum(album.getArtist(), album.getName())) {
+        for (MediaFile mediaFile : mediaFileDao.getSongsForAlbum(0L, Integer.MAX_VALUE, album.getArtist(),
+                album.getName())) {
             result.getSong().add(createJaxbChild(player, mediaFile, username));
         }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AlbumDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AlbumDao.java
@@ -70,16 +70,6 @@ public class AlbumDao extends AbstractDao {
                 albumName);
     }
 
-    public List<Album> getAlbumsForArtist(final String artist, final List<MusicFolder> musicFolders) {
-        if (musicFolders.isEmpty()) {
-            return Collections.emptyList();
-        }
-        Map<String, Object> args = LegacyMap.of("artist", artist, "folders", MusicFolder.toIdList(musicFolders));
-        return namedQuery("select " + QUERY_COLUMNS
-                + " from album where artist = :artist and present and folder_id in (:folders) "
-                + "order by album_order, name", rowMapper, args);
-    }
-
     public List<Album> getAlbumsForArtist(final long offset, final long count, final String artist, boolean byYear,
             final List<MusicFolder> musicFolders) {
         if (musicFolders.isEmpty()) {
@@ -87,9 +77,9 @@ public class AlbumDao extends AbstractDao {
         }
         Map<String, Object> args = LegacyMap.of("artist", artist, "folders", MusicFolder.toIdList(musicFolders),
                 "offset", offset, "count", count);
-        return namedQuery("select " + QUERY_COLUMNS + " from album "
-                + "where artist = :artist and present and folder_id in (:folders) order by "
-                + (byYear ? "year" : "album_order") + ", name limit :count offset :offset", rowMapper, args);
+        return namedQuery("select " + QUERY_COLUMNS
+                + " from album where artist = :artist and present and folder_id in (:folders) order by "
+                + (byYear ? "year, " : "") + "album_order limit :count offset :offset", rowMapper, args);
     }
 
     public @Nullable Album createAlbum(Album album) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AlbumDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AlbumDao.java
@@ -77,9 +77,11 @@ public class AlbumDao extends AbstractDao {
         }
         Map<String, Object> args = LegacyMap.of("artist", artist, "folders", MusicFolder.toIdList(musicFolders),
                 "offset", offset, "count", count);
-        return namedQuery("select " + QUERY_COLUMNS
-                + " from album where artist = :artist and present and folder_id in (:folders) order by "
-                + (byYear ? "year, " : "") + "album_order limit :count offset :offset", rowMapper, args);
+        return namedQuery(
+                "select " + QUERY_COLUMNS
+                        + " from album where artist = :artist and present and folder_id in (:folders) order by "
+                        + (byYear ? "year is null, year, " : "") + "album_order limit :count offset :offset",
+                rowMapper, args);
     }
 
     public @Nullable Album createAlbum(Album album) {
@@ -222,15 +224,13 @@ public class AlbumDao extends AbstractDao {
         Map<String, Object> args = LegacyMap.of("folders", MusicFolder.toIdList(musicFolders), "count", count, "offset",
                 offset, "fromYear", fromYear, "toYear", toYear);
         if (fromYear <= toYear) {
-            return namedQuery(
-                    "select " + QUERY_COLUMNS + " from album where present and folder_id in (:folders) "
-                            + "and year between :fromYear and :toYear order by year limit :count offset :offset",
-                    rowMapper, args);
+            return namedQuery("select " + QUERY_COLUMNS + " from album where present and folder_id in (:folders) "
+                    + "and year between :fromYear and :toYear "
+                    + "order by year, album_order limit :count offset :offset", rowMapper, args);
         } else {
-            return namedQuery(
-                    "select " + QUERY_COLUMNS + " from album where present and folder_id in (:folders) "
-                            + "and year between :toYear and :fromYear order by year desc limit :count offset :offset",
-                    rowMapper, args);
+            return namedQuery("select " + QUERY_COLUMNS + " from album where present and folder_id in (:folders) "
+                    + "and year between :toYear and :fromYear "
+                    + "order by year desc, album_order limit :count offset :offset", rowMapper, args);
         }
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -135,7 +135,7 @@ public class MediaFileDao extends AbstractDao {
         Map<String, Object> args = LegacyMap.of("type", mediaType.name(), "count", count, "offset", offset, "folders",
                 MusicFolder.toPathList(folders));
         return namedQuery("select " + QUERY_COLUMNS
-                + " from media_file where present and type= :type and folder in(:folders)　order by media_file_order limit :count offset :offset",
+                + " from media_file where present and type= :type and folder in(:folders)　limit :count offset :offset",
                 rowMapper, args);
     }
 
@@ -895,8 +895,7 @@ public class MediaFileDao extends AbstractDao {
          */
         List<MediaFile> tmpResult = namedQuery("select " + QUERY_COLUMNS + ", foo.irownum from (select "
                 + "        (select count(id) from media_file where id < boo.id and type = :type and album_artist = :artist) as irownum, boo.* "
-                + "    from (select * from media_file where type = :type "
-                + "        and album_artist = :artist order by media_file_order, album_artist, album) boo "
+                + "    from (select * from media_file where type = :type and album_artist = :artist) boo "
                 + ") as foo where foo.irownum in ( :randomRownum ) limit :limit ", iRowMapper, args);
 
         /* Restore the order lost in IN. */

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -144,9 +144,10 @@ public class MediaFileDao extends AbstractDao {
     }
 
     public List<MediaFile> getChildrenOf(final long offset, final long count, String path, boolean byYear) {
-        String order = byYear ? "year" : "media_file_order";
-        return query("select " + QUERY_COLUMNS + " from media_file where parent_path=? and present order by " + order
-                + " limit ? offset ?", rowMapper, path, count, offset);
+        return query(
+                "select " + QUERY_COLUMNS + " from media_file where parent_path=? and present order by "
+                        + (byYear ? "year is null, year, " : "") + "media_file_order limit ? offset ?",
+                rowMapper, path, count, offset);
     }
 
     public List<MediaFile> getChildrenWithOrderOf(String path) {
@@ -384,17 +385,15 @@ public class MediaFileDao extends AbstractDao {
                 offset);
 
         if (fromYear <= toYear) {
-            return namedQuery(
-                    "select " + QUERY_COLUMNS
-                            + " from media_file where type = :type and folder in (:folders) and present "
-                            + "and year between :fromYear and :toYear order by year limit :count offset :offset",
-                    rowMapper, args);
+            return namedQuery("select " + QUERY_COLUMNS
+                    + " from media_file where type = :type and folder in (:folders) and present "
+                    + "and year between :fromYear and :toYear "
+                    + "order by year, media_file_order limit :count offset :offset", rowMapper, args);
         } else {
-            return namedQuery(
-                    "select " + QUERY_COLUMNS
-                            + " from media_file where type = :type and folder in (:folders) and present "
-                            + "and year between :toYear and :fromYear order by year desc limit :count offset :offset",
-                    rowMapper, args);
+            return namedQuery("select " + QUERY_COLUMNS
+                    + " from media_file where type = :type and folder in (:folders) and present "
+                    + "and year between :toYear and :fromYear "
+                    + "order by year desc, media_file_order limit :count offset :offset", rowMapper, args);
         }
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -156,24 +156,10 @@ public class MediaFileDao extends AbstractDao {
                 rowMapper, path);
     }
 
-    public List<MediaFile> getFilesInPlaylist(int playlistId) {
-        return query("select " + prefix(QUERY_COLUMNS, "media_file") + " from playlist_file, media_file where "
-                + "media_file.id = playlist_file.media_file_id and playlist_file.playlist_id = ? "
-                + "order by playlist_file.id", rowMapper, playlistId);
-    }
-
     public List<MediaFile> getFilesInPlaylist(int playlistId, long offset, long count) {
         return query("select " + prefix(QUERY_COLUMNS, "media_file") + " from playlist_file, media_file "
                 + "where media_file.id = playlist_file.media_file_id and playlist_file.playlist_id = ? and present "
                 + "order by playlist_file.id limit ? offset ?", rowMapper, playlistId, count, offset);
-    }
-
-    public List<MediaFile> getSongsForAlbum(String artist, String album) {
-        return query(
-                "select " + QUERY_COLUMNS + " from media_file where album_artist=? and album=? and present "
-                        + "and type in (?,?,?) order by disc_number, track_number",
-                rowMapper, artist, album, MediaFile.MediaType.MUSIC.name(), MediaFile.MediaType.AUDIOBOOK.name(),
-                MediaFile.MediaType.PODCAST.name());
     }
 
     public List<MediaFile> getSongsForAlbum(final long offset, final long count, MediaFile album) {
@@ -696,13 +682,6 @@ public class MediaFileDao extends AbstractDao {
                 "select count(*) from media_file where type = :type and folder in (:folders) and present", 0, args);
     }
 
-    public int getAlbumCount(MusicFolder folder) {
-        return queryForInt(
-                "select count(*) from media_file right join music_folder on music_folder.path = media_file.folder "
-                        + "where present and folder = ? and type = ?",
-                0, folder.getPathString(), MediaFile.MediaType.ALBUM.name());
-    }
-
     public int getArtistCount(MusicFolder folder) {
         return queryForInt(
                 "select count(*) from media_file right join music_folder on music_folder.path = media_file.folder "
@@ -757,13 +736,13 @@ public class MediaFileDao extends AbstractDao {
                 username);
     }
 
-    public void resetLastScanned() {
-        update("update media_file set last_scanned = ?, children_last_updated = ? where present", FAR_PAST, FAR_PAST);
-    }
-
-    public void resetLastScanned(int id) {
-        update("update media_file set last_scanned = ?, children_last_updated = ? where present and id = ?", FAR_PAST,
-                FAR_PAST, id);
+    public void resetLastScanned(@Nullable Integer id) {
+        String query = "update media_file set last_scanned = ?, children_last_updated = ? where present";
+        if (id == null) {
+            update(query, FAR_PAST, FAR_PAST);
+        } else {
+            update(query + " and id = ?", FAR_PAST, FAR_PAST, id);
+        }
     }
 
     public void updateLastScanned(int id, Instant lastScanned) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PlaylistService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PlaylistService.java
@@ -150,7 +150,7 @@ public class PlaylistService {
     }
 
     public List<MediaFile> getFilesInPlaylist(int id, boolean includeNotPresent) {
-        List<MediaFile> files = mediaFileDao.getFilesInPlaylist(id);
+        List<MediaFile> files = mediaFileDao.getFilesInPlaylist(id, 0L, Integer.MAX_VALUE);
         if (includeNotPresent) {
             return files;
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/playlist/DefaultPlaylistExportHandler.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/playlist/DefaultPlaylistExportHandler.java
@@ -62,7 +62,7 @@ public class DefaultPlaylistExportHandler implements PlaylistExportHandler {
 
     private Playlist createChameleonGenericPlaylistFromDBId(int id) {
         Playlist newPlaylist = new Playlist();
-        List<MediaFile> files = mediaFileDao.getFilesInPlaylist(id);
+        List<MediaFile> files = mediaFileDao.getFilesInPlaylist(id, 0L, Integer.MAX_VALUE);
         files.forEach(file -> {
             Media component = new Media();
             Content content = new Content(file.getPathString());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
@@ -195,7 +195,7 @@ public class ScannerProcedureService {
         indexManager.startIndexing();
 
         if (settingsService.isIgnoreFileTimestamps()) {
-            mediaFileDao.resetLastScanned();
+            mediaFileDao.resetLastScanned(null);
             artistDao.deleteAll();
             albumDao.deleteAll();
             indexManager.deleteAll();
@@ -803,7 +803,7 @@ public class ScannerProcedureService {
         for (MusicFolder folder : musicFolderService.getAllMusicFolders()) {
             stats.setFolderId(folder.getId());
             stats.setArtistCount(mediaFileDao.getArtistCount(folder));
-            stats.setAlbumCount(mediaFileDao.getAlbumCount(folder));
+            stats.setAlbumCount(mediaFileDao.getAlbumCount(Arrays.asList(folder)));
             stats.setSongCount(mediaFileDao.getSongCount(folder));
             stats.setVideoCount(mediaFileDao.getVideoCount(folder));
             stats.setTotalDuration(mediaFileDao.getTotalSeconds(folder));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PlaylistServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/PlaylistServiceTest.java
@@ -61,7 +61,8 @@ class PlaylistServiceTest {
 
         @Test
         void testExportToM3U() throws Exception {
-            Mockito.when(mediaFileDao.getFilesInPlaylist(ArgumentMatchers.eq(23))).thenReturn(getPlaylistFiles());
+            Mockito.when(mediaFileDao.getFilesInPlaylist(ArgumentMatchers.eq(23), Mockito.anyLong(), Mockito.anyLong()))
+                    .thenReturn(getPlaylistFiles());
 
             try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
                 playlistService.exportPlaylist(23, outputStream);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/SortProcedureServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/SortProcedureServiceTest.java
@@ -262,7 +262,7 @@ class SortProcedureServiceTest {
             List<MediaFile> files = mediaFileDao.getChildrenOf(0, Integer.MAX_VALUE, album.getPathString(), false);
             assertEquals(2, files.size());
             for (int i = 0; i < files.size(); i++) {
-                assertEquals(i, files.get(i).getOrder());
+                assertEquals(i + 1, files.get(i).getOrder());
             }
             files.sort((m1, m2) -> Integer.compare(m1.getOrder(), m2.getOrder()));
             assertEquals("file1", files.get(0).getName());
@@ -316,7 +316,7 @@ class SortProcedureServiceTest {
             List<MediaFile> artists = mediaFileDao.getArtistAll(musicFolders);
             assertEquals(3, artists.size());
             for (int i = 0; i < artists.size(); i++) {
-                assertEquals(i, artists.get(i).getOrder());
+                assertEquals(i + 1, artists.get(i).getOrder());
             }
             artists.sort((m1, m2) -> Integer.compare(m1.getOrder(), m2.getOrder()));
 
@@ -355,7 +355,7 @@ class SortProcedureServiceTest {
                     false);
             assertEquals(9, albums.size());
             for (int i = 0; i < albums.size(); i++) {
-                assertEquals(i, albums.get(i).getOrder());
+                assertEquals(i + 1, albums.get(i).getOrder());
             }
             albums.sort((m1, m2) -> Integer.compare(m1.getOrder(), m2.getOrder()));
 
@@ -612,7 +612,7 @@ class SortProcedureServiceTest {
                     .collect(Collectors.toList());
             assertEquals(2, songs.size());
             for (int i = 0; i < songs.size(); i++) {
-                assertEquals(i, songs.get(i).getOrder());
+                assertEquals(i + 1, songs.get(i).getOrder());
             }
             songs.sort((m1, m2) -> Integer.compare(m1.getOrder(), m2.getOrder()));
 
@@ -634,7 +634,7 @@ class SortProcedureServiceTest {
             List<Artist> artistID3s = artistDao.getAlphabetialArtists(0, Integer.MAX_VALUE, musicFolders);
             assertEquals(12, artistID3s.size());
             for (int i = 0; i < artistID3s.size(); i++) {
-                assertEquals(i, artistID3s.get(i).getOrder());
+                assertEquals(i + 1, artistID3s.get(i).getOrder());
             }
             artistID3s.sort((m1, m2) -> Integer.compare(m1.getOrder(), m2.getOrder()));
 
@@ -694,7 +694,7 @@ class SortProcedureServiceTest {
             List<Album> albumId3s = albumDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, false, false, musicFolders);
             assertEquals(13, albumId3s.size());
             for (int i = 0; i < albumId3s.size(); i++) {
-                assertEquals(i, albumId3s.get(i).getOrder());
+                assertEquals(i + 1, albumId3s.get(i).getOrder());
             }
             albumId3s.sort((m1, m2) -> Integer.compare(m1.getOrder(), m2.getOrder()));
 
@@ -787,6 +787,13 @@ class SortProcedureServiceTest {
             populateDatabase();
         }
 
+        /**
+         * The test cases below are only valid when checked out and run locally. Because merging is a logic that takes
+         * into account file dates, it cannot be reproduced in the test on Github. This means that if the file dates are
+         * exactly the same, it is difficult to decide which one to use as a reference when merging. This is by design.
+         * Exactly identical file dates are rare cases. Additionally, it can be circumvented by the user modifying the
+         * sort tag accordingly.
+         */
         @Test
         void testUpdateSortOfAlbum() throws ExecutionException {
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/PlaylistUpnpProcessorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/PlaylistUpnpProcessorTest.java
@@ -100,7 +100,7 @@ class PlaylistUpnpProcessorTest extends AbstractNeedsScan {
         List<Album> albums = albumUpnpProcessor.getItems(0, 100);
         assertEquals(61, albums.size());
         List<MediaFile> files = albums.stream()
-                .map(a -> mediaFileDao.getSongsForAlbum(a.getArtist(), a.getName()).get(0))
+                .map(a -> mediaFileDao.getSongsForAlbum(0L, Integer.MAX_VALUE, a.getArtist(), a.getName()).get(0))
                 .collect(Collectors.toList());
         assertEquals(61, files.size());
         playlistDao.setFilesInPlaylist(playlistUpnpProcessor.getItems(0, 1).get(0).getId(), files);


### PR DESCRIPTION

### Overview

Dao methods mainly related to order queries will be fixed. This does not affect the flow of existing scans.

### Details

Includes fixes such as: Only the last item affects view.

 - Remove unnecessary overloads and standardize methods
 - Remove unnecessary order by
 - Fix year sorting better

### year sorting

Albums are often sorted by year or by Alphabetical. Simply put, traditional order by was 'order by year' or 'order by name'. After this commit, the year order by will be e.g. 

 > `year is null, year (desc), media_file_order`

To be specific...

NAME | YEAR
-- | --
A | null
B | null
C | 2003
D | 2002
E | 2001
F | 2001

This will line up with EFDCAB. For reverse order it is CDEFAB. In short, if the year is not included in the tag due to missing data, it will line up at the end. If the years are the same, they will line up in Alphabetical.

Having a consistent sorting rule makes it easier to notice incomplete tags!


