### PR TITLE
Improve stats gathering

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -307,17 +307,6 @@ public class MediaFileDao extends AbstractDao {
         }
     }
 
-    public long getTotalBytes(MusicFolder folder) {
-        return queryForLong("select sum(file_size) from media_file where present and folder = ? and type = 'MUSIC'", 0L,
-                folder.getPathString());
-    }
-
-    public long getTotalSeconds(MusicFolder folder) {
-        return queryForLong(
-                "select sum(duration_seconds) from media_file where present and folder = ? and type = 'MUSIC'", 0L,
-                folder.getPathString());
-    }
-
     public List<MediaFile> getMostFrequentlyPlayedAlbums(final int offset, final int count,
             final List<MusicFolder> musicFolders) {
         if (musicFolders.isEmpty()) {
@@ -682,23 +671,6 @@ public class MediaFileDao extends AbstractDao {
                 MusicFolder.toPathList(musicFolders));
         return namedQueryForInt(
                 "select count(*) from media_file where type = :type and folder in (:folders) and present", 0, args);
-    }
-
-    public int getArtistCount(MusicFolder folder) {
-        return queryForInt(
-                "select count(*) from media_file right join music_folder on music_folder.path = media_file.folder "
-                        + "where present and folder = ? and type = ? and media_file.path <> folder",
-                0, folder.getPathString(), MediaFile.MediaType.DIRECTORY.name());
-    }
-
-    public int getSongCount(MusicFolder folder) {
-        return queryForInt("select count(*) from media_file where present and folder = ? and type = ?", 0,
-                folder.getPathString(), MediaFile.MediaType.MUSIC.name());
-    }
-
-    public int getVideoCount(MusicFolder folder) {
-        return queryForInt("select count(*) from media_file where present and folder = ? and type = ?", 0,
-                folder.getPathString(), MediaFile.MediaType.VIDEO.name());
     }
 
     public int getPlayedAlbumCount(final List<MusicFolder> musicFolders) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
@@ -799,17 +799,10 @@ public class ScannerProcedureService {
             return;
         }
         writeInfo("Collecting media library statistics ...");
-        MediaLibraryStatistics stats = new MediaLibraryStatistics(scanDate);
-        for (MusicFolder folder : musicFolderService.getAllMusicFolders()) {
-            stats.setFolderId(folder.getId());
-            stats.setArtistCount(mediaFileDao.getArtistCount(folder));
-            stats.setAlbumCount(mediaFileDao.getAlbumCount(Arrays.asList(folder)));
-            stats.setSongCount(mediaFileDao.getSongCount(folder));
-            stats.setVideoCount(mediaFileDao.getVideoCount(folder));
-            stats.setTotalDuration(mediaFileDao.getTotalSeconds(folder));
-            stats.setTotalSize(mediaFileDao.getTotalBytes(folder));
+        musicFolderService.getAllMusicFolders().forEach(folder -> {
+            MediaLibraryStatistics stats = staticsDao.gatherMediaLibraryStatistics(scanDate, folder);
             staticsDao.createMediaLibraryStatistics(stats);
-        }
+        });
         createScanEvent(scanDate, ScanEventType.RUN_STATS, null);
     }
 


### PR DESCRIPTION

### Overview

It speeds up the statistics collection 'RUN_STATS'  that is performed at the end of the scan. 

### Fixes

Queries that had been run per item will be consolidated. This will increase the speed by about 5x. Less than a second for thousands to tens of thousands of small libraries. About 30 seconds for a library of 400,000 songs with 40 music directories. (Based on current statistics items)

### Non-Goal

 - Statistics collection itself is essentially a feature that can be separated from the Scan Process. (For example, after the scan is finished, you can proceed as a low-load background process.) There are no such design changes in this phase. 





