### PR TITLE
Fix bugs that episodes with queries could not be downloaded

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/PodcastServiceImpl.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/PodcastServiceImpl.java
@@ -64,6 +64,7 @@ import com.tesshu.jpsonic.util.StringUtil;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.UncheckedException;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.config.CookieSpecs;
@@ -538,17 +539,18 @@ public class PodcastServiceImpl implements PodcastService {
         return episodes;
     }
 
-    boolean isAudioEpisode(String url) {
-        String suffix;
+    private String getExtension(String url) {
         try {
             URI uri = new URI(url);
-            String withoutQuery = new URI(uri.getScheme(), uri.getAuthority(), uri.getPath(), null, uri.getFragment())
-                    .toString();
-            suffix = FilenameUtils.getExtension(withoutQuery);
+            return FilenameUtils.getExtension(
+                    new URI(uri.getScheme(), uri.getAuthority(), uri.getPath(), null, uri.getFragment()).toString());
         } catch (URISyntaxException e) {
-            return false;
+            throw new UncheckedException(e);
         }
-        return mediaFileService.isAudioFile(suffix);
+    }
+
+    boolean isAudioEpisode(String url) {
+        return mediaFileService.isAudioFile(getExtension(url));
     }
 
     private String getDescription(Element element) {
@@ -792,7 +794,7 @@ public class PodcastServiceImpl implements PodcastService {
         filename = filename.substring(0, Math.min(filename.length(), 146));
 
         filename = StringUtil.fileSystemSafe(filename);
-        String extension = FilenameUtils.getExtension(episode.getUrl());
+        String extension = getExtension(episode.getUrl());
 
         Path channelDir = getChannelDirectory(channel);
         Path file = Path.of(channelDir.toString(), filename + "." + extension);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/PodcastServiceImplTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/PodcastServiceImplTest.java
@@ -24,11 +24,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.net.URISyntaxException;
-import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -181,14 +179,17 @@ class PodcastServiceImplTest {
             final PodcastChannel channel = new PodcastChannel(null, null, channelTitle, null, null, null, null);
             final int epId = 99;
             final Instant publishDate = Instant.now();
+            final String pubDateStr = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault())
+                    .format(publishDate);
 
             String episodeTitle = "epTitle";
             String episodeUrl = "http://tesshu.com/chTitle/epTitle.mp3?size=mid";
 
             PodcastEpisode episode = new PodcastEpisode(epId, null, episodeUrl, null, episodeTitle, null, publishDate,
                     null, null, null, null, null);
-
-            assertThrows(InvalidPathException.class, () -> podcastService.getFile(channel, episode));
+            String fileName = channel.getTitle() + " - " + pubDateStr + " - " + epId + " - " + episodeTitle + ".mp3";
+            assertEquals(podcastFolder.toString() + File.separator + channelTitle + File.separator + fileName,
+                    podcastService.getFile(channel, episode).toString());
         }
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/PodcastServiceImplTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/PodcastServiceImplTest.java
@@ -24,9 +24,11 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.net.URISyntaxException;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -41,6 +43,7 @@ import com.tesshu.jpsonic.service.MediaFileService;
 import com.tesshu.jpsonic.service.SecurityService;
 import com.tesshu.jpsonic.service.SettingsService;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -122,45 +125,70 @@ class PodcastServiceImplTest {
         assertFalse(podcastService.isAudioEpisode("http://tesshu.com/episode.sh?size=mid"));
     }
 
-    @Test
-    void testGetFile() throws URISyntaxException {
+    @Nested
+    class GetFiletTest {
 
-        Path podcastFolder = Path
-                .of(PodcastServiceImplTest.class.getResource("/MEDIAS/Podcast").toURI());
-        Mockito.when(settingsService.getPodcastFolder()).thenReturn(podcastFolder.toString());
-        Mockito.when(securityService.isWriteAllowed(Mockito.any(Path.class))).thenReturn(true);
+        // https://github.com/tesshucom/jpsonic/pull/2281
+        @Test
+        void testExtensionAndDot() throws URISyntaxException {
 
-        final String channelTitle = "chTitle";
-        final PodcastChannel channel = new PodcastChannel(null, null, channelTitle, null, null, null, null);
-        final int epId = 99;
-        final Instant publishDate = Instant.now();
-        final String pubDateStr = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault())
-                .format(publishDate);
+            Path podcastFolder = Path.of(PodcastServiceImplTest.class.getResource("/MEDIAS/Podcast").toURI());
+            Mockito.when(settingsService.getPodcastFolder()).thenReturn(podcastFolder.toString());
+            Mockito.when(securityService.isWriteAllowed(Mockito.any(Path.class))).thenReturn(true);
 
-        String episodeTitle = "epTitle";
-        String episodeUrl = "http://tesshu.com/chTitle/epTitle.mp3";
+            final String channelTitle = "chTitle";
+            final PodcastChannel channel = new PodcastChannel(null, null, channelTitle, null, null, null, null);
+            final int epId = 99;
+            final Instant publishDate = Instant.now();
+            final String pubDateStr = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault())
+                    .format(publishDate);
 
-        PodcastEpisode episode = new PodcastEpisode(epId, null, episodeUrl, null, episodeTitle, null, publishDate, null,
-                null, null, null, null);
-        String fileName = channel.getTitle() + " - " + pubDateStr + " - " + epId + " - " + episodeTitle + ".mp3";
-        assertEquals(podcastFolder.toString() + File.separator + channelTitle + File.separator + fileName,
-                podcastService.getFile(channel, episode).toString());
+            String episodeTitle = "epTitle";
+            String episodeUrl = "http://tesshu.com/chTitle/epTitle.mp3";
 
-        episodeUrl = "http://tesshu.com/chTitle/epTitle.m4a";
+            PodcastEpisode episode = new PodcastEpisode(epId, null, episodeUrl, null, episodeTitle, null, publishDate,
+                    null, null, null, null, null);
+            String fileName = channel.getTitle() + " - " + pubDateStr + " - " + epId + " - " + episodeTitle + ".mp3";
+            assertEquals(podcastFolder.toString() + File.separator + channelTitle + File.separator + fileName,
+                    podcastService.getFile(channel, episode).toString());
 
-        episode = new PodcastEpisode(epId, null, episodeUrl, null, episodeTitle, null, publishDate, null, null, null,
-                null, null);
-        fileName = channel.getTitle() + " - " + pubDateStr + " - " + epId + " - " + episodeTitle + ".m4a";
-        assertEquals(podcastFolder.toString() + File.separator + channelTitle + File.separator + fileName,
-                podcastService.getFile(channel, episode).toString());
+            episodeUrl = "http://tesshu.com/chTitle/epTitle.m4a";
 
-        episodeUrl = "http://tesshu.com/Star+Wars/Star+Wars+Ep.1.mp3";
-        episodeTitle = "Star Wars Ep.1";
+            episode = new PodcastEpisode(epId, null, episodeUrl, null, episodeTitle, null, publishDate, null, null,
+                    null, null, null);
+            fileName = channel.getTitle() + " - " + pubDateStr + " - " + epId + " - " + episodeTitle + ".m4a";
+            assertEquals(podcastFolder.toString() + File.separator + channelTitle + File.separator + fileName,
+                    podcastService.getFile(channel, episode).toString());
 
-        episode = new PodcastEpisode(epId, null, episodeUrl, null, episodeTitle, null, publishDate, null, null, null,
-                null, null);
-        fileName = channel.getTitle() + " - " + pubDateStr + " - " + epId + " - Star Wars Ep.1.mp3";
-        assertEquals(podcastFolder.toString() + File.separator + channelTitle + File.separator + fileName,
-                podcastService.getFile(channel, episode).toString());
+            episodeUrl = "http://tesshu.com/Star+Wars/Star+Wars+Ep.1.mp3";
+            episodeTitle = "Star Wars Ep.1";
+
+            episode = new PodcastEpisode(epId, null, episodeUrl, null, episodeTitle, null, publishDate, null, null,
+                    null, null, null);
+            fileName = channel.getTitle() + " - " + pubDateStr + " - " + epId + " - Star Wars Ep.1.mp3";
+            assertEquals(podcastFolder.toString() + File.separator + channelTitle + File.separator + fileName,
+                    podcastService.getFile(channel, episode).toString());
+        }
+
+        @Test
+        void testEpisodeUrlWithQuery() throws URISyntaxException {
+
+            Path podcastFolder = Path.of(PodcastServiceImplTest.class.getResource("/MEDIAS/Podcast").toURI());
+            Mockito.when(settingsService.getPodcastFolder()).thenReturn(podcastFolder.toString());
+            Mockito.when(securityService.isWriteAllowed(Mockito.any(Path.class))).thenReturn(true);
+
+            final String channelTitle = "chTitle";
+            final PodcastChannel channel = new PodcastChannel(null, null, channelTitle, null, null, null, null);
+            final int epId = 99;
+            final Instant publishDate = Instant.now();
+
+            String episodeTitle = "epTitle";
+            String episodeUrl = "http://tesshu.com/chTitle/epTitle.mp3?size=mid";
+
+            PodcastEpisode episode = new PodcastEpisode(epId, null, episodeUrl, null, episodeTitle, null, publishDate,
+                    null, null, null, null, null);
+
+            assertThrows(InvalidPathException.class, () -> podcastService.getFile(channel, episode));
+        }
     }
 }


### PR DESCRIPTION


## Problem description

If the podcast episode enclosure  url contains a query, it cannot be downloaded. Degradation caused by #2271. Lack of testing.

In #2271, podcast audio file extension detection was introduced. In fact, PodcastServiceImpl has other processing that should be done by removing the URL query, but there was a lack of correction.

### Steps to reproduce

Download a podcast containing an episode with URL containing a query.

[example](https://www.omnycontent.com/d/playlist/92f07af0-df9c-498e-a68a-ab4201477bd9/1b09462c-806f-4261-bd7a-ae6300cc0b94/2ab991d3-f2c3-413e-9174-ae6300ccc261/podcast.rss)


## System information

 * **Jpsonic version**: v112.1.4

