### PR TITLE
Change log level of SSDP from WARN to ERROR

### DIFF
--- a/jpsonic-main/src/main/resources/application.properties
+++ b/jpsonic-main/src/main/resources/application.properties
@@ -14,6 +14,7 @@ logging.level.org.eclipse.jetty.io.AbstractConnection=ERROR
 logging.level.com.tesshu.jpsonic.spring.AirsonicHsqlDatabase=WARN
 logging.level.com.tesshu.jpsonic.Application=INFO
 logging.level.com.tesshu.jpsonic.service.VersionService=INFO
+logging.level.org.fourthline.cling.protocol.RetrieveRemoteDescriptors=ERROR
 logging.pattern.console=%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p){green} %clr(---){faint} %clr(%-40.40logger{32}){blue} %clr(:){faint} %m%n%wEx
 logging.pattern.file=%d{yyyy-MM-dd HH:mm:ss.SSS} %5p --- %-40.40logger{32} : %m%n%wEx
 


### PR DESCRIPTION
Logging for SSDP will be suppressed. Common log design flaws.

## Problem description

 - Depending on the document descriptor provided by the device, a format warning may appear when searching for SSDP when UPnP is started.
 - If a warning occurs, the log will record the UDN and Port of the target SSDP (network card, etc.)
   - The URL of the published SSDP XML is logged
 - In Jpsonic default, logs can only be viewed by accounts with Admin privileges, so they are not an immediate threat. However, since this warning is not necessary during operation except during development, it is appropriate to suppress it.
 - It doesn't occur at all depending on the devices present in the LAN.


### Steps to reproduce

 - Connect a device on your LAN network that provides the Document Descriptor in incomplete format and enable UPnP
   - Such as providing the Document Descriptor, such as an empty dummy.xml.
   - Or use a device with such specifications. DSM, etc.

## System information

 * **Jpsonic version**: 112.1.7
   * However, the Jpsonic version is irrelevant. I noticed this issue recently. But A similar issue had been reported on PleX about a year ago. (Reporting when using DSM. The cause and effect are very similar.)


