### PR TITLE
Improve UPDATE_SORT_OF_ARTIST

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/GenericDaoHelper.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/GenericDaoHelper.java
@@ -39,6 +39,7 @@ public class GenericDaoHelper implements DaoHelper {
     public GenericDaoHelper(DataSource dataSource) {
         this.dataSource = dataSource;
         this.jdbcTemplate = new JdbcTemplate(dataSource);
+        jdbcTemplate.setFetchSize(10_000);
         this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -951,8 +951,9 @@ public class MediaFileDao extends AbstractDao {
     }
 
     public List<SortCandidate> getSortOfArtistToBeFixedWithId(@NonNull List<SortCandidate> candidates) {
+        List<SortCandidate> result = new ArrayList<>();
         if (candidates.isEmpty()) {
-            return Collections.emptyList();
+            return result;
         }
         String query = "select 0 as field, :name, :sote, id from media_file "
                 + "where type != :directory and album_artist = :name and album_artist_sort <> :sote and present "
@@ -960,7 +961,6 @@ public class MediaFileDao extends AbstractDao {
                 + "where artist = :name and artist_sort <> :sote and present "
                 + "union select 2 as field, :name, :sote, id from media_file "
                 + "where type = :music and composer = :name and composer_sort <> :sote and present";
-        List<SortCandidate> result = new ArrayList<>();
         Map<String, Object> args = new ConcurrentHashMap<>();
         args.put("directory", MediaType.DIRECTORY.name());
         args.put("music", MediaType.MUSIC.name());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
@@ -967,6 +968,28 @@ public class MediaFileDao extends AbstractDao {
                         + "   and composer in (:names) and (composer_sort is null "
                         + "       or composer_sort not in(:sotes))) to_be_fixed order by id",
                 (rs, rowNum) -> rs.getInt(1), args);
+    }
+
+    public List<SortCandidate> getSortOfArtistToBeFixedWithId(@NonNull List<SortCandidate> candidates) {
+        if (candidates.isEmpty()) {
+            return Collections.emptyList();
+        }
+        String query = "select 0 as field, :name, :sote, id from media_file "
+                + "where type != :directory and album_artist = :name and album_artist_sort <> :sote and present "
+                + "union select 1 as field, :name, :sote, id from media_file "
+                + "where artist = :name and artist_sort <> :sote and present "
+                + "union select 2 as field, :name, :sote, id from media_file "
+                + "where type = :music and composer = :name and composer_sort <> :sote and present";
+        List<SortCandidate> result = new ArrayList<>();
+        Map<String, Object> args = new ConcurrentHashMap<>();
+        args.put("directory", MediaType.DIRECTORY.name());
+        args.put("music", MediaType.MUSIC.name());
+        candidates.forEach(candidate -> {
+            args.put("name", candidate.getName());
+            args.put("sote", candidate.getSort());
+            result.addAll(namedQuery(query, sortCandidateWithIdMapper, args));
+        });
+        return result;
     }
 
     public List<SortCandidate> getSortForAlbumWithoutSorts(List<MusicFolder> folders) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/SortCandidate.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/SortCandidate.java
@@ -30,18 +30,34 @@ public class SortCandidate {
      * The value set in the name tag corresponding to be modified sort tag. The element value of artist, album artist,
      * composer, etc.
      */
+    private CandidateField field;
     private String name;
     private String reading;
+    private int id;
 
     /**
      * Correction value for sort tag
      */
     private String sort;
 
-    public SortCandidate(String name, String sort) {
+    public SortCandidate(int field, String name, String sort, int... id) {
         super();
+        this.field = CandidateField.of(field);
         this.name = name;
         this.sort = sort;
+        if (id.length == 0) {
+            this.id = -1;
+        } else {
+            this.id = id[0];
+        }
+    }
+
+    public @NonNull CandidateField getField() {
+        return field;
+    }
+
+    public void setField(CandidateField field) {
+        this.field = field;
     }
 
     public @NonNull String getName() {
@@ -68,4 +84,37 @@ public class SortCandidate {
         this.sort = sort;
     }
 
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public enum CandidateField {
+
+        UNKNOWN(-1), ALBUM_ARTIST(0), ARTIST(1), COMPOSER(2), ALBUM(3);
+
+        private final int value;
+
+        CandidateField(int value) {
+            this.value = value;
+        }
+
+        static CandidateField of(int v) {
+            if (ALBUM_ARTIST.getValue() == v) {
+                return ALBUM_ARTIST;
+            } else if (ARTIST.getValue() == v) {
+                return ARTIST;
+            } else if (COMPOSER.getValue() == v) {
+                return COMPOSER;
+            }
+            return UNKNOWN;
+        }
+
+        public int getValue() {
+            return value;
+        }
+    }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
@@ -98,9 +98,9 @@ public class SortProcedureService {
     }
 
     List<Integer> copySortOfArtist(List<MusicFolder> folders) {
-        List<SortCandidate> candidates = mediaFileDao.getCopyableSortForPersons(folders);
-        candidates.forEach(utils::analyze);
-        return updateSortOfArtist(candidates);
+        List<SortCandidate> candidatesWithId = mediaFileDao.getCopyableSortForPersons(folders);
+        candidatesWithId.forEach(utils::analyze);
+        return updateSortOfArtistWithId(candidatesWithId);
     }
 
     List<Integer> mergeSortOfAlbum(List<MusicFolder> folders) {
@@ -191,5 +191,13 @@ public class SortProcedureService {
         List<Integer> toBeFixed = mediaFileDao.getSortOfArtistToBeFixed(candidates);
         candidates.forEach(c -> mediaFileDao.updateArtistSort(c));
         return toBeFixed;
+    }
+
+    private List<Integer> updateSortOfArtistWithId(@NonNull List<SortCandidate> candidatesWithId) {
+        if (candidatesWithId.isEmpty()) {
+            return Collections.emptyList();
+        }
+        candidatesWithId.forEach(c -> mediaFileDao.updateArtistSortWithId(c));
+        return candidatesWithId.stream().map(SortCandidate::getId).collect(Collectors.toList());
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
@@ -86,9 +86,9 @@ public class SortProcedureService {
     }
 
     List<Integer> compensateSortOfArtist(List<MusicFolder> folders) {
-        List<SortCandidate> candidates = mediaFileDao.getSortForPersonWithoutSorts(folders);
-        candidates.forEach(utils::analyze);
-        return updateSortOfArtist(candidates);
+        List<SortCandidate> candidatesWithId = mediaFileDao.getSortForPersonWithoutSorts(folders);
+        candidatesWithId.forEach(utils::analyze);
+        return updateSortOfArtistWithId(candidatesWithId);
     }
 
     List<Integer> copySortOfAlbum(List<MusicFolder> folders) {
@@ -185,15 +185,6 @@ public class SortProcedureService {
         }
         List<Integer> toBeFixed = mediaFileDao.getSortOfAlbumToBeFixed(candidates);
         candidates.forEach(c -> mediaFileDao.updateAlbumSort(c));
-        return toBeFixed;
-    }
-
-    private List<Integer> updateSortOfArtist(@NonNull List<SortCandidate> candidates) {
-        if (candidates.isEmpty()) {
-            return Collections.emptyList();
-        }
-        List<Integer> toBeFixed = mediaFileDao.getSortOfArtistToBeFixed(candidates);
-        candidates.forEach(c -> mediaFileDao.updateArtistSort(c));
         return toBeFixed;
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
@@ -110,9 +110,13 @@ public class SortProcedureService {
     }
 
     List<Integer> mergeSortOfArtist(List<MusicFolder> folders) {
-        List<SortCandidate> candidates = mediaFileDao.guessPersonsSorts(folders);
-        candidates.forEach(utils::analyze);
-        return updateSortOfArtist(candidates);
+        List<SortCandidate> candidatesWithoutId = mediaFileDao.guessPersonsSorts(folders);
+        if (candidatesWithoutId.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<SortCandidate> candidatesWithId = mediaFileDao.getSortOfArtistToBeFixedWithId(candidatesWithoutId);
+        candidatesWithId.forEach(utils::analyze);
+        return updateSortOfArtistWithId(candidatesWithId);
     }
 
     <T extends Orderable> List<T> getToBeOrderUpdate(List<T> list, Comparator<T> comparator) {

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JapaneseReadingUtilsTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JapaneseReadingUtilsTest.java
@@ -1143,7 +1143,7 @@ class JapaneseReadingUtilsTest {
 
         @Test
         void testNullSort() {
-            SortCandidate candidate = new SortCandidate(nameRaw, null);
+            SortCandidate candidate = new SortCandidate(-1, nameRaw, null);
             utils.analyze(candidate);
             assertEquals(nameRaw, candidate.getName());
             assertEquals(readingAnalyzedFromName, candidate.getReading());
@@ -1152,7 +1152,7 @@ class JapaneseReadingUtilsTest {
 
         @Test
         void testNotNullSort() {
-            SortCandidate candidate = new SortCandidate(nameRaw, sortRaw);
+            SortCandidate candidate = new SortCandidate(-1, nameRaw, sortRaw);
             utils.analyze(candidate);
             assertEquals(nameRaw, candidate.getName());
             assertEquals(readingAnalyzedFromSort, candidate.getReading());


### PR DESCRIPTION
### Overview

One of the scanning processes, UPDATE_SORT_OF_ARTIST, is sped up.

> UPDATE_SORT_OF_ARTIST merges, copies, and compensates sort tags. This feature is for languages that strongly rely on sorting tags, such as Japanese.
> 
>  - Merge : If multiple pronunciations are registered for a person's name, they are merged into a single value. The order of > priority will be Alba Artist, Artist, Composer, and if there are duplicates, it will be judged by the file update date.
>  - Copy : If any of the sort tags are null for the same person name, it will be copied from the available data.
>  - Compensate : If the Japanese name is not resolved by Merge/Copy (the tag is completely missing in the library), it will be parsed based on the artist name.

Ideally, the tags of all music files should be completely managed, but in reality, it may be difficult to strictly manage tens of thousands of files. UPDATE_SORT_OF_ARTIST is a process for automatically managing sort tags with a certain degree of accuracy.

### Fixes

 - Spring's JdbcTemplate fetch size will be changed to 10,000. (Buffer size when mapping values obtained from DB on the Java side)
   - The main effect is seen during scanning. Especially with hundreds of thousands of songs or more, it will be clear.
   - Global definitions will be changed (not just during scanning). This is because there is no particular adverse effect outside of scanning. Dare I say REST Artist-All or Album-All. However, these are seldom used in Apps...
 - The update query performed by UPDATE_SORT_OF_ARTIST will be replaced with an update query with id as the key.

### Effect

<details>
<summary>For dummy data of 400,000 songs</summary>

Well, speeding up has only just begun. 

![image](https://github.com/tesshucom/jpsonic/assets/27724847/655f868c-e8b2-48b5-980c-72e654221e97)

Copying will occur even in libraries with fully well-formed tag management. The identity of this Copy is Copy for File Structure-Artist. (The sort tag isn't registered for the directory name, right?)

![image](https://github.com/tesshucom/jpsonic/assets/27724847/7c409b5d-6625-488e-94e0-bcc4a45e89a3)

</details>

If you are an English-speaking person and you think this process is unnecessary, you can turn it off in the Advanced Settings Page. If you are okay with that.

___

However, in the case of a general user's library, which has several thousand to tens of thousands of songs, the time required for this is within the margin of error. Also, since this process is a cumulative update, the next scan will not count the updated data.

The following data is not a dummy, but a real result when scanning about 5000 FLAC songs automatically citing data from CDDB at the time of ripping. I think 1 second is acceptable!

![image](https://github.com/tesshucom/jpsonic/assets/27724847/b54d1c74-0146-423d-9575-81a9b221ae8c)

 - In the case of Japanese, sorting tags in CDDB are not necessarily clean data. Since there are many character types, typos and notation variations may be included.
 - By design, this is a necessary step to prevent missing searches.
 - It is very closely related to highly-accurate-sorting. 
 - And they are related to operational accuracy when using screen readers and voice input.
 - Possibly, it's a gimmick that could also work for languages with similar characteristics to Japanese.
