### PR TITLE
Add wait to scan thread

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AlbumDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AlbumDao.java
@@ -122,8 +122,8 @@ public class AlbumDao extends AbstractDao {
         return null;
     }
 
-    public int updateOrder(String artist, String name, int order) {
-        return update("update album set album_order = ? where artist=? and name=?", order, artist, name);
+    public int updateOrder(int id, int order) {
+        return update("update album set album_order = ? where id=?", order, id);
     }
 
     public void updateCoverArtPath(String artist, String name, String coverArtPath) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/ArtistDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/ArtistDao.java
@@ -100,8 +100,8 @@ public class ArtistDao extends AbstractDao {
         return null;
     }
 
-    public int updateOrder(String name, int order) {
-        return update("update artist set artist_order=? where name=?", order, name);
+    public int updateOrder(int id, int order) {
+        return update("update artist set artist_order=? where id=?", order, id);
     }
 
     public List<Artist> getAlphabetialArtists(final int offset, final int count, final List<MusicFolder> musicFolders) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -232,7 +232,7 @@ public class MediaFileDao extends AbstractDao {
         return null;
     }
 
-    public @Nullable MediaFile updateMediaFile(MediaFile file) {
+    public Optional<MediaFile> updateMediaFile(MediaFile file) {
         String sql = "update media_file set folder=?, type=?, format=?, title=?, album=?, "
                 + "artist=?, album_artist=?, disc_number=?, track_number=?, year=?, genre=?, "
                 + "bit_rate=?, variable_bit_rate=?, duration_seconds=?, file_size=?, width=?, "
@@ -255,9 +255,9 @@ public class MediaFileDao extends AbstractDao {
                 file.getAlbumArtistReading(), file.getArtistSortRaw(), file.getAlbumSortRaw(),
                 file.getAlbumArtistSortRaw(), file.getComposerSortRaw(), file.getOrder(), file.getPathString());
         if (c > 0) {
-            return file;
+            return Optional.of(file);
         }
-        return null;
+        return Optional.empty();
     }
 
     public void updateChildrenLastUpdated(String pathString, Instant childrenLastUpdated) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -242,7 +242,7 @@ public class MediaFileDao extends AbstractDao {
                 + "composer=?, artist_sort=?, album_sort=?, title_sort=?, "
                 + "album_artist_sort=?, composer_sort=?, artist_reading=?, album_reading=?, "
                 + "album_artist_reading=?, artist_sort_raw=?, album_sort_raw=?, "
-                + "album_artist_sort_raw=?, composer_sort_raw=?, media_file_order=? where path=?";
+                + "album_artist_sort_raw=?, composer_sort_raw=?, media_file_order=? where id=?";
         int c = update(sql, file.getFolder(), file.getMediaType().name(), file.getFormat(), file.getTitle(),
                 file.getAlbumName(), file.getArtist(), file.getAlbumArtist(), file.getDiscNumber(),
                 file.getTrackNumber(), file.getYear(), file.getGenre(), file.getBitRate(), file.isVariableBitRate(),
@@ -253,7 +253,7 @@ public class MediaFileDao extends AbstractDao {
                 file.getComposer(), file.getArtistSort(), file.getAlbumSort(), file.getTitleSort(),
                 file.getAlbumArtistSort(), file.getComposerSort(), file.getArtistReading(), file.getAlbumReading(),
                 file.getAlbumArtistReading(), file.getArtistSortRaw(), file.getAlbumSortRaw(),
-                file.getAlbumArtistSortRaw(), file.getComposerSortRaw(), file.getOrder(), file.getPathString());
+                file.getAlbumArtistSortRaw(), file.getComposerSortRaw(), file.getOrder(), file.getId());
         if (c > 0) {
             return Optional.of(file);
         }
@@ -483,17 +483,6 @@ public class MediaFileDao extends AbstractDao {
                 MusicFolder.toPathList(folders), "future", FAR_FUTURE, "count", count);
         return namedQuery("select " + QUERY_COLUMNS
                 + " from media_file where type = :type and present and folder in (:folders) and last_scanned = :future limit :count",
-                rowMapper, args);
-    }
-
-    public @Nullable MediaFile getFetchedFirstChildOf(MediaFile album) {
-        Map<String, Object> args = Map.of("types",
-                Arrays.asList(MediaFile.MediaType.MUSIC.name(), MediaFile.MediaType.PODCAST.name(),
-                        MediaFile.MediaType.AUDIOBOOK.name(), MediaFile.MediaType.VIDEO.name()),
-                "albumpath", album.getPathString());
-        return namedQueryOne("select " + QUERY_COLUMNS + ", "
-                + "case when album_artist is null then 1 when album is null then 2 else 0 end is_valid "
-                + "from media_file where present and parent_path=:albumpath and type in (:types) order by is_valid, media_file_order limit 1",
                 rowMapper, args);
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -750,14 +750,16 @@ public class MediaFileDao extends AbstractDao {
                 MediaFile.MediaType.AUDIOBOOK.name(), MediaFile.MediaType.VIDEO.name());
     }
 
-    public void expunge() {
-        int minId = queryForInt("select min(id) from media_file where not present", 0);
-        int maxId = queryForInt("select max(id) from media_file where not present", 0);
+    public int getMinId() {
+        return queryForInt("select min(id) from media_file where not present", 0);
+    }
 
-        final int batchSize = 1000;
-        for (int id = minId; id <= maxId; id += batchSize) {
-            update("delete from media_file where id between ? and ? and not present", id, id + batchSize);
-        }
+    public int getMaxId() {
+        return queryForInt("select max(id) from media_file where not present", 0);
+    }
+
+    public int expunge(int from, int to) {
+        return update("delete from media_file where id between ? and ? and not present", from, to);
     }
 
     public List<MediaFile> getArtistAll(final List<MusicFolder> musicFolders) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -265,8 +265,8 @@ public class MediaFileDao extends AbstractDao {
                 pathString);
     }
 
-    public int updateOrder(String pathString, int order) {
-        return update("update media_file set media_file_order = ? where path=?", order, pathString);
+    public int updateOrder(int id, int order) {
+        return update("update media_file set media_file_order = ? where id=?", order, id);
     }
 
     public void updateCoverArtPath(String pathString, String coverArtPath) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
@@ -855,14 +855,18 @@ public class ScannerProcedureService {
     }
 
     void runStats(@NonNull Instant scanDate) {
-        if (isInterrupted()) {
-            return;
-        }
         writeInfo("Collecting media library statistics ...");
-        musicFolderService.getAllMusicFolders().forEach(folder -> {
-            MediaLibraryStatistics stats = staticsDao.gatherMediaLibraryStatistics(scanDate, folder);
+        List<MusicFolder> folders = musicFolderService.getAllMusicFolders();
+        for (int i = 0; i < folders.size(); i++) {
+            if (i % 4 == 0) {
+                repeatWait();
+                if (isInterrupted()) {
+                    return;
+                }
+            }
+            MediaLibraryStatistics stats = staticsDao.gatherMediaLibraryStatistics(scanDate, folders.get(i));
             staticsDao.createMediaLibraryStatistics(stats);
-        });
+        }
         createScanEvent(scanDate, ScanEventType.RUN_STATS, null);
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/SortProcedureService.java
@@ -19,26 +19,14 @@
 
 package com.tesshu.jpsonic.service.scanner;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
-import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
 
-import com.tesshu.jpsonic.dao.AlbumDao;
-import com.tesshu.jpsonic.dao.ArtistDao;
 import com.tesshu.jpsonic.dao.MediaFileDao;
-import com.tesshu.jpsonic.domain.Album;
-import com.tesshu.jpsonic.domain.Artist;
 import com.tesshu.jpsonic.domain.JapaneseReadingUtils;
-import com.tesshu.jpsonic.domain.JpsonicComparators;
-import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.domain.MusicFolder;
-import com.tesshu.jpsonic.domain.Orderable;
 import com.tesshu.jpsonic.domain.SortCandidate;
-import com.tesshu.jpsonic.service.MediaFileService;
-import com.tesshu.jpsonic.service.MusicFolderService;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Service;
@@ -52,27 +40,13 @@ import org.springframework.stereotype.Service;
         "jpsonicComparators" })
 public class SortProcedureService {
 
-    private final MusicFolderService musicFolderService;
-    private final MediaFileService mediaFileService;
-    private final WritableMediaFileService writableMediaFileService;
     private final MediaFileDao mediaFileDao;
-    private final ArtistDao artistDao;
-    private final AlbumDao albumDao;
     private final JapaneseReadingUtils utils;
-    private final JpsonicComparators comparators;
 
-    public SortProcedureService(MusicFolderService musicFolderService, MediaFileService mediaFileService,
-            WritableMediaFileService writableMediaFileService, MediaFileDao mediaFileDao, ArtistDao artistDao,
-            AlbumDao albumDao, JapaneseReadingUtils utils, JpsonicComparators jpsonicComparator) {
+    public SortProcedureService(MediaFileDao mediaFileDao, JapaneseReadingUtils utils) {
         super();
-        this.musicFolderService = musicFolderService;
-        this.mediaFileService = mediaFileService;
-        this.writableMediaFileService = writableMediaFileService;
         this.mediaFileDao = mediaFileDao;
-        this.artistDao = artistDao;
-        this.albumDao = albumDao;
         this.utils = utils;
-        this.comparators = jpsonicComparator;
     }
 
     void clearMemoryCache() {
@@ -117,66 +91,6 @@ public class SortProcedureService {
         List<SortCandidate> candidatesWithId = mediaFileDao.getSortOfArtistToBeFixedWithId(candidatesWithoutId);
         candidatesWithId.forEach(utils::analyze);
         return updateSortOfArtistWithId(candidatesWithId);
-    }
-
-    <T extends Orderable> List<T> getToBeOrderUpdate(List<T> list, Comparator<T> comparator) {
-        List<Integer> rawOrders = list.stream().map(Orderable::getOrder).collect(Collectors.toList());
-        Collections.sort(list, comparator);
-        List<T> result = new ArrayList<>();
-        for (int i = 0; i < list.size(); i++) {
-            if (i + 1 != rawOrders.get(i)) {
-                list.get(i).setOrder(i + 1);
-                result.add(list.get(i));
-            }
-        }
-        return result;
-    }
-
-    int updateOrderOfAlbumID3() {
-        List<MusicFolder> folders = musicFolderService.getAllMusicFolders();
-        List<Album> albums = albumDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, false, false, folders);
-        LongAdder count = new LongAdder();
-        getToBeOrderUpdate(albums, comparators.albumOrderByAlpha()).forEach(
-                album -> count.add(albumDao.updateOrder(album.getArtist(), album.getName(), album.getOrder())));
-        return count.intValue();
-    }
-
-    int updateOrderOfArtistID3() {
-        List<MusicFolder> folders = musicFolderService.getAllMusicFolders();
-        List<Artist> artists = artistDao.getAlphabetialArtists(0, Integer.MAX_VALUE, folders);
-        LongAdder count = new LongAdder();
-        getToBeOrderUpdate(artists, comparators.artistOrderByAlpha())
-                .forEach(artist -> count.add(artistDao.updateOrder(artist.getName(), artist.getOrder())));
-        return count.intValue();
-    }
-
-    int updateOrderOfArtist() {
-        List<MusicFolder> folders = musicFolderService.getAllMusicFolders();
-        List<MediaFile> artists = mediaFileDao.getArtistAll(folders);
-        LongAdder count = new LongAdder();
-        getToBeOrderUpdate(artists, comparators.mediaFileOrderByAlpha())
-                .forEach(artist -> count.add(writableMediaFileService.updateOrder(artist)));
-        return count.intValue();
-    }
-
-    int updateOrderOfAlbum() {
-        List<MusicFolder> folders = musicFolderService.getAllMusicFolders();
-        List<MediaFile> albums = mediaFileService.getAlphabeticalAlbums(0, Integer.MAX_VALUE, false, folders);
-        LongAdder count = new LongAdder();
-        getToBeOrderUpdate(albums, comparators.mediaFileOrderByAlpha())
-                .forEach(album -> count.add(writableMediaFileService.updateOrder(album)));
-        return count.intValue();
-    }
-
-    int updateOrderOfSongs(MediaFile parent) {
-        List<MediaFile> songs = mediaFileDao.getChildrenWithOrderOf(parent.getPathString()).stream()
-                .filter(child -> mediaFileService.isAudioFile(child.getFormat())
-                        || mediaFileService.isVideoFile(child.getFormat()))
-                .collect(Collectors.toList());
-        LongAdder count = new LongAdder();
-        getToBeOrderUpdate(songs, comparators.songsDefault())
-                .forEach(song -> count.add(writableMediaFileService.updateOrder(song)));
-        return count.intValue();
     }
 
     private List<Integer> updateSortOfAlbumsWithId(@NonNull List<SortCandidate> candidatesWithId) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/WritableMediaFileService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/WritableMediaFileService.java
@@ -470,12 +470,14 @@ public class WritableMediaFileService {
     @SuppressLint(value = "NULL_DEREFERENCE", justification = "False positive. parseMediaFile is NonNull")
     Optional<MediaFile> refreshMediaFile(@NonNull Instant scanDate, @NonNull MediaFile registered) {
         MediaFile parsed = parseMediaFile(scanDate, registered.toPath(), registered);
-        MediaFile updated = mediaFileDao.updateMediaFile(parsed);
-        if (updated != null && updated.getMediaType() != MediaType.ALBUM) {
-            indexManager.index(updated);
-        }
+        Optional<MediaFile> updated = mediaFileDao.updateMediaFile(parsed);
+        updated.ifPresent(m -> {
+            if (m.getMediaType() != MediaType.ALBUM) {
+                indexManager.index(m);
+            }
+        });
         mediaFileCache.remove(parsed.toPath());
-        return Optional.ofNullable(updated);
+        return updated;
     }
 
     // Updateable even during scanning

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/WritableMediaFileService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/WritableMediaFileService.java
@@ -454,7 +454,7 @@ public class WritableMediaFileService {
     }
 
     int updateOrder(@NonNull final MediaFile file) {
-        return mediaFileDao.updateOrder(file.getPathString(), file.getOrder());
+        return mediaFileDao.updateOrder(file.getId(), file.getOrder());
     }
 
     /*

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureServiceTest.java
@@ -35,6 +35,8 @@ import com.tesshu.jpsonic.dao.ArtistDao;
 import com.tesshu.jpsonic.dao.MediaFileDao;
 import com.tesshu.jpsonic.dao.StaticsDao;
 import com.tesshu.jpsonic.domain.JapaneseReadingUtils;
+import com.tesshu.jpsonic.domain.JpsonicComparators;
+import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.domain.ScanEvent;
 import com.tesshu.jpsonic.domain.ScanEvent.ScanEventType;
@@ -54,7 +56,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-@SuppressWarnings("PMD.TooManyStaticImports")
+@SuppressWarnings({ "PMD.AvoidDuplicateLiterals", "PMD.TooManyStaticImports" })
 class ScannerProcedureServiceTest {
 
     private SettingsService settingsService;
@@ -77,7 +79,7 @@ class ScannerProcedureServiceTest {
                 mock(IndexManager.class), mediaFileService, writableMediaFileService, mock(PlaylistService.class),
                 mediaFileDao, mock(ArtistDao.class), albumDao, staticsDao, mock(SortProcedureService.class),
                 new ScannerStateServiceImpl(staticsDao), mock(Ehcache.class), mock(MediaFileCache.class),
-                mock(JapaneseReadingUtils.class), mock(ThreadPoolTaskExecutor.class));
+                mock(JapaneseReadingUtils.class), mock(JpsonicComparators.class), mock(ThreadPoolTaskExecutor.class));
     }
 
     @Nested
@@ -186,5 +188,56 @@ class ScannerProcedureServiceTest {
         Mockito.doNothing().when(staticsDao).createScanEvent(eventCap.capture());
         scannerProcedureService.createScanEvent(startDate, ScanEventType.PARSE_FILE_STRUCTURE, null);
         assertNotEquals(-1, eventCap.getValue().getFreeMemory());
+    }
+
+    @Test
+    void testGetToBeOrderUpdate() {
+
+        MediaFile m1 = new MediaFile();
+        m1.setPathString("path1");
+        m1.setPresent(true);
+        m1.setOrder(1);
+        MediaFile m2 = new MediaFile();
+        m2.setPathString("path2");
+        m2.setPresent(true);
+        m2.setOrder(2);
+        MediaFile m3 = new MediaFile();
+        m3.setPathString("path3");
+        m3.setPresent(true);
+        m3.setOrder(3);
+
+        JapaneseReadingUtils readingUtils = mock(JapaneseReadingUtils.class);
+        JpsonicComparators comparators = new JpsonicComparators(mock(SettingsService.class), readingUtils);
+
+        List<MediaFile> result = scannerProcedureService.getToBeOrderUpdate(Arrays.asList(m2, m3, m1),
+                comparators.songsDefault());
+        assertEquals(3, result.size());
+        assertEquals("path1", result.get(0).getPathString());
+        assertEquals("path2", result.get(1).getPathString());
+        assertEquals("path3", result.get(2).getPathString());
+        result = scannerProcedureService.getToBeOrderUpdate(result, comparators.songsDefault());
+        assertEquals(0, result.size());
+
+        m1.setOrder(3);
+        m2.setOrder(2);
+        m3.setOrder(1);
+        result = scannerProcedureService.getToBeOrderUpdate(Arrays.asList(m1, m2, m3), comparators.songsDefault());
+        assertEquals(2, result.size());
+        assertEquals("path1", result.get(0).getPathString());
+        assertEquals(1, result.get(0).getOrder());
+        assertEquals("path3", result.get(1).getPathString());
+        assertEquals(3, result.get(1).getOrder());
+
+        result = scannerProcedureService.getToBeOrderUpdate(result, comparators.songsDefault());
+        assertEquals(1, result.size());
+        assertEquals("path3", result.get(0).getPathString());
+        assertEquals(2, result.get(0).getOrder());
+
+        result = scannerProcedureService.getToBeOrderUpdate(result, comparators.songsDefault());
+        assertEquals(1, result.size());
+        assertEquals(1, result.get(0).getOrder());
+
+        result = scannerProcedureService.getToBeOrderUpdate(result, comparators.songsDefault());
+        assertEquals(0, result.size());
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureServiceTest.java
@@ -191,7 +191,7 @@ class ScannerProcedureServiceTest {
     }
 
     @Test
-    void testGetToBeOrderUpdate() {
+    void testInvokeUpdateOrder() {
 
         MediaFile m1 = new MediaFile();
         m1.setPathString("path1");
@@ -208,36 +208,58 @@ class ScannerProcedureServiceTest {
 
         JapaneseReadingUtils readingUtils = mock(JapaneseReadingUtils.class);
         JpsonicComparators comparators = new JpsonicComparators(mock(SettingsService.class), readingUtils);
+        WritableMediaFileService wmfs = mock(WritableMediaFileService.class);
 
-        List<MediaFile> result = scannerProcedureService.getToBeOrderUpdate(Arrays.asList(m2, m3, m1),
-                comparators.songsDefault());
+        ArgumentCaptor<MediaFile> captor = ArgumentCaptor.forClass(MediaFile.class);
+        Mockito.when(wmfs.updateOrder(captor.capture())).thenReturn(1);
+
+        int count = scannerProcedureService.invokeUpdateOrder(Arrays.asList(m2, m3, m1), comparators.songsDefault(),
+                (song) -> wmfs.updateOrder(song));
+        assertEquals(3, count);
+
+        List<MediaFile> result = captor.getAllValues();
         assertEquals(3, result.size());
         assertEquals("path1", result.get(0).getPathString());
         assertEquals("path2", result.get(1).getPathString());
         assertEquals("path3", result.get(2).getPathString());
-        result = scannerProcedureService.getToBeOrderUpdate(result, comparators.songsDefault());
-        assertEquals(0, result.size());
+
+        captor = ArgumentCaptor.forClass(MediaFile.class);
+        Mockito.when(wmfs.updateOrder(captor.capture())).thenReturn(1);
+        scannerProcedureService.invokeUpdateOrder(result, comparators.songsDefault(), (song) -> wmfs.updateOrder(song));
+        assertEquals(0, captor.getAllValues().size());
 
         m1.setOrder(3);
         m2.setOrder(2);
         m3.setOrder(1);
-        result = scannerProcedureService.getToBeOrderUpdate(Arrays.asList(m1, m2, m3), comparators.songsDefault());
+        count = scannerProcedureService.invokeUpdateOrder(Arrays.asList(m1, m2, m3), comparators.songsDefault(),
+                (song) -> wmfs.updateOrder(song));
+        assertEquals(2, count);
+        result = captor.getAllValues();
         assertEquals(2, result.size());
         assertEquals("path1", result.get(0).getPathString());
         assertEquals(1, result.get(0).getOrder());
         assertEquals("path3", result.get(1).getPathString());
         assertEquals(3, result.get(1).getOrder());
 
-        result = scannerProcedureService.getToBeOrderUpdate(result, comparators.songsDefault());
+        captor = ArgumentCaptor.forClass(MediaFile.class);
+        Mockito.when(wmfs.updateOrder(captor.capture())).thenReturn(1);
+        scannerProcedureService.invokeUpdateOrder(result, comparators.songsDefault(), (song) -> wmfs.updateOrder(song));
+        result = captor.getAllValues();
         assertEquals(1, result.size());
         assertEquals("path3", result.get(0).getPathString());
         assertEquals(2, result.get(0).getOrder());
 
-        result = scannerProcedureService.getToBeOrderUpdate(result, comparators.songsDefault());
+        captor = ArgumentCaptor.forClass(MediaFile.class);
+        Mockito.when(wmfs.updateOrder(captor.capture())).thenReturn(1);
+        scannerProcedureService.invokeUpdateOrder(result, comparators.songsDefault(), (song) -> wmfs.updateOrder(song));
+        result = captor.getAllValues();
         assertEquals(1, result.size());
         assertEquals(1, result.get(0).getOrder());
 
-        result = scannerProcedureService.getToBeOrderUpdate(result, comparators.songsDefault());
+        captor = ArgumentCaptor.forClass(MediaFile.class);
+        Mockito.when(wmfs.updateOrder(captor.capture())).thenReturn(1);
+        scannerProcedureService.invokeUpdateOrder(result, comparators.songsDefault(), (song) -> wmfs.updateOrder(song));
+        result = captor.getAllValues();
         assertEquals(0, result.size());
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/SortProcedureServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/SortProcedureServiceTest.java
@@ -19,7 +19,6 @@
 
 package com.tesshu.jpsonic.service.scanner;
 
-import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
 import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -36,14 +35,9 @@ import com.tesshu.jpsonic.dao.ArtistDao;
 import com.tesshu.jpsonic.dao.MediaFileDao;
 import com.tesshu.jpsonic.domain.Album;
 import com.tesshu.jpsonic.domain.Artist;
-import com.tesshu.jpsonic.domain.JapaneseReadingUtils;
-import com.tesshu.jpsonic.domain.JpsonicComparators;
 import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.domain.ScanLog.ScanLogType;
-import com.tesshu.jpsonic.service.MediaFileService;
-import com.tesshu.jpsonic.service.MusicFolderService;
-import com.tesshu.jpsonic.service.SettingsService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.Nested;
@@ -814,60 +808,5 @@ class SortProcedureServiceTest {
             assertEquals(2L, albumId3s.stream().filter(a -> "albumD".equals(a.getNameSort())).count()); // merged
             assertEquals(1L, albumId3s.stream().filter(a -> "ニホンゴノアルバムメイ".equals(a.getNameSort())).count()); // compensated
         }
-    }
-
-    @Test
-    void testGetToBeOrderUpdate() {
-
-        MediaFile m1 = new MediaFile();
-        m1.setPathString("path1");
-        m1.setPresent(true);
-        m1.setOrder(1);
-        MediaFile m2 = new MediaFile();
-        m2.setPathString("path2");
-        m2.setPresent(true);
-        m2.setOrder(2);
-        MediaFile m3 = new MediaFile();
-        m3.setPathString("path3");
-        m3.setPresent(true);
-        m3.setOrder(3);
-
-        JapaneseReadingUtils readingUtils = mock(JapaneseReadingUtils.class);
-        JpsonicComparators comparators = new JpsonicComparators(mock(SettingsService.class), readingUtils);
-
-        SortProcedureService sortProcedureService = new SortProcedureService(mock(MusicFolderService.class),
-                mock(MediaFileService.class), mock(WritableMediaFileService.class), mock(MediaFileDao.class),
-                mock(ArtistDao.class), mock(AlbumDao.class), readingUtils, comparators);
-
-        List<MediaFile> result = sortProcedureService.getToBeOrderUpdate(Arrays.asList(m2, m3, m1),
-                comparators.songsDefault());
-        assertEquals(3, result.size());
-        assertEquals("path1", result.get(0).getPathString());
-        assertEquals("path2", result.get(1).getPathString());
-        assertEquals("path3", result.get(2).getPathString());
-        result = sortProcedureService.getToBeOrderUpdate(result, comparators.songsDefault());
-        assertEquals(0, result.size());
-
-        m1.setOrder(3);
-        m2.setOrder(2);
-        m3.setOrder(1);
-        result = sortProcedureService.getToBeOrderUpdate(Arrays.asList(m1, m2, m3), comparators.songsDefault());
-        assertEquals(2, result.size());
-        assertEquals("path1", result.get(0).getPathString());
-        assertEquals(1, result.get(0).getOrder());
-        assertEquals("path3", result.get(1).getPathString());
-        assertEquals(3, result.get(1).getOrder());
-
-        result = sortProcedureService.getToBeOrderUpdate(result, comparators.songsDefault());
-        assertEquals(1, result.size());
-        assertEquals("path3", result.get(0).getPathString());
-        assertEquals(2, result.get(0).getOrder());
-
-        result = sortProcedureService.getToBeOrderUpdate(result, comparators.songsDefault());
-        assertEquals(1, result.size());
-        assertEquals(1, result.get(0).getOrder());
-
-        result = sortProcedureService.getToBeOrderUpdate(result, comparators.songsDefault());
-        assertEquals(0, result.size());
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/WritableMediaFileServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/WritableMediaFileServiceTest.java
@@ -42,6 +42,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import com.tesshu.jpsonic.dao.AlbumDao;
@@ -192,7 +193,7 @@ class WritableMediaFileServiceTest {
             MediaFile mediaFile = createMediaFile(MediaFileDao.VERSION - 1);
             mediaFile.setPathString(dir.toString());
             Mockito.when(mediaFileDao.getMediaFile(mediaFile.getPathString())).thenReturn(mediaFile);
-            Mockito.when(mediaFileDao.updateMediaFile(mediaFile)).thenReturn(mediaFile);
+            Mockito.when(mediaFileDao.updateMediaFile(mediaFile)).thenReturn(Optional.of(mediaFile));
 
             try {
                 mediaFile.setChanged(Files.getLastModifiedTime(dir).toInstant());
@@ -224,7 +225,7 @@ class WritableMediaFileServiceTest {
             }
             mediaFile.setLastScanned(FAR_PAST);
             Mockito.when(mediaFileDao.getMediaFile(mediaFile.getPathString())).thenReturn(mediaFile);
-            Mockito.when(mediaFileDao.updateMediaFile(mediaFile)).thenReturn(mediaFile);
+            Mockito.when(mediaFileDao.updateMediaFile(mediaFile)).thenReturn(Optional.of(mediaFile));
 
             assertEquals(mediaFile.getChanged(), Files.getLastModifiedTime(mediaFile.toPath()).toInstant());
             assertEquals(FAR_PAST, mediaFile.getLastScanned());
@@ -295,7 +296,7 @@ class WritableMediaFileServiceTest {
             }
             mediaFile.setLastScanned(FAR_PAST);
             Mockito.when(mediaFileDao.getMediaFile(mediaFile.getPathString())).thenReturn(mediaFile);
-            Mockito.when(mediaFileDao.updateMediaFile(mediaFile)).thenReturn(mediaFile);
+            Mockito.when(mediaFileDao.updateMediaFile(mediaFile)).thenReturn(Optional.of(mediaFile));
 
             assertThat("Changed Lt LastModified", mediaFile.getChanged().toEpochMilli(),
                     lessThan(Files.getLastModifiedTime(mediaFile.toPath()).toMillis()));
@@ -345,7 +346,7 @@ class WritableMediaFileServiceTest {
             }
             mediaFile.setLastScanned(FAR_PAST);
             Mockito.when(mediaFileDao.getMediaFile(mediaFile.getPathString())).thenReturn(mediaFile);
-            Mockito.when(mediaFileDao.updateMediaFile(mediaFile)).thenReturn(mediaFile);
+            Mockito.when(mediaFileDao.updateMediaFile(mediaFile)).thenReturn(Optional.of(mediaFile));
 
             assertEquals(mediaFile.getChanged().toEpochMilli(),
                     Files.getLastModifiedTime(mediaFile.toPath()).toMillis());
@@ -420,7 +421,7 @@ class WritableMediaFileServiceTest {
             }
             mediaFile.setLastScanned(FAR_PAST);
             Mockito.when(mediaFileDao.getMediaFile(mediaFile.getPathString())).thenReturn(mediaFile);
-            Mockito.when(mediaFileDao.updateMediaFile(mediaFile)).thenReturn(mediaFile);
+            Mockito.when(mediaFileDao.updateMediaFile(mediaFile)).thenReturn(Optional.of(mediaFile));
 
             assertThat("Changed Lt LastModified", mediaFile.getChanged().toEpochMilli(),
                     lessThan(Files.getLastModifiedTime(mediaFile.toPath()).toMillis()));
@@ -446,7 +447,7 @@ class WritableMediaFileServiceTest {
             }
             mediaFile.setLastScanned(mediaFile.getChanged());
             Mockito.when(mediaFileDao.getMediaFile(mediaFile.getPathString())).thenReturn(mediaFile);
-            Mockito.when(mediaFileDao.updateMediaFile(mediaFile)).thenReturn(mediaFile);
+            Mockito.when(mediaFileDao.updateMediaFile(mediaFile)).thenReturn(Optional.of(mediaFile));
 
             assertThat("Changed Lt LastModified", mediaFile.getChanged().toEpochMilli(),
                     lessThan(Files.getLastModifiedTime(mediaFile.toPath()).toMillis()));
@@ -548,7 +549,7 @@ class WritableMediaFileServiceTest {
 
             Mockito.clearInvocations(mediaFileDao);
             mediaFileCaptor = ArgumentCaptor.forClass(MediaFile.class);
-            Mockito.when(mediaFileDao.updateMediaFile(mediaFileCaptor.capture())).thenReturn(null);
+            Mockito.when(mediaFileDao.updateMediaFile(mediaFileCaptor.capture())).thenReturn(Optional.empty());
 
             Instant statsUpdated = now();
             writableMediaFileService.refreshMediaFile(statsUpdated, mediaFile);


### PR DESCRIPTION
#### Overview

Add appropriate waits where a for-loop CRUDs a large number of records, in the scan thread.

#### Purpose

It's the same general reason why waits are provided for long loops. Provide periodic mitigation for overcrowded processing.　Periodically relieve congestion and facilitate time sharing with other concurrent threads.

 - A simple example that is easy to imagine is when we operate a web page while Scan is busy processing. Some SELECT or UPDATE may be executed when the web page is opened. You probably don't mind a little execution wait. However, if the degree is large, that will develop into a stagnation of processing.
 - Even if the user does not move their hand, there may be some invisible processing going on.
   - Playing music, updating play counts
   - Check recursive scan status
   - Status check (Ping) that Docker periodically performs
   - etc, etc ... etc. The entire App Server is multi-threaded, even though scanning is single-threaded. UPnP, search engines, DBs, etc. are multithreaded.
 - If the processing holdup is too large, it will cause self-destruction. So to speak, self-DDoS.

#### Details

   - As a guideline, it will be corrected so that a wait of about 50ms will be executed for places where there is a concern that it will be locked for about 2-3 seconds or more.
     - For the time being, incorporating that process is the first landing point. It allows for continuous parameter adjustments in the future.
   - If we just want to simply wait, there will be a lot of methods. This pull request does not introduce common processing. The wait time is simply written for each procedure block. Because simple coding is desirable? No, for slightly different reasons.



