### PR TITLE
Change Java startup options to those for G1 GC

### DIFF
--- a/install/docker/production.synology.yml
+++ b/install/docker/production.synology.yml
@@ -2,8 +2,10 @@
 # This is a JPSONIC boot configuration sample in Synology DS220+ or in Linux with UPnP.
 # You can easily start Jpsonic by changing the volume, port and so on.
 #
-# usege: 
+# usage: 
 #   docker-compose -f production.synology.yml up -d
+#
+# @since v112.2.0
 #
 
 version: '3.9'
@@ -37,10 +39,7 @@ services:
         limits:
 
           # Jpsonic container is limited to 1Gb so that it can run on DS220+'s standard memory.
-          # Xmx512m is assigned by default, but with these settings,
-          # it is assumed that 100,000 songs can be scanned for music only.
-          # For larger libraries, increase Xmx and this setting by the same value.
-          # ie) memory: 1.5g at -Xmx1024
+          # Add 512m to the number assigned to -Xmx. See 'JAVA_OPTS'.
           memory: 1g
 
     environment:
@@ -79,23 +78,50 @@ services:
      MIME_DFF: 'audio/x-dsd'
 
      # Specify the appropriate Java options.
-     # Currently, Jpsonic will not require extremely large memory.
-     # If you are using 32 bit OS please specify -Xmx256m
-     JAVA_OPTS: '-Xmx512m'
+     # If you are using a pure DLNA player (not UPnP) and have problems, remove XX:MaxGCPauseMillis.
+     # Note, however, that scanning will be slightly slower.
+
+     # The following settings are standard settings. 100K songs or less.
+     # Specify 1g for Docker memory.
+     JAVA_OPTS: '-Xms512m -Xmx512m -XX:MaxGCPauseMillis=500'
+
+     # 70K-10K songs (Maybe just a little faster). Specify 1.25g for Docker memory.
+     # JAVA_OPTS: '-Xms768m -Xmx768m -XX:MaxGCPauseMillis=500'
+
+     # 200K songs or less. Specify 1.5g for Docker memory.
+     # JAVA_OPTS: '-Xms1024m -Xmx1024m -XX:MaxGCPauseMillis=500'
+
+     # 300K songs or less. Specify 1.75g for Docker memory.
+     # JAVA_OPTS: '-Xms1280m -Xmx1280m -XX:MaxGCPauseMillis=500'
+
+     # 400K songs or less. Specify 2g for Docker memory.
+     # JAVA_OPTS: '-Xms1536m -Xmx1536m -XX:MaxGCPauseMillis=500'
 
      #　Option example when using JMX. The "ea" tag image is required to use JMX.
      #　For VisualVM, you need to specify the port in File-Add JMX Connection.
      #　e.g. localhost:3333
-     #　
-     #JAVA_OPTS: >
-     #  -Xmx512m
-     #  -Dcom.sun.management.jmxremote
-     #  -Dcom.sun.management.jmxremote.port=3333
-     #  -Dcom.sun.management.jmxremote.rmi.port=3333
-     #  -Dcom.sun.management.jmxremote.local.only=false
-     #  -Dcom.sun.management.jmxremote.ssl=false
-     #  -Dcom.sun.management.jmxremote.authenticate=false
-     #  -Djava.rmi.server.hostname=localhost
+     #
+     # JAVA_OPTS: >
+     #   -Xms512m
+     #   -Xmx512m
+     #   -XX:MaxGCPauseMillis=500
+     #   -Dcom.sun.management.jmxremote
+     #   -Dcom.sun.management.jmxremote.port=3333
+     #   -Dcom.sun.management.jmxremote.rmi.port=3333
+     #   -Dcom.sun.management.jmxremote.local.only=false
+     #   -Dcom.sun.management.jmxremote.ssl=false
+     #   -Dcom.sun.management.jmxremote.authenticate=false
+     #   -Djava.rmi.server.hostname=localhost
+
+     # If you want to perform long-term profiling such as scan performance adjustment,
+     # it is a good idea to output GC Log.
+     # See Universal GC Log Analyzer (https://gceasy.io/)
+     #
+     # JAVA_OPTS: >
+     #   -Xms512m
+     #   -Xmx512m
+     #   -XX:MaxGCPauseMillis=500
+     #   -Xlog:gc*:file=/jpsonic/data/jpsonic_gc.log:time,level,tags:filecount=0'
 
     # Usually no need to change.
     # Unlike other Sonic servers, Jpsonic has a graceful shutdown implemented.


### PR DESCRIPTION
Prerequisites: #2310

Change the default Java startup options mentioned in Docker to those of G1 GC. Depending on the number of songs, it may affect the initial scan by minutes in some cases.

Change is very simple. 

`JAVA_OPTS: '-Xmx512m'` -> `JAVA_OPTS: '-Xms512m -Xmx512m -XX:MaxGCPauseMillis=500'`

Other than this, it is a comment line correction. Therefore, if the previous production.synology.yml exists locally, it can be used by rewriting only there.


As mentioned in the comments, If you are using a pure DLNA player (not UPnP) and have problems, remove XX:MaxGCPauseMillis. This is because DLNA has provisions for response speed. However, that scanning will be slightly slower.
