### PR TITLE
Change JDK distribution used in CI from Adopt to Temurin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       if: contains(matrix.language, 'java')
       uses: actions/setup-java@v3
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: 11
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
@@ -75,7 +75,7 @@ jobs:
       - name: Set up java
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
       - name: Set up ffmpeg
         id: ffmpeg
@@ -114,7 +114,7 @@ jobs:
       - name: Set up java
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 17
       - name: Set up ffmpeg
         id: ffmpeg
@@ -144,7 +144,7 @@ jobs:
       - name: Set up java
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Set up ffmpeg
         id: ffmpeg
@@ -174,7 +174,7 @@ jobs:
       - name: Set up java
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
       - name: Download coverage
         uses: actions/download-artifact@v3
@@ -197,7 +197,7 @@ jobs:
       - name: Set up java
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Cache Maven packages
         uses: actions/cache@v3
@@ -243,7 +243,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 17
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
@@ -305,7 +305,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 17
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2


### PR DESCRIPTION

The distribution of JDK used by CI will change from adopt to temurin.

  - Temurin is used for the upstream image of all Jpsonic's Docker Images. will be changed to use what they have in common.
  - [setup-java](https://github.com/actions/setup-java)
    - > NOTE: AdoptOpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from adopt and adopt-openj9, to temurin and semeru respectively, to keep receiving software and security updates.