### PR TITLE
Remove Java11 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,16 +55,16 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: 11
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+        java-version: 17
+    - name: Compile with Maven
+      run: mvn clean compile -Dmaven.test.skip=true -Dpmd.skip=true -Pjetty-embed -Prelease17
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
   ##########################################################################
-  verify-JDK11:
+  verify-JDK17:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-    name: JDK11 on ${{ matrix.os }}
+    name: JDK17 on ${{ matrix.os }}
     strategy:
       matrix:
         os: [ windows-latest, ubuntu-latest ]
@@ -76,7 +76,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - name: Set up ffmpeg
         id: ffmpeg
         uses: FedericoCarboni/setup-ffmpeg@v2
@@ -102,33 +102,6 @@ jobs:
       - name: Verify with Maven on Win
         if: contains(matrix.os, 'windows-latest')
         run: mvn -DfailIfNoTests=false -DtranscodePath="${{ steps.ffmpeg.outputs.path }}" clean verify -B -Ptomcat-embed -Punit-test
-  ##########################################################################
-  verify-JDK17:
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-    name: JDK17 on ubuntu-latest
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Set up java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: 17
-      - name: Set up ffmpeg
-        id: ffmpeg
-        uses: FedericoCarboni/setup-ffmpeg@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Cache Maven packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2 
-      - name: Verify with Maven
-        run: mvn -DtranscodePath="${{ steps.ffmpeg.outputs.path }}" clean verify -B -Ptomcat-embed -Prelease${{ matrix.java }} -Punit-test
   ##########################################################################
   verify-experiment:
     needs: pre_job
@@ -162,7 +135,7 @@ jobs:
   ##########################################################################
   send-coverage:
     name: Send coverage to Codacy
-    needs: [ verify-JDK11, verify-JDK17 ]
+    needs: [ verify-JDK17 ]
     if: "(github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop')"
     env:
       CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
@@ -185,11 +158,11 @@ jobs:
   ##########################################################################
   ship-war:
     if: "(github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop') && github.event_name != 'schedule'"
-    needs: [ verify-JDK11, verify-JDK17, verify-experiment ]
+    needs: [ verify-JDK17, verify-experiment ]
     name: Package with JDK ${{ matrix.java }} on ubuntu
     strategy:
       matrix:
-        java: [ 11, 17, 18, 19, 20 ]
+        java: [ 17, 18, 19, 20 ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImplTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImplTest.java
@@ -88,7 +88,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
@@ -566,9 +568,11 @@ class MediaScannerServiceImplTest {
             populateDatabase();
         }
 
-        // Flaky in Windows Server 2022 & JDK11 (#1645)
-        // Flaky in Ubunts & JDK11 (#1840)
-        @DisabledOnJre(JRE.JAVA_11)
+        /*
+         * On platforms with Timestamp disabled the result will be different from the case. Windows for home use will
+         * work fine.
+         */
+        @DisabledOnOs(OS.WINDOWS) // Windows Server 2022 & JDK17
         @Test
         void testBehavioralSpecForTagReflesh() throws URISyntaxException, IOException, InterruptedException {
 

--- a/pom.xml
+++ b/pom.xml
@@ -829,21 +829,14 @@
     </reporting>
     <profiles>
         <profile>
-            <id>release11</id>
-            <properties>
-                <java.version>11</java.version>
-                <maven.compiler.release>${java.version}</maven.compiler.release>
-            </properties>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-        </profile>
-        <profile>
             <id>release17</id>
             <properties>
                 <java.version>17</java.version>
                 <maven.compiler.release>${java.version}</maven.compiler.release>
             </properties>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
         </profile>
         <profile>
             <id>release18</id>


### PR DESCRIPTION
Prerequisites: #2305

### Overview

The end of Active Support for Java11 in Sep 2023. Along with this, Jpsonic's Java11 Support will also end, so it will be removed from CI.

### Note

 - Some of our CI will continue to use Java 11, as the tools that submit coverage to Codacy only support Java 11. It doesn't affect the build of Jpsonic .
 - This pull request also serves as a working confirmation of Sonatype-lift. Sonatype-lift will be removed, especially if Facebook Infer does not work. (In any case, Sonatype-lift has been announced to end. It will be replaced by others in the near future. There was also a notice. `A new offering launching in late-2023: Sonatype Developer`)



