### PR TITLE
Improve UPDATE_SORT_OF_ALBUM

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -946,11 +946,11 @@ public class MediaFileDao extends AbstractDao {
         if (folders.isEmpty()) {
             return Collections.emptyList();
         }
-        Map<String, Object> args = Map.of("type", MediaFile.MediaType.ALBUM.name(), "folders",
+        Map<String, Object> args = Map.of("type", MediaType.DIRECTORY.name(), "folders",
                 MusicFolder.toPathList(folders));
-        return namedQuery("select distinct 3 as field, album as name, null as sort from media_file "
-                + "where present and folder in (:folders) and type = :type and (album is not null and album_sort is null) ",
-                sortCandidateMapper, args);
+        return namedQuery("select distinct 3 as field, album as name, null as sort, id from media_file "
+                + "where present and folder in (:folders) and type <> :type and (album is not null and album_sort is null) ",
+                sortCandidateWithIdMapper, args);
     }
 
     public List<SortCandidate> guessAlbumSorts(List<MusicFolder> folders) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -780,15 +780,14 @@ public class MediaFileDao extends AbstractDao {
         if (folders.isEmpty()) {
             return Collections.emptyList();
         }
-        Map<String, Object> args = Map.of("type", MediaFile.MediaType.ALBUM.name(), "folders",
+        Map<String, Object> args = Map.of("type", MediaFile.MediaType.DIRECTORY.name(), "folders",
                 MusicFolder.toPathList(folders));
-        return namedQuery(
-                "select 3 as field, known.name , known.sort from (select distinct album as name from media_file "
-                        + "where folder in (:folders) and present and type = :type and (album is not null and album_sort is null)) unknown "
-                        + "join (select distinct album as name, album_sort as sort from media_file "
-                        + "where folder in (:folders) and type = :type and album is not null and album_sort is not null and present) known "
-                        + "on known.name = unknown.name ",
-                sortCandidateMapper, args);
+        return namedQuery("select 3 as field, known.name , known.sort, id from ( "
+                + "select distinct album as name, id from media_file "
+                + "where folder in (:folders) and present and album is not null and album_sort is null) unknown "
+                + "join (select distinct album as name, album_sort as sort from media_file "
+                + "where folder in (:folders) and type <> :type and album is not null and album_sort is not null and present) known "
+                + "on known.name = unknown.name ", sortCandidateWithIdMapper, args);
     }
 
     public List<SortCandidate> getCopyableSortForPersons(List<MusicFolder> folders) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
-import java.util.stream.Collectors;
 
 import com.tesshu.jpsonic.domain.Genre;
 import com.tesshu.jpsonic.domain.MediaFile;
@@ -911,15 +910,6 @@ public class MediaFileDao extends AbstractDao {
         return namedQuery(query, sortCandidateWithIdMapper, args);
     }
 
-    public List<Integer> getSortOfAlbumToBeFixed(List<SortCandidate> candidates) {
-        Map<String, Object> args = LegacyMap.of("names",
-                candidates.stream().map(SortCandidate::getName).collect(Collectors.toList()), "sotes",
-                candidates.stream().map(SortCandidate::getSort).collect(Collectors.toList()));
-        return namedQuery("select distinct id from media_file "
-                + "where present and album in (:names) and (album_sort is null or album_sort not in(:sotes))  "
-                + "order by id ", (rs, rowNum) -> rs.getInt(1), args);
-    }
-
     public List<SortCandidate> getSortOfArtistToBeFixedWithId(@NonNull List<SortCandidate> candidates) {
         List<SortCandidate> result = new ArrayList<>();
         if (candidates.isEmpty()) {
@@ -1005,27 +995,9 @@ public class MediaFileDao extends AbstractDao {
         return result;
     }
 
-    public void updateAlbumSort(SortCandidate candidate) {
-        update("update media_file set album_reading = ?, album_sort = ? "
-                + "where present and album = ? and (album_sort is null or album_sort <> ?)", candidate.getReading(),
-                candidate.getSort(), candidate.getName(), candidate.getSort());
-    }
-
     public void updateAlbumSortWithId(SortCandidate candidate) {
         update("update media_file set album_reading = ?, album_sort = ? where present and id = ?",
                 candidate.getReading(), candidate.getSort(), candidate.getId());
-    }
-
-    public void updateArtistSort(SortCandidate candidate) {
-        update("update media_file set artist_reading = ?, artist_sort = ? "
-                + "where present and artist = ? and (artist_sort is null or artist_sort <> ?)", candidate.getReading(),
-                candidate.getSort(), candidate.getName(), candidate.getSort());
-        update("update media_file set album_artist_reading = ?, album_artist_sort = ? "
-                + "where present and type not in ('DIERECTORY', 'ALBUM') and album_artist = ? and (album_artist_sort is null or album_artist_sort <> ?)",
-                candidate.getReading(), candidate.getSort(), candidate.getName(), candidate.getSort());
-        update("update media_file set composer_sort = ? "
-                + "where present and type not in ('DIERECTORY', 'ALBUM') and composer = ? and (composer_sort is null or composer_sort <> ?)",
-                candidate.getSort(), candidate.getName(), candidate.getSort());
     }
 
     public void updateArtistSortWithId(SortCandidate candidate) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
@@ -80,9 +80,9 @@ public class SortProcedureService {
     }
 
     List<Integer> compensateSortOfAlbum(List<MusicFolder> folders) {
-        List<SortCandidate> candidates = mediaFileDao.getSortForAlbumWithoutSorts(folders);
-        candidates.forEach(utils::analyze);
-        return updateSortOfAlbums(candidates);
+        List<SortCandidate> candidatesWithId = mediaFileDao.getSortForAlbumWithoutSorts(folders);
+        candidatesWithId.forEach(utils::analyze);
+        return updateSortOfAlbumsWithId(candidatesWithId);
     }
 
     List<Integer> compensateSortOfArtist(List<MusicFolder> folders) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
@@ -179,15 +179,6 @@ public class SortProcedureService {
         return count.intValue();
     }
 
-    private List<Integer> updateSortOfAlbums(@NonNull List<SortCandidate> candidates) {
-        if (candidates.isEmpty()) {
-            return Collections.emptyList();
-        }
-        List<Integer> toBeFixed = mediaFileDao.getSortOfAlbumToBeFixed(candidates);
-        candidates.forEach(c -> mediaFileDao.updateAlbumSort(c));
-        return toBeFixed;
-    }
-
     private List<Integer> updateSortOfAlbumsWithId(@NonNull List<SortCandidate> candidatesWithId) {
         if (candidatesWithId.isEmpty()) {
             return Collections.emptyList();

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
@@ -92,9 +92,9 @@ public class SortProcedureService {
     }
 
     List<Integer> copySortOfAlbum(List<MusicFolder> folders) {
-        List<SortCandidate> candidates = mediaFileDao.getCopyableSortForAlbums(folders);
-        candidates.forEach(utils::analyze);
-        return updateSortOfAlbums(candidates);
+        List<SortCandidate> candidatesWithId = mediaFileDao.getCopyableSortForAlbums(folders);
+        candidatesWithId.forEach(utils::analyze);
+        return updateSortOfAlbumsWithId(candidatesWithId);
     }
 
     List<Integer> copySortOfArtist(List<MusicFolder> folders) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
@@ -104,9 +104,9 @@ public class SortProcedureService {
     }
 
     List<Integer> mergeSortOfAlbum(List<MusicFolder> folders) {
-        List<SortCandidate> candidates = mediaFileDao.guessAlbumSorts(folders);
-        candidates.forEach(utils::analyze);
-        return updateSortOfAlbums(candidates);
+        List<SortCandidate> candidatesWithId = mediaFileDao.guessAlbumSorts(folders);
+        candidatesWithId.forEach(utils::analyze);
+        return updateSortOfAlbumsWithId(candidatesWithId);
     }
 
     List<Integer> mergeSortOfArtist(List<MusicFolder> folders) {
@@ -186,6 +186,14 @@ public class SortProcedureService {
         List<Integer> toBeFixed = mediaFileDao.getSortOfAlbumToBeFixed(candidates);
         candidates.forEach(c -> mediaFileDao.updateAlbumSort(c));
         return toBeFixed;
+    }
+
+    private List<Integer> updateSortOfAlbumsWithId(@NonNull List<SortCandidate> candidatesWithId) {
+        if (candidatesWithId.isEmpty()) {
+            return Collections.emptyList();
+        }
+        candidatesWithId.forEach(c -> mediaFileDao.updateAlbumSortWithId(c));
+        return candidatesWithId.stream().map(SortCandidate::getId).collect(Collectors.toList());
     }
 
     private List<Integer> updateSortOfArtistWithId(@NonNull List<SortCandidate> candidatesWithId) {


### PR DESCRIPTION
Related : #2280

### Overview

One of the scanning processes, UPDATE_SORT_OF_ALBUM, is speed up.


![image](https://github.com/tesshucom/jpsonic/assets/27724847/5bf5873b-2d7b-4cc3-8898-8c5052264128)

> Depends on the conditions!
> A reasonably large library is assumed. For small libraries there may be slightly more overhead. Albums are often tagged with higher quality than the artist. Therefore, the expected speedup effect may not be as high as compared to Artist. 

