### PR TITLE
Rewrite to Java 17 Syntax

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/TomcatApplicationHelper.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/TomcatApplicationHelper.java
@@ -62,8 +62,8 @@ public final class TomcatApplicationHelper {
             // on each request.
             // See http://stackoverflow.com/questions/29653326/spring-boot-application-slow-because-of-jsp-compilation
             Container jsp = context.findChild("jsp");
-            if (jsp instanceof Wrapper) {
-                ((Wrapper) jsp).addInitParameter("development", Boolean.toString(development));
+            if (jsp instanceof Wrapper wrapper) {
+                wrapper.addInitParameter("development", Boolean.toString(development));
             }
         });
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DatabaseSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DatabaseSettingsController.java
@@ -90,20 +90,16 @@ public class DatabaseSettingsController {
         if (!bindingResult.hasErrors()) {
             settingsService.resetDatabaseToDefault();
             settingsService.setDatabaseConfigType(command.getConfigType());
-            switch (command.getConfigType()) {
-            case URL:
+
+            if (command.getConfigType() == DataSourceConfigType.URL) {
                 settingsService.setDatabaseConfigEmbedDriver(command.getEmbedDriver());
                 settingsService.setDatabaseConfigEmbedUrl(command.getEmbedUrl());
                 settingsService.setDatabaseConfigEmbedPassword(command.getEmbedPassword());
                 settingsService.setDatabaseConfigEmbedUsername(command.getEmbedUsername());
-                break;
-            case JNDI:
+            } else if (command.getConfigType() == DataSourceConfigType.JNDI) {
                 settingsService.setDatabaseConfigJNDIName(command.getJNDIName());
-                break;
-            case HOST:
-            default:
-                break;
             }
+
             if (command.getConfigType() != DataSourceConfigType.HOST) {
                 settingsService.setDatabaseMysqlVarcharMaxlength(command.getMysqlVarcharMaxlength());
                 settingsService.setDatabaseUsertableQuote(command.getUsertableQuote());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SubsonicRESTController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SubsonicRESTController.java
@@ -1424,24 +1424,13 @@ public class SubsonicRESTController {
     }
 
     private MediaType getMedyaType(MediaFile.MediaType mediaType) {
-        MediaType result = null;
-        switch (mediaType) {
-        case MUSIC:
-            result = MediaType.MUSIC;
-            break;
-        case PODCAST:
-            result = MediaType.PODCAST;
-            break;
-        case AUDIOBOOK:
-            result = MediaType.AUDIOBOOK;
-            break;
-        case VIDEO:
-            result = MediaType.VIDEO;
-            break;
-        default:
-            break;
-        }
-        return result;
+        return switch (mediaType) {
+        case MUSIC -> MediaType.MUSIC;
+        case PODCAST -> MediaType.PODCAST;
+        case AUDIOBOOK -> MediaType.AUDIOBOOK;
+        case VIDEO -> MediaType.VIDEO;
+        default -> null;
+        };
     }
 
     private String findCoverArt(MediaFile mediaFile, MediaFile parent) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AbstractDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AbstractDao.java
@@ -200,8 +200,8 @@ public class AbstractDao {
     static @Nullable Object castArg(@Nullable Object arg) {
         if (arg == null) {
             return null;
-        } else if (arg instanceof Instant) {
-            return Timestamp.from((Instant) arg);
+        } else if (arg instanceof Instant dateTime) {
+            return Timestamp.from(dateTime);
         }
         return arg;
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AbstractDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AbstractDao.java
@@ -80,9 +80,9 @@ public class AbstractDao {
     }
 
     protected static String prefix(String columns, String prefix) {
-        List<String> l = Arrays.asList(columns.split(", "));
+        List<String> l = Arrays.asList(columns.replaceAll("\n", " ").split(", "));
         l.replaceAll(s -> prefix + "." + s);
-        return String.join(", ", l);
+        return String.join(", ", l).trim().concat(" ");
     }
 
     @SuppressFBWarnings(value = "SQL_INJECTION_SPRING_JDBC", justification = "False positive. find-sec-bugs#385")

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AvatarDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AvatarDao.java
@@ -26,6 +26,7 @@ import java.sql.SQLException;
 import java.util.List;
 
 import com.tesshu.jpsonic.domain.Avatar;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 
@@ -37,7 +38,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class AvatarDao extends AbstractDao {
 
-    private static final String INSERT_COLUMNS = "name, created_date, mime_type, width, height, data";
+    private static final String INSERT_COLUMNS = """
+            name, created_date, mime_type, width, height, data\s
+            """;
     private static final String QUERY_COLUMNS = "id, " + INSERT_COLUMNS;
 
     private final AvatarRowMapper rowMapper;
@@ -47,39 +50,24 @@ public class AvatarDao extends AbstractDao {
         rowMapper = new AvatarRowMapper();
     }
 
-    /**
-     * Returns all system avatars.
-     *
-     * @return All system avatars.
-     */
     public List<Avatar> getAllSystemAvatars() {
-        String sql = "select " + QUERY_COLUMNS + " from system_avatar";
+        String sql = "select " + QUERY_COLUMNS + "from system_avatar";
         return query(sql, rowMapper);
     }
 
-    /**
-     * Returns the system avatar with the given ID.
-     *
-     * @param id
-     *            The system avatar ID.
-     *
-     * @return The avatar or <code>null</code> if not found.
-     */
-    public Avatar getSystemAvatar(int id) {
-        String sql = "select " + QUERY_COLUMNS + " from system_avatar where id=" + id;
-        return queryOne(sql, rowMapper);
+    public @Nullable Avatar getSystemAvatar(int id) {
+        String sql = "select " + QUERY_COLUMNS + """
+                from system_avatar
+                where id=?
+                """;
+        return queryOne(sql, rowMapper, id);
     }
 
-    /**
-     * Returns the custom avatar for the given user.
-     *
-     * @param username
-     *            The username.
-     *
-     * @return The avatar or <code>null</code> if not found.
-     */
-    public Avatar getCustomAvatar(String username) {
-        String sql = "select " + QUERY_COLUMNS + " from custom_avatar where username=?";
+    public @Nullable Avatar getCustomAvatar(String username) {
+        String sql = "select " + QUERY_COLUMNS + """
+                from custom_avatar
+                where username=?
+                """;
         return queryOne(sql, rowMapper, username);
     }
 
@@ -92,7 +80,10 @@ public class AvatarDao extends AbstractDao {
      *            The username.
      */
     public void setCustomAvatar(Avatar avatar, String username) {
-        String sql = "delete from custom_avatar where username=?";
+        String sql = """
+                delete from custom_avatar
+                where username=?
+                """;
         update(sql, username);
 
         if (avatar != null) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/BookmarkDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/BookmarkDao.java
@@ -48,11 +48,7 @@ public class BookmarkDao extends AbstractDao {
         bookmarkRowMapper = new BookmarkRowMapper();
     }
 
-    /**
-     * Returns all bookmarks.
-     *
-     * @return Possibly empty list of all bookmarks.
-     */
+    @Deprecated
     public List<Bookmark> getBookmarks() {
         String sql = "select " + QUERY_COLUMNS + " from bookmark";
         return query(sql, bookmarkRowMapper);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/BookmarkDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/BookmarkDao.java
@@ -38,7 +38,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Repository
 public class BookmarkDao extends AbstractDao {
 
-    private static final String INSERT_COLUMNS = "media_file_id, position_millis, username, comment, created, changed";
+    private static final String INSERT_COLUMNS = """
+            media_file_id, position_millis, username, comment, created, changed\s
+            """;
     private static final String QUERY_COLUMNS = "id, " + INSERT_COLUMNS;
 
     private final BookmarkRowMapper bookmarkRowMapper;
@@ -50,46 +52,46 @@ public class BookmarkDao extends AbstractDao {
 
     @Deprecated
     public List<Bookmark> getBookmarks() {
-        String sql = "select " + QUERY_COLUMNS + " from bookmark";
+        String sql = "select " + QUERY_COLUMNS + "from bookmark";
         return query(sql, bookmarkRowMapper);
     }
 
-    /**
-     * Returns all bookmarks for a given user.
-     *
-     * @return Possibly empty list of all bookmarks for the user.
-     */
     public List<Bookmark> getBookmarks(String username) {
-        String sql = "select " + QUERY_COLUMNS + " from bookmark where username=?";
+        String sql = "select " + QUERY_COLUMNS + """
+                from bookmark
+                where username=?
+                """;
         return query(sql, bookmarkRowMapper, username);
     }
 
-    /**
-     * Creates or updates a bookmark. If created, the ID of the bookmark will be set by this method.
-     */
     @Transactional
     public void createOrUpdateBookmark(Bookmark bookmark) {
-        int n = update(
-                "update bookmark set position_millis=?, comment=?, changed=? where media_file_id=? and username=?",
-                bookmark.getPositionMillis(), bookmark.getComment(), bookmark.getChanged(), bookmark.getMediaFileId(),
-                bookmark.getUsername());
+        int n = update("""
+                update bookmark
+                set position_millis=?, comment=?, changed=?
+                where media_file_id=? and username=?
+                """, bookmark.getPositionMillis(), bookmark.getComment(), bookmark.getChanged(),
+                bookmark.getMediaFileId(), bookmark.getUsername());
 
         if (n == 0) {
             update("insert into bookmark (" + INSERT_COLUMNS + ") values (" + questionMarks(INSERT_COLUMNS) + ")",
                     bookmark.getMediaFileId(), bookmark.getPositionMillis(), bookmark.getUsername(),
                     bookmark.getComment(), bookmark.getCreated(), bookmark.getChanged());
-            int id = queryForInt("select id from bookmark where media_file_id=? and username=?", 0,
-                    bookmark.getMediaFileId(), bookmark.getUsername());
+            int id = queryForInt("""
+                    select id
+                    from bookmark
+                    where media_file_id=? and username=?
+                    """, 0, bookmark.getMediaFileId(), bookmark.getUsername());
             bookmark.setId(id);
         }
     }
 
-    /**
-     * Deletes the bookmark for the given username and media file.
-     */
     @Transactional
     public void deleteBookmark(String username, int mediaFileId) {
-        update("delete from bookmark where username=? and media_file_id=?", username, mediaFileId);
+        update("""
+                delete from bookmark
+                where username=? and media_file_id=?
+                """, username, mediaFileId);
     }
 
     private static class BookmarkRowMapper implements RowMapper<Bookmark> {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/InternetRadioDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/InternetRadioDao.java
@@ -26,6 +26,7 @@ import java.sql.SQLException;
 import java.util.List;
 
 import com.tesshu.jpsonic.domain.InternetRadio;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.RowMapper;
@@ -40,7 +41,9 @@ import org.springframework.stereotype.Repository;
 public class InternetRadioDao extends AbstractDao {
 
     private static final Logger LOG = LoggerFactory.getLogger(InternetRadioDao.class);
-    private static final String INSERT_COLUMNS = "name, stream_url, homepage_url, enabled, changed";
+    private static final String INSERT_COLUMNS = """
+            name, stream_url, homepage_url, enabled, changed\s
+            """;
     private static final String QUERY_COLUMNS = "id, " + INSERT_COLUMNS;
 
     private final InternetRadioRowMapper rowMapper;
@@ -50,35 +53,19 @@ public class InternetRadioDao extends AbstractDao {
         rowMapper = new InternetRadioRowMapper();
     }
 
-    /**
-     * Returns the internet radio station with the given ID.
-     *
-     * @param id
-     *            The unique internet radio station ID.
-     *
-     * @return The internet radio station with the given ID, or <code>null</code> if no such internet radio exists.
-     */
-    public InternetRadio getInternetRadioById(int id) {
-        String sql = "select " + QUERY_COLUMNS + " from internet_radio where id=?";
+    public @Nullable InternetRadio getInternetRadioById(int id) {
+        String sql = "select " + QUERY_COLUMNS + """
+                from internet_radio
+                where id=?
+                """;
         return queryOne(sql, rowMapper, id);
     }
 
-    /**
-     * Returns all internet radio stations.
-     *
-     * @return Possibly empty list of all internet radio stations.
-     */
     public List<InternetRadio> getAllInternetRadios() {
         String sql = "select " + QUERY_COLUMNS + " from internet_radio";
         return query(sql, rowMapper);
     }
 
-    /**
-     * Creates a new internet radio station.
-     *
-     * @param radio
-     *            The internet radio station to create.
-     */
     public void createInternetRadio(InternetRadio radio) {
         String sql = "insert into internet_radio (" + INSERT_COLUMNS + ") values (?, ?, ?, ?, ?)";
         update(sql, radio.getName(), radio.getStreamUrl(), radio.getHomepageUrl(), radio.isEnabled(),
@@ -88,28 +75,23 @@ public class InternetRadioDao extends AbstractDao {
         }
     }
 
-    /**
-     * Deletes the internet radio station with the given ID.
-     *
-     * @param id
-     *            The internet radio station ID.
-     */
     public void deleteInternetRadio(Integer id) {
-        String sql = "delete from internet_radio where id=?";
+        String sql = """
+                delete from internet_radio
+                where id=?
+                """;
         update(sql, id);
         if (LOG.isInfoEnabled()) {
             LOG.info("Deleted internet radio station with ID " + id);
         }
     }
 
-    /**
-     * Updates the given internet radio station.
-     *
-     * @param radio
-     *            The internet radio station to update.
-     */
     public void updateInternetRadio(InternetRadio radio) {
-        String sql = "update internet_radio set name=?, stream_url=?, homepage_url=?, enabled=?, changed=? where id=?";
+        String sql = """
+                update internet_radio
+                set name=?, stream_url=?, homepage_url=?, enabled=?, changed=?
+                where id=?
+                """;
         update(sql, radio.getName(), radio.getStreamUrl(), radio.getHomepageUrl(), radio.isEnabled(),
                 radio.getChanged(), radio.getId());
     }
@@ -121,5 +103,4 @@ public class InternetRadioDao extends AbstractDao {
                     nullableInstantOf(rs.getTimestamp(6)));
         }
     }
-
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/PlayQueueDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/PlayQueueDao.java
@@ -38,7 +38,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Repository
 public class PlayQueueDao extends AbstractDao {
 
-    private static final String INSERT_COLUMNS = "username, \"CURRENT\", position_millis, changed, changed_by";
+    private static final String INSERT_COLUMNS = """
+            username, \"CURRENT\", position_millis, changed, changed_by\s
+            """;
     private static final String QUERY_COLUMNS = "id, " + INSERT_COLUMNS;
 
     private final RowMapper<SavedPlayQueue> rowMapper;
@@ -50,20 +52,28 @@ public class PlayQueueDao extends AbstractDao {
 
     @Transactional
     public SavedPlayQueue getPlayQueue(String username) {
-        SavedPlayQueue playQueue = queryOne("select " + QUERY_COLUMNS + " from play_queue where username=?", rowMapper,
-                username);
+        SavedPlayQueue playQueue = queryOne("select " + QUERY_COLUMNS + """
+                from play_queue
+                where username=?
+                """, rowMapper, username);
         if (playQueue == null) {
             return null;
         }
-        List<Integer> mediaFileIds = queryForInts("select media_file_id from play_queue_file where play_queue_id = ?",
-                playQueue.getId());
+        List<Integer> mediaFileIds = queryForInts("""
+                select media_file_id
+                from play_queue_file
+                where play_queue_id = ?
+                """, playQueue.getId());
         playQueue.setMediaFileIds(mediaFileIds);
         return playQueue;
     }
 
     @Transactional
     public void savePlayQueue(SavedPlayQueue playQueue) {
-        update("delete from play_queue where username=?", playQueue.getUsername());
+        update("""
+                delete from play_queue
+                where username=?
+                """, playQueue.getUsername());
         update("insert into play_queue(" + INSERT_COLUMNS + ") values (" + questionMarks(INSERT_COLUMNS) + ")",
                 playQueue.getUsername(), playQueue.getCurrentMediaFileId(), playQueue.getPositionMillis(),
                 playQueue.getChanged(), playQueue.getChangedBy());
@@ -71,7 +81,10 @@ public class PlayQueueDao extends AbstractDao {
         playQueue.setId(id);
 
         for (Integer mediaFileId : playQueue.getMediaFileIds()) {
-            update("insert into play_queue_file(play_queue_id, media_file_id) values (?, ?)", id, mediaFileId);
+            update("""
+                    insert into play_queue_file(play_queue_id, media_file_id)
+                    values (?, ?)
+                    """, id, mediaFileId);
         }
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/ShareDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/ShareDao.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.domain.Share;
 import com.tesshu.jpsonic.util.LegacyMap;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,7 +43,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Repository
 public class ShareDao extends AbstractDao {
 
-    private static final String INSERT_COLUMNS = "name, description, username, created, expires, last_visited, visit_count";
+    private static final String INSERT_COLUMNS = """
+            name, description, username, created, expires, last_visited, visit_count\s
+            """;
     private static final String QUERY_COLUMNS = "id, " + INSERT_COLUMNS;
 
     private final ShareRowMapper shareRowMapper;
@@ -54,12 +57,6 @@ public class ShareDao extends AbstractDao {
         shareFileRowMapper = new ShareFileRowMapper();
     }
 
-    /**
-     * Creates a new share.
-     *
-     * @param share
-     *            The share to create. The ID of the share will be set by this method.
-     */
     @Transactional
     public void createShare(Share share) {
         String sql = "insert into share (" + INSERT_COLUMNS + ") values (" + questionMarks(INSERT_COLUMNS) + ")";
@@ -71,79 +68,66 @@ public class ShareDao extends AbstractDao {
         }
     }
 
-    /**
-     * Returns all shares.
-     *
-     * @return Possibly empty list of all shares.
-     */
     public List<Share> getAllShares() {
-        String sql = "select " + QUERY_COLUMNS + " from share";
+        String sql = "select " + QUERY_COLUMNS + "from share";
         return query(sql, shareRowMapper);
     }
 
-    public Share getShareByName(String shareName) {
-        String sql = "select " + QUERY_COLUMNS + " from share where name=?";
+    public @Nullable Share getShareByName(String shareName) {
+        String sql = "select " + QUERY_COLUMNS + """
+                from share
+                where name=?
+                """;
         return queryOne(sql, shareRowMapper, shareName);
     }
 
-    public Share getShareById(int id) {
-        String sql = "select " + QUERY_COLUMNS + " from share where id=?";
+    public @Nullable Share getShareById(int id) {
+        String sql = "select " + QUERY_COLUMNS + """
+                from share
+                where id=?
+                """;
         return queryOne(sql, shareRowMapper, id);
     }
 
-    /**
-     * Updates the given share.
-     *
-     * @param share
-     *            The share to update.
-     */
     public void updateShare(Share share) {
-        String sql = "update share set name=?, description=?, username=?, created=?, expires=?, last_visited=?, visit_count=? where id=?";
+        String sql = """
+                update share
+                set name=?, description=?, username=?, created=?,
+                        expires=?, last_visited=?, visit_count=?
+                where id=?
+                """;
         update(sql, share.getName(), share.getDescription(), share.getUsername(), share.getCreated(),
                 share.getExpires(), share.getLastVisited(), share.getVisitCount(), share.getId());
     }
 
-    /**
-     * Creates shared files.
-     *
-     * @param shareId
-     *            The share ID.
-     * @param paths
-     *            Paths of the files to share.
-     */
     public void createSharedFiles(int shareId, String... paths) {
-        String sql = "insert into share_file (share_id, path) values (?, ?)";
+        String sql = """
+                insert into share_file (share_id, path)
+                values (?, ?)
+                """;
         for (String path : paths) {
             update(sql, shareId, path);
         }
     }
 
-    /**
-     * Returns files for a share.
-     *
-     * @param shareId
-     *            The ID of the share.
-     *
-     * @return The paths of the shared files.
-     */
     public List<String> getSharedFiles(final int shareId, final List<MusicFolder> musicFolders) {
         if (musicFolders.isEmpty()) {
             return Collections.emptyList();
         }
         Map<String, Object> args = LegacyMap.of("shareId", shareId, "folders", MusicFolder.toPathList(musicFolders));
-        return namedQuery("select share_file.path from share_file, media_file where share_id = :shareId and "
-                + "share_file.path = media_file.path and media_file.present and media_file.folder in (:folders)",
-                shareFileRowMapper, args);
+        return namedQuery("""
+                select share_file.path
+                from share_file, media_file
+                where share_id = :shareId and share_file.path = media_file.path
+                        and media_file.present and media_file.folder in (:folders)
+                """, shareFileRowMapper, args);
     }
 
-    /**
-     * Deletes the share with the given ID.
-     *
-     * @param id
-     *            The ID of the share to delete.
-     */
     public void deleteShare(Integer id) {
-        update("delete from share where id=?", id);
+        update("""
+                delete from share
+                where id=?
+                """, id);
     }
 
     private static class ShareRowMapper implements RowMapper<Share> {
@@ -160,6 +144,5 @@ public class ShareDao extends AbstractDao {
         public String mapRow(ResultSet rs, int rowNum) throws SQLException {
             return rs.getString(1);
         }
-
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/StaticsDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/StaticsDao.java
@@ -43,7 +43,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Repository
 public class StaticsDao extends AbstractDao {
 
-    private static final String EVENT_QUERY_COLUMNS = "start_date, executed, type, max_memory, total_memory, free_memory, max_thread, comment";
+    private static final String EVENT_QUERY_COLUMNS = """
+            start_date, executed, type, max_memory, total_memory,
+            free_memory, max_thread, comment\s
+            """;
 
     private final RowMapper<ScanLog> scanLogMapper = (ResultSet rs, int rowNum) -> {
         return new ScanLog(nullableInstantOf(rs.getTimestamp(1)), ScanLogType.valueOf(rs.getString(2)));
@@ -64,7 +67,11 @@ public class StaticsDao extends AbstractDao {
 
     @Transactional
     public void createFolderLog(@NonNull Instant executed, @NonNull ScanEventType type) {
-        boolean exist = queryForInt("select count(*) from scan_log where start_date = ?", 0, executed) > 0;
+        boolean exist = queryForInt("""
+                select count(*)
+                from scan_log
+                where start_date = ?
+                """, 0, executed) > 0;
         if (!exist) {
             createScanLog(executed, ScanLogType.FOLDER_CHANGED);
         }
@@ -72,68 +79,152 @@ public class StaticsDao extends AbstractDao {
     }
 
     public List<ScanLog> getScanLog(ScanLogType type) {
-        return query("select start_date, type from scan_log where type=? order by start_date desc", scanLogMapper,
-                type.name());
+        return query("""
+                select start_date, type
+                from scan_log
+                where type=?
+                order by start_date desc
+                """, scanLogMapper, type.name());
     }
 
     public void createScanLog(@NonNull Instant scanDate, @NonNull ScanLogType type) {
-        update("insert into scan_log (start_date, type) values (?, ?)", scanDate, type.name());
+        update("""
+                insert into scan_log (start_date, type)
+                values (?, ?)
+                """, scanDate, type.name());
     }
 
     public void deleteBefore(Instant retention) {
-        update("delete from scan_log where type = ? and (start_date <> (select start_date from scan_log "
-                + "where type = ? order by start_date desc limit 1)) and start_date < ?", ScanLogType.SCAN_ALL.name(),
-                ScanLogType.SCAN_ALL.name(), retention);
-        update("delete from scan_log where type <> ? and start_date < ?", ScanLogType.SCAN_ALL.name(), retention);
-        update("delete from scan_event where (type=? or type=? or type=?)", ScanEventType.FOLDER_CREATE.name(),
-                ScanEventType.FOLDER_DELETE.name(), ScanEventType.FOLDER_UPDATE.name());
+        update("""
+                delete from scan_log
+                where type = ?
+                        and (start_date <>
+                                (select start_date
+                                from scan_log
+                                where type = ?
+                                order by start_date desc
+                                limit 1))
+                        and start_date < ?
+                """, ScanLogType.SCAN_ALL.name(), ScanLogType.SCAN_ALL.name(), retention);
+        update("""
+                delete from scan_log
+                where type <> ? and start_date < ?
+                """, ScanLogType.SCAN_ALL.name(), retention);
+        update("""
+                delete from scan_event
+                where (type=? or type=? or type=?)
+                """, ScanEventType.FOLDER_CREATE.name(), ScanEventType.FOLDER_DELETE.name(),
+                ScanEventType.FOLDER_UPDATE.name());
     }
 
     public void createScanEvent(@NonNull ScanEvent scanEvent) {
-        update("insert into scan_event (" + EVENT_QUERY_COLUMNS + ") values(?, ?, ?, ?, ?, ?, ?, ?)",
-                scanEvent.getStartDate(), scanEvent.getExecuted(), scanEvent.getType().name(), scanEvent.getMaxMemory(),
-                scanEvent.getTotalMemory(), scanEvent.getFreeMemory(), scanEvent.getMaxThread(),
-                scanEvent.getComment());
+        update("""
+                insert into scan_event (%s)
+                values(?, ?, ?, ?, ?, ?, ?, ?)
+                """.formatted(EVENT_QUERY_COLUMNS), scanEvent.getStartDate(), scanEvent.getExecuted(),
+                scanEvent.getType().name(), scanEvent.getMaxMemory(), scanEvent.getTotalMemory(),
+                scanEvent.getFreeMemory(), scanEvent.getMaxThread(), scanEvent.getComment());
     }
 
     public void deleteOtherThanLatest() {
-        update("delete from scan_log where type = ? and start_date <> (select start_date from scan_log "
-                + "where type = ? order by start_date desc limit 1)", ScanLogType.SCAN_ALL.name(),
-                ScanLogType.SCAN_ALL.name());
-        update("delete from scan_log where type <> ?", ScanLogType.SCAN_ALL.name());
-        update("delete from scan_event where (type=? or type=? or type=?)", ScanEventType.FOLDER_CREATE.name(),
-                ScanEventType.FOLDER_DELETE.name(), ScanEventType.FOLDER_UPDATE.name());
+        update("""
+                delete from scan_log
+                where type = ? and start_date <>
+                        (select start_date
+                        from scan_log
+                        where type = ?
+                        order by start_date desc
+                        limit 1)
+                """, ScanLogType.SCAN_ALL.name(), ScanLogType.SCAN_ALL.name());
+        update("""
+                delete from scan_log
+                where type <> ?
+                """, ScanLogType.SCAN_ALL.name());
+        update("""
+                delete from scan_event
+                where (type=? or type=? or type=?)
+                """, ScanEventType.FOLDER_CREATE.name(), ScanEventType.FOLDER_DELETE.name(),
+                ScanEventType.FOLDER_UPDATE.name());
     }
 
     public List<MediaLibraryStatistics> getRecentMediaLibraryStatistics() {
-        String sql = "select start_date, folder_id, artist_count, album_count, song_count, video_count, total_size, total_duration "
-                + "from media_library_statistics where start_date = (select max(start_date) from scan_log where type = 'SCAN_ALL')";
+        String sql = """
+                select start_date, folder_id, artist_count, album_count,
+                        song_count, video_count, total_size, total_duration
+                from media_library_statistics
+                where start_date =
+                        (select max(start_date)
+                        from scan_log
+                        where type = 'SCAN_ALL')
+                """;
         return query(sql, libStatsMapper);
     }
 
     public boolean isNeverScanned() {
-        return queryForInt("select count(*) from scan_log where type='SCAN_ALL'", 0) == 0;
+        return queryForInt("""
+                select count(*)
+                from scan_log
+                where type='SCAN_ALL'
+                """, 0) == 0;
     }
 
     public boolean isfolderChangedSinceLastScan() {
         Map<String, Object> args = LegacyMap.of("folderChanges", Arrays.asList(ScanEventType.FOLDER_CREATE.name(),
                 ScanEventType.FOLDER_DELETE.name(), ScanEventType.FOLDER_UPDATE.name()), "scanAll",
                 ScanLogType.SCAN_ALL.name());
-        return namedQueryForInt(
-                "select count(*) from scan_event events where type in (:folderChanges) and events.start_date > "
-                        + "(select start_date from scan_log where type = :scanAll order by start_date desc limit 1)",
-                0, args) > 0;
+        return namedQueryForInt("""
+                select count(*)
+                from scan_event events
+                where type in (:folderChanges) and events.start_date >
+                        (select start_date
+                        from scan_log
+                        where type = :scanAll
+                        order by start_date desc
+                        limit 1)
+                """, 0, args) > 0;
     }
 
-    public MediaLibraryStatistics gatherMediaLibraryStatistics(@NonNull Instant scanDate, MusicFolder folder) {
-        String query = "select (select id from music_folder where path = :folder) as folder_id, "
-                + "count(case when present and folder = :folder and type = :directory and media_file.path <> folder then 1 end) as artist_count, "
-                + "count(case when present and folder = :folder and type = :album then 1 end) as album_count, "
-                + "count(case when present and folder = :folder and type = :music then 1 end) as song_count, "
-                + "count(case when present and folder = :folder and type = :video then 1 end) as video_count, "
-                + "sum(case when present and folder = :folder and type = :music then file_size end) as total_size, "
-                + "sum(case when present and folder = :folder and type = :music then duration_seconds end) as total_duration "
-                + "from media_file ";
+    public @NonNull MediaLibraryStatistics gatherMediaLibraryStatistics(@NonNull Instant scanDate,
+            @NonNull MusicFolder folder) {
+        String query = """
+                select (select id from music_folder where path = :folder) as folder_id,
+                        count(
+                                case
+                                    when present
+                                            and folder = :folder
+                                            and type = :directory
+                                            and media_file.path <> folder
+                                    then 1
+                                end) as artist_count,
+                        count(
+                                case
+                                    when present
+                                            and folder = :folder
+                                            and type = :album
+                                    then 1
+                                end) as album_count,
+                        count(
+                                case
+                                    when present and folder = :folder and type = :music
+                                    then 1
+                                end) as song_count,
+                        count(
+                                case
+                                    when present and folder = :folder and type = :video
+                                    then 1
+                                end) as video_count,
+                        sum(
+                                case
+                                    when present and folder = :folder and type = :music
+                                    then file_size
+                                end) as total_size,
+                        sum(
+                                case
+                                    when present and folder = :folder and type = :music
+                                    then duration_seconds
+                                end) as total_duration
+                from media_file
+                """;
         RowMapper<MediaLibraryStatistics> mapper = (ResultSet rs, int rowNum) -> {
             return new MediaLibraryStatistics(scanDate, rs.getInt(1), rs.getInt(2), rs.getInt(3), rs.getInt(4),
                     rs.getInt(5), rs.getLong(6), rs.getLong(7));
@@ -145,19 +236,33 @@ public class StaticsDao extends AbstractDao {
     }
 
     public void createMediaLibraryStatistics(MediaLibraryStatistics stats) {
-        String sql = "insert into media_library_statistics (start_date, folder_id, artist_count, album_count, "
-                + "song_count, video_count, total_size, total_duration) values (?, ?, ?, ?, ?, ?, ?, ?)";
+        String sql = """
+                insert into media_library_statistics
+                        (start_date, folder_id, artist_count,
+                        album_count, song_count, video_count,
+                        total_size, total_duration)
+                values (?, ?, ?, ?, ?, ?, ?, ?)
+                """;
         update(sql, stats.getExecuted(), stats.getFolderId(), stats.getArtistCount(), stats.getAlbumCount(),
                 stats.getSongCount(), stats.getVideoCount(), stats.getTotalSize(), stats.getTotalDuration());
     }
 
     public List<ScanEvent> getScanEvents(@NonNull Instant scanDate) {
-        String sql = "select " + EVENT_QUERY_COLUMNS + " from scan_event where start_date = ? order by executed";
+        String sql = "select " + EVENT_QUERY_COLUMNS + """
+                from scan_event
+                where start_date = ? order by executed
+                """;
         return query(sql, scanEventMapper, scanDate);
     }
 
-    public ScanEventType getLastScanEventType(@NonNull Instant startDate) {
-        String sql = "select type from scan_event where start_date=? order by executed desc limit 1";
+    public @NonNull ScanEventType getLastScanEventType(@NonNull Instant startDate) {
+        String sql = """
+                select type
+                from scan_event
+                where start_date=?
+                order by executed desc
+                limit 1
+                """;
         List<String> result = queryForStrings(sql, startDate);
         if (result.isEmpty()) {
             return ScanEventType.UNKNOWN;
@@ -171,9 +276,16 @@ public class StaticsDao extends AbstractDao {
                 Arrays.asList(ScanEventType.SUCCESS.name(), ScanEventType.FINISHED.name(),
                         ScanEventType.DESTROYED.name(), ScanEventType.CANCELED.name()),
                 "logType", ScanLogType.SCAN_ALL.name());
-        String sql = "select " + prefix(EVENT_QUERY_COLUMNS, "event") + " from scan_event event "
-                + "join (select start_date from scan_log where type = :logType order by start_date desc limit 1) last_log "
-                + "on last_log.start_date = event.start_date where type in (:eventTypes)";
+        String sql = "select " + prefix(EVENT_QUERY_COLUMNS, "event") + """
+                from scan_event event
+                join
+                        (select start_date
+                        from scan_log
+                        where type = :logType
+                        order by start_date desc limit 1) last_log
+                on last_log.start_date = event.start_date
+                where type in (:eventTypes)
+                """;
         return namedQuery(sql, scanEventMapper, args);
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/TranscodingDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/TranscodingDao.java
@@ -38,7 +38,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Repository
 public class TranscodingDao extends AbstractDao {
 
-    private static final String INSERT_COLUMNS = "name, source_formats, target_format, step1, step2, step3, default_active";
+    private static final String INSERT_COLUMNS = """
+            name, source_formats, target_format, step1, step2, step3, default_active\s
+            """;
     private static final String QUERY_COLUMNS = "id, " + INSERT_COLUMNS;
 
     private final TranscodingRowMapper rowMapper;
@@ -48,59 +50,41 @@ public class TranscodingDao extends AbstractDao {
         rowMapper = new TranscodingRowMapper();
     }
 
-    /**
-     * Returns all transcodings.
-     *
-     * @return Possibly empty list of all transcodings.
-     */
     public List<Transcoding> getAllTranscodings() {
-        String sql = "select " + QUERY_COLUMNS + " from transcoding2";
+        String sql = "select " + QUERY_COLUMNS + "from transcoding2";
         return query(sql, rowMapper);
     }
 
-    /**
-     * Returns all active transcodings for the given player.
-     *
-     * @param playerId
-     *            The player ID.
-     *
-     * @return All active transcodings for the player.
-     */
     public List<Transcoding> getTranscodingsForPlayer(Integer playerId) {
-        String sql = "select " + QUERY_COLUMNS + " from transcoding2, player_transcoding2 "
-                + "where player_transcoding2.player_id = ? "
-                + "and   player_transcoding2.transcoding_id = transcoding2.id";
+        String sql = "select " + QUERY_COLUMNS + """
+                from transcoding2, player_transcoding2
+                where player_transcoding2.player_id = ?
+                        and player_transcoding2.transcoding_id = transcoding2.id
+                """;
         return query(sql, rowMapper, playerId);
     }
 
-    /**
-     * Sets the list of active transcodings for the given player.
-     *
-     * @param playerId
-     *            The player ID.
-     * @param transcodingIds
-     *            ID's of the active transcodings.
-     */
     @Transactional
     public void setTranscodingsForPlayer(Integer playerId, int... transcodingIds) {
-        update("delete from player_transcoding2 where player_id = ?", playerId);
-        String sql = "insert into player_transcoding2(player_id, transcoding_id) values (?, ?)";
+        update("""
+                delete from player_transcoding2
+                where player_id = ?
+                """, playerId);
+        String sql = """
+                insert into player_transcoding2(player_id, transcoding_id)
+                values (?, ?)
+                """;
         for (int transcodingId : transcodingIds) {
             update(sql, playerId, transcodingId);
         }
     }
 
-    /**
-     * Creates a new transcoding.
-     *
-     * @param transcoding
-     *            The transcoding to create.
-     *
-     * @return registered ID that is assumed to be registered
-     */
     @Transactional
     public int createTranscoding(Transcoding transcoding) {
-        Integer existingMax = queryForInt("select max(id) from transcoding2", 0);
+        Integer existingMax = queryForInt("""
+                select max(id)
+                from transcoding2
+                """, 0);
         int registered = existingMax + 1;
         transcoding.setId(registered);
         String sql = "insert into transcoding2 (" + QUERY_COLUMNS + ") values (" + questionMarks(QUERY_COLUMNS) + ")";
@@ -110,26 +94,21 @@ public class TranscodingDao extends AbstractDao {
         return registered;
     }
 
-    /**
-     * Deletes the transcoding with the given ID.
-     *
-     * @param id
-     *            The transcoding ID.
-     */
     public void deleteTranscoding(Integer id) {
-        String sql = "delete from transcoding2 where id=?";
+        String sql = """
+                delete from transcoding2
+                where id=?
+                """;
         update(sql, id);
     }
 
-    /**
-     * Updates the given transcoding.
-     *
-     * @param transcoding
-     *            The transcoding to update.
-     */
     public void updateTranscoding(Transcoding transcoding) {
-        String sql = "update transcoding2 set name=?, source_formats=?, target_format=?, "
-                + "step1=?, step2=?, step3=?, default_active=? where id=?";
+        String sql = """
+                update transcoding2
+                set name=?, source_formats=?, target_format=?,
+                        step1=?, step2=?, step3=?, default_active=?
+                where id=?
+                """;
         update(sql, transcoding.getName(), transcoding.getSourceFormats(), transcoding.getTargetFormat(),
                 transcoding.getStep1(), transcoding.getStep2(), transcoding.getStep3(), transcoding.isDefaultActive(),
                 transcoding.getId());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/UserDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/UserDao.java
@@ -77,7 +77,6 @@ public class UserDao extends AbstractDao {
     private static final int ROLE_ID_PODCAST = 7;
     private static final int ROLE_ID_STREAM = 8;
     private static final int ROLE_ID_SETTINGS = 9;
-    private static final int ROLE_ID_JUKEBOX = 10;
     private static final int ROLE_ID_SHARE = 11;
     private static final int SINGLE_USER = 1;
 
@@ -298,47 +297,21 @@ public class UserDao extends AbstractDao {
     private void readRoles(User user) {
         String sql = "select role_id from user_role where username=?";
         List<?> roles = getJdbcTemplate().queryForList(sql, Integer.class, new Object[] { user.getUsername() });
-        for (Object role : roles) {
+        roles.forEach(role -> {
             switch ((Integer) role) {
-            case ROLE_ID_ADMIN:
-                user.setAdminRole(true);
-                break;
-            case ROLE_ID_DOWNLOAD:
-                user.setDownloadRole(true);
-                break;
-            case ROLE_ID_UPLOAD:
-                user.setUploadRole(true);
-                break;
-            case ROLE_ID_PLAYLIST:
-                user.setPlaylistRole(true);
-                break;
-            case ROLE_ID_COVER_ART:
-                user.setCoverArtRole(true);
-                break;
-            case ROLE_ID_COMMENT:
-                user.setCommentRole(true);
-                break;
-            case ROLE_ID_PODCAST:
-                user.setPodcastRole(true);
-                break;
-            case ROLE_ID_STREAM:
-                user.setStreamRole(true);
-                break;
-            case ROLE_ID_SETTINGS:
-                user.setSettingsRole(true);
-                break;
-            case ROLE_ID_JUKEBOX:
-                break;
-            case ROLE_ID_SHARE:
-                user.setShareRole(true);
-                break;
-            default:
-                if (LOG.isWarnEnabled()) {
-                    LOG.warn("Unknown role: '" + role + '\'');
-                }
-                break;
+            case ROLE_ID_ADMIN -> user.setAdminRole(true);
+            case ROLE_ID_DOWNLOAD -> user.setDownloadRole(true);
+            case ROLE_ID_UPLOAD -> user.setUploadRole(true);
+            case ROLE_ID_PLAYLIST -> user.setPlaylistRole(true);
+            case ROLE_ID_COVER_ART -> user.setCoverArtRole(true);
+            case ROLE_ID_COMMENT -> user.setCommentRole(true);
+            case ROLE_ID_PODCAST -> user.setPodcastRole(true);
+            case ROLE_ID_STREAM -> user.setStreamRole(true);
+            case ROLE_ID_SETTINGS -> user.setSettingsRole(true);
+            case ROLE_ID_SHARE -> user.setShareRole(true);
+            default -> LOG.warn("Unknown role: '" + role + '\'');
             }
-        }
+        });
     }
 
     @SuppressWarnings("PMD.NPathComplexity") // It's not particularly difficult, so you can leave it as it is.

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Album.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Album.java
@@ -23,7 +23,7 @@ package com.tesshu.jpsonic.domain;
 
 import java.time.Instant;
 
-public class Album implements Orderable {
+public final class Album implements Orderable {
 
     private int id;
     private String path;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/AlphanumWrapper.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/AlphanumWrapper.java
@@ -122,10 +122,9 @@ class AlphanumWrapper extends Collator {
         if (o == this) {
             return true;
         }
-        if (!(o instanceof AlphanumWrapper)) {
+        if (!(o instanceof AlphanumWrapper that)) {
             return false;
         }
-        AlphanumWrapper that = (AlphanumWrapper) o;
         return new EqualsBuilder().appendSuper(super.equals(that)).append(that, that.deligate).isEquals();
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Artist.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Artist.java
@@ -23,7 +23,7 @@ package com.tesshu.jpsonic.domain;
 
 import java.time.Instant;
 
-public class Artist implements Orderable {
+public final class Artist implements Orderable {
 
     private int id;
     private String name;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/JapaneseReadingUtils.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/JapaneseReadingUtils.java
@@ -350,32 +350,21 @@ public class JapaneseReadingUtils {
         case ADVERB:
             return pron.concat(SPACE);
         case POSTPOSITIONAL_PARTICLE:
-            switch (level2) {
-            case CONJUNCTIVE_PARTICLE:
-                return pron.concat(SPACE);
-            case ADVERBIAL_PARTICLE:
-                return pron.concat(SPACE);
-            case SENTENCE_ENDING_PARTICLE:
-                return pron;
-            case MULTI_PARTICLE:
-                return pron;
-            default:
-                return SPACE.concat(pron).concat(SPACE);
-            }
+            return switch (level2) {
+            case CONJUNCTIVE_PARTICLE, ADVERBIAL_PARTICLE -> pron.concat(SPACE);
+            case SENTENCE_ENDING_PARTICLE, MULTI_PARTICLE -> pron;
+            default -> SPACE.concat(pron).concat(SPACE);
+            };
         case SYMBOL:
-            switch (level2) {
-            case COMMA:
-                return pron.concat(SPACE);
-            case PERIOD:
-                return pron.concat(SPACE);
-            default:
-                return pron;
-            }
+            return switch (level2) {
+            case COMMA, PERIOD -> pron.concat(SPACE);
+            default -> pron;
+            };
         case NOUN:
-            if (level2 == Tag.SUFFIX) {
-                return HYPHEN.concat(pron);
-            }
-            break;
+            return switch (level2) {
+            case SUFFIX -> HYPHEN.concat(pron);
+            default -> pron;
+            };
         default:
             break;
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaFile.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaFile.java
@@ -463,7 +463,14 @@ public class MediaFile implements Orderable {
 
     @Override
     public boolean equals(Object o) {
-        return o instanceof MediaFile && ((MediaFile) o).pathString.equals(pathString);
+        if (this == o) {
+            return true;
+        } else if (pathString == null) {
+            return false;
+        } else if (o instanceof MediaFile that) {
+            return pathString.equals(that.pathString);
+        }
+        return false;
     }
 
     @Override

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaFile.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MediaFile.java
@@ -40,7 +40,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * @author Sindre Mehus
  */
-public class MediaFile implements Orderable {
+// Will change from non-sealed to final in the future.
+public non-sealed class MediaFile implements Orderable {
 
     private int id;
     private String pathString;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicFolder.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicFolder.java
@@ -109,11 +109,12 @@ public class MusicFolder implements Serializable {
     public boolean equals(Object o) {
         if (this == o) {
             return true;
-        }
-        if (!(o instanceof MusicFolder)) {
+        } else if (id == null) {
             return false;
+        } else if (o instanceof MusicFolder that) {
+            return id.equals(that.id);
         }
-        return Objects.equals(id, ((MusicFolder) o).id);
+        return false;
     }
 
     @Override

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicIndex.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicIndex.java
@@ -27,6 +27,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+
 /**
  * A music index is a mapping from an index string to a list of prefixes. A complete index consists of a list of
  * <code>MusicIndex</code> instances.
@@ -57,7 +59,7 @@ public class MusicIndex implements Serializable {
      * @param index
      *            The index string, e.g., "A" or "The".
      */
-    public MusicIndex(String index) {
+    public MusicIndex(@NonNull String index) {
         this.index = index;
     }
 
@@ -102,14 +104,10 @@ public class MusicIndex implements Serializable {
     public boolean equals(Object o) {
         if (this == o) {
             return true;
+        } else if (o instanceof MusicIndex that) {
+            return Objects.equals(index, that.index);
         }
-        if (!(o instanceof MusicIndex)) {
-            return false;
-        }
-
-        final MusicIndex musicIndex = (MusicIndex) o;
-
-        return Objects.equals(index, musicIndex.index);
+        return false;
     }
 
     /**

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Orderable.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Orderable.java
@@ -19,7 +19,7 @@
 
 package com.tesshu.jpsonic.domain;
 
-public interface Orderable {
+public sealed interface Orderable permits Album, Artist, MediaFile {
 
     int getOrder();
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Transcoding.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Transcoding.java
@@ -22,7 +22,6 @@
 package com.tesshu.jpsonic.domain;
 
 import java.util.List;
-import java.util.Objects;
 
 import com.tesshu.jpsonic.util.StringUtil;
 
@@ -226,13 +225,12 @@ public class Transcoding {
     public boolean equals(Object o) {
         if (this == o) {
             return true;
-        }
-        if (!(o instanceof Transcoding)) {
+        } else if (id == null) {
             return false;
+        } else if (o instanceof Transcoding that) {
+            return id.equals(that.id);
         }
-
-        Transcoding that = (Transcoding) o;
-        return Objects.equals(id, that.id);
+        return false;
     }
 
     @Override

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Version.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/Version.java
@@ -21,9 +21,12 @@
 
 package com.tesshu.jpsonic.domain;
 
+import java.util.Objects;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * Represents the version number of Airsonic.
@@ -40,7 +43,7 @@ public class Version implements Comparable<Version> {
      * @param version
      *            A string of the format "1.27", "1.27.2" or "1.27.beta3".
      */
-    public Version(String version) {
+    public Version(@NonNull String version) {
         this.internalVersion = new DefaultArtifactVersion(version);
     }
 
@@ -62,11 +65,12 @@ public class Version implements Comparable<Version> {
      */
     @Override
     public boolean equals(Object o) {
-        if (o instanceof Version) {
-            return internalVersion.equals(((Version) o).internalVersion);
-        } else {
-            return false;
+        if (this == o) {
+            return true;
+        } else if (o instanceof Version that) {
+            return Objects.equals(internalVersion, that.internalVersion);
         }
+        return false;
     }
 
     /**

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/filter/BootstrapVerificationFilter.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/filter/BootstrapVerificationFilter.java
@@ -93,8 +93,8 @@ public class BootstrapVerificationFilter implements Filter {
     }
 
     private void logServerInfo(ServletRequest req) {
-        if (!serverInfoLogged.getAndSet(true) && req instanceof HttpServletRequest) {
-            String serverInfo = ((HttpServletRequest) req).getSession().getServletContext().getServerInfo();
+        if (!serverInfoLogged.getAndSet(true) && req instanceof HttpServletRequest hsr) {
+            String serverInfo = hsr.getSession().getServletContext().getServerInfo();
             if (LOG.isInfoEnabled()) {
                 LOG.info("Servlet container: " + serverInfo);
             }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/RecoverService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/RecoverService.java
@@ -101,9 +101,15 @@ public class RecoverService {
             message.setFrom(new InternetAddress(settingsService.getSmtpFrom()));
             message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(email));
             message.setSubject("Jpsonic Password");
-            message.setText("Hi there!\n\n"
-                    + "You have requested to reset your Jpsonic password.  Please find your new login details below.\n\n"
-                    + "Username: " + username + "\n" + "Password: ******\n\n");
+            message.setText("""
+                    Hi there!
+
+                    You have requested to reset your Jpsonic password. Please find your new login details below.
+
+                    Username: %s
+                    Password: ******
+
+                    """.formatted(username));
             message.setSentDate(Date.from(now()));
 
             try (Transport trans = session.getTransport(prot)) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/TranscodingService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/TranscodingService.java
@@ -724,56 +724,34 @@ public class TranscodingService {
      * it can be changed and consistency is not guaranteed. Delete insert is done, in this method.
      */
     @Transactional
-    public void restoreTranscoding(Transcodings transcode, boolean addTag) {
+    public void restoreTranscoding(@NonNull Transcodings transcode, boolean addTag) {
         if (transcode == null) {
             return;
         }
-        Transcoding transcoding;
-        switch (transcode) {
-
-        case MP3:
-            transcoding = new Transcoding(null, Transcodings.MP3.getName(),
-                    "mp3 ogg oga aac m4a flac wav wma aif aiff ape mpc shn", "mp3",
-                    "ffmpeg -i %s -map 0:0 -b:a %bk ".concat(addTag ? "-id3v2_version 3 " : "").concat("-v 0 -f mp3 -"),
-                    null, null, true);
-            break;
-
-        case FLAC:
-            transcoding = new Transcoding(null, Transcodings.FLAC.getName(), FORMAT_FLAC, FORMAT_FLAC,
-                    "ffmpeg -i %s -map 0:0 -v 0 -sample_fmt s16 -vn -ar 44100 -ac 2 -acodec flac -f flac -", null, null,
-                    false);
-            break;
-
-        case DSF:
-            transcoding = new Transcoding(null, Transcodings.DSF.getName(), "dsf", FORMAT_FLAC,
-                    "ffmpeg -i %s -map 0:0 -v 0 -sample_fmt s16 -vn -ar 44100 -ac 2 -acodec flac -f flac -af \"lowpass=24000, volume=6dB\" -",
-                    null, null, false);
-            break;
-
-        case FLV:
-            transcoding = new Transcoding(null, Transcodings.FLV.getName(),
-                    "avi mpg mpeg mp4 m4v mkv mov wmv ogv divx m2ts", "flv",
-                    "ffmpeg -ss %o -i %s -async 1 -b %bk -s %wx%h -ar 44100 -ac 2 -v 0 -f flv -vcodec libx264 -preset superfast -threads 0 -",
-                    null, null, true);
-            break;
-
-        case MKV:
-            transcoding = new Transcoding(null, Transcodings.MKV.getName(),
-                    "avi mpg mpeg mp4 m4v mkv mov wmv ogv divx m2ts", "mkv",
-                    "ffmpeg -ss %o -i %s -c:v libx264 -preset superfast -b:v %bk -c:a libvorbis -f matroska -threads 0 -",
-                    null, null, true);
-            break;
-
-        case MP4:
-            transcoding = new Transcoding(null, Transcodings.MP4.getName(),
-                    "avi flv mpg mpeg m4v mkv mov wmv ogv divx m2ts", "mp4",
-                    "ffmpeg -ss %o -i %s -async 1 -b %bk -s %wx%h -ar 44100 -ac 2 -v 0 -f mp4 -vcodec libx264 -preset superfast -threads 0 -movflags frag_keyframe+empty_moov -",
-                    null, null, true);
-            break;
-
-        default:
-            return;
-        }
+        Transcoding transcoding = switch (transcode) {
+        case MP3 -> new Transcoding(null, Transcodings.MP3.getName(),
+                "mp3 ogg oga aac m4a flac wav wma aif aiff ape mpc shn", "mp3",
+                "ffmpeg -i %s -map 0:0 -b:a %bk ".concat(addTag ? "-id3v2_version 3 " : "").concat("-v 0 -f mp3 -"),
+                null, null, true);
+        case FLAC -> new Transcoding(null, Transcodings.FLAC.getName(), FORMAT_FLAC, FORMAT_FLAC,
+                "ffmpeg -i %s -map 0:0 -v 0 -sample_fmt s16 -vn -ar 44100 -ac 2 -acodec flac -f flac -", null, null,
+                false);
+        case DSF -> new Transcoding(null, Transcodings.DSF.getName(), "dsf", FORMAT_FLAC,
+                "ffmpeg -i %s -map 0:0 -v 0 -sample_fmt s16 -vn -ar 44100 -ac 2 -acodec flac -f flac -af \"lowpass=24000, volume=6dB\" -",
+                null, null, false);
+        case FLV -> new Transcoding(null, Transcodings.FLV.getName(), "avi mpg mpeg mp4 m4v mkv mov wmv ogv divx m2ts",
+                "flv",
+                "ffmpeg -ss %o -i %s -async 1 -b %bk -s %wx%h -ar 44100 -ac 2 -v 0 -f flv -vcodec libx264 -preset superfast -threads 0 -",
+                null, null, true);
+        case MKV -> new Transcoding(null, Transcodings.MKV.getName(), "avi mpg mpeg mp4 m4v mkv mov wmv ogv divx m2ts",
+                "mkv",
+                "ffmpeg -ss %o -i %s -c:v libx264 -preset superfast -b:v %bk -c:a libvorbis -f matroska -threads 0 -",
+                null, null, true);
+        case MP4 -> new Transcoding(null, Transcodings.MP4.getName(), "avi flv mpg mpeg m4v mkv mov wmv ogv divx m2ts",
+                "mp4",
+                "ffmpeg -ss %o -i %s -async 1 -b %bk -s %wx%h -ar 44100 -ac 2 -v 0 -f mp4 -vcodec libx264 -preset superfast -threads 0 -movflags frag_keyframe+empty_moov -",
+                null, null, true);
+        };
 
         // Newly created transcode
         int registered = transcodingDao.createTranscoding(transcoding);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/UPnPService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/UPnPService.java
@@ -275,8 +275,8 @@ public class UPnPService {
         List<String> result = new ArrayList<>();
         for (Device<?, ?, ?> device : deligate.getRegistry()
                 .getDevices(new DeviceType("schemas-upnp-org", "ZonePlayer"))) {
-            if (device instanceof RemoteDevice) {
-                URL descriptorURL = ((RemoteDevice) device).getIdentity().getDescriptorURL();
+            if (device instanceof RemoteDevice remoteDevice) {
+                URL descriptorURL = remoteDevice.getIdentity().getDescriptorURL();
                 if (descriptorURL != null) {
                     result.add(descriptorURL.getHost());
                 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MusicParser.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/MusicParser.java
@@ -142,7 +142,7 @@ public class MusicParser extends MetaDataParser {
         Tag tag = af.getTag();
         if (isEmpty(tag)) {
             return metaData;
-        } else if (tag instanceof WavTag && !((WavTag) tag).isExistingId3Tag()) {
+        } else if (tag instanceof WavTag wavTag && !wavTag.isExistingId3Tag()) {
             if (LOG.isInfoEnabled()) {
                 LOG.info("Only ID3 chunk is supported: {}", FileUtil.getShortPath(path));
             }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/ParserUtils.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/metadata/ParserUtils.java
@@ -220,7 +220,7 @@ public final class ParserUtils {
         Tag tag = af.getTag();
         if (isEmpty(tag)) {
             return Optional.empty();
-        } else if (tag instanceof WavTag && !((WavTag) tag).isExistingId3Tag()) {
+        } else if (tag instanceof WavTag wavTag && !wavTag.isExistingId3Tag()) {
             if (LOG.isInfoEnabled()) {
                 LOG.info("Cover art is only supported in ID3 chunks: {}", getShortPath(path));
             }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/playlist/XspfPlaylistImportHandler.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/playlist/XspfPlaylistImportHandler.java
@@ -79,8 +79,7 @@ public class XspfPlaylistImportHandler implements PlaylistImportHandler {
     }
 
     private @Nullable MediaFile getMediaFile(StringContainer sc) {
-        if (sc instanceof Location) {
-            Location location = (Location) sc;
+        if (sc instanceof Location location) {
             try {
                 if (sc.getText() != null) {
                     MediaFile mediaFile = mediaFileService.getMediaFile(Path.of(location.getText()));

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/UPnPSearchCriteriaDirector.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/UPnPSearchCriteriaDirector.java
@@ -424,8 +424,7 @@ public class UPnPSearchCriteriaDirector implements UPnPSearchCriteriaListener {
     private List<String> purseSearchFields(String upnpProp) {
         List<String> fieldName = new ArrayList<>();
         switch (upnpProp) {
-
-        case "dc:title":
+        case "dc:title" -> {
             if (Album.class == assignableClass) {
                 fieldName.add(FieldNamesConstants.ALBUM);
                 fieldName.add(FieldNamesConstants.ALBUM_READING);
@@ -436,45 +435,33 @@ public class UPnPSearchCriteriaDirector implements UPnPSearchCriteriaListener {
                 fieldName.add(FieldNamesConstants.TITLE);
                 fieldName.add(FieldNamesConstants.TITLE_READING);
             }
-            break;
-
-        case "upnp:artist":
-        case UPNP_PROP_ILLEGAL_ALBUM_ARTIST:
+        }
+        case "upnp:artist", UPNP_PROP_ILLEGAL_ALBUM_ARTIST -> {
             fieldName.add(FieldNamesConstants.ARTIST);
             fieldName.add(FieldNamesConstants.ARTIST_READING);
-            break;
-
-        case "dc:creator":
-        case "upnp:author":
+        }
+        case "dc:creator", "upnp:author" -> {
             fieldName.add(FieldNamesConstants.COMPOSER);
             fieldName.add(FieldNamesConstants.COMPOSER_READING);
-            break;
-
-        case "upnp:genre":
+        }
+        case "upnp:genre" -> {
             fieldName.add(FieldNamesConstants.GENRE);
-            break;
-
-        case UPNP_PROP_ALBUM:
+        }
+        case UPNP_PROP_ALBUM -> {
             if (Album.class == assignableClass) {
                 // Currently unreachable.
                 // (Searching the Album field of an AudioItem is not common.
-                // Because it is common to search for the container title of an album or musicAlbum.)
+                // Because it is common to search for the container title of an album or
+                // musicAlbum.)
                 // Therefore, Jpsonic does not have an "album" field for "song" search.
                 // (Increasing the number of fields leads to an increase in false searches)
                 fieldName.add(FieldNamesConstants.ALBUM);
                 fieldName.add(FieldNamesConstants.ALBUM_READING);
             }
-            break;
-
-        default:
-            /*
-             * Only the properties corresponding to the client application to be tested are added sequentially along
-             * with the operation check. Therefore, properties that have not been used will not be mapped and will be
-             * ignored. And non-standard properties(illegalProp) will be ignored.
-             */
-            break;
         }
-
+        default -> {
+        }
+        }
         return fieldName;
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/Router.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/Router.java
@@ -21,7 +21,7 @@
 
 package com.tesshu.jpsonic.service.upnp;
 
-public interface Router {
+public sealed interface Router permits NATPMPRouter {
 
     /**
      * Adds a NAT entry on the UPNP device.

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/UpnpProcessDispatcher.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/UpnpProcessDispatcher.java
@@ -96,44 +96,25 @@ public interface UpnpProcessDispatcher {
 
     @SuppressWarnings("rawtypes")
     default UpnpContentProcessor findProcessor(String type) {
-        switch (type) {
-        case CONTAINER_ID_ROOT:
-            return getRootProcessor();
-        case CONTAINER_ID_PLAYLIST_PREFIX:
-            return getPlaylistProcessor();
-        case CONTAINER_ID_FOLDER_PREFIX:
-            return getMediaFileProcessor();
-        case CONTAINER_ID_ALBUM_PREFIX:
-            return getAlbumProcessor();
-        case CONTAINER_ID_RECENT_PREFIX:
-            return getRecentAlbumProcessor();
-        case CONTAINER_ID_RECENT_ID3_PREFIX:
-            return getRecentAlbumId3Processor();
-        case CONTAINER_ID_ARTIST_PREFIX:
-            return getArtistProcessor();
-        case CONTAINER_ID_ARTIST_BY_FOLDER_PREFIX:
-            return getArtistByFolderProcessor();
-        case CONTAINER_ID_ALBUM_BY_GENRE_PREFIX:
-            return getAlbumByGenreProcessor();
-        case CONTAINER_ID_SONG_BY_GENRE_PREFIX:
-            return getSongByGenreProcessor();
-        case CONTAINER_ID_INDEX_PREFIX:
-            return getIndexProcessor();
-        case CONTAINER_ID_INDEX_ID3_PREFIX:
-            return getIndexId3Processor();
-        case CONTAINER_ID_PODCAST_PREFIX:
-            return getPodcastProcessor();
-        case CONTAINER_ID_RANDOM_ALBUM:
-            return getRandomAlbumProcessor();
-        case CONTAINER_ID_RANDOM_SONG:
-            return getRandomSongProcessor();
-        case CONTAINER_ID_RANDOM_SONG_BY_ARTIST:
-            return getRandomSongByArtistProcessor();
-        case CONTAINER_ID_RANDOM_SONG_BY_FOLDER_ARTIST:
-            return getRandomSongByFolderArtistProcessor();
-        default:
-            throw new AssertionError(String.format("Unreachable code(%s=%s).", "type", type));
-        }
+        return switch (type) {
+        case CONTAINER_ID_ROOT -> getRootProcessor();
+        case CONTAINER_ID_PLAYLIST_PREFIX -> getPlaylistProcessor();
+        case CONTAINER_ID_FOLDER_PREFIX -> getMediaFileProcessor();
+        case CONTAINER_ID_ALBUM_PREFIX -> getAlbumProcessor();
+        case CONTAINER_ID_RECENT_PREFIX -> getRecentAlbumProcessor();
+        case CONTAINER_ID_RECENT_ID3_PREFIX -> getRecentAlbumId3Processor();
+        case CONTAINER_ID_ARTIST_PREFIX -> getArtistProcessor();
+        case CONTAINER_ID_ARTIST_BY_FOLDER_PREFIX -> getArtistByFolderProcessor();
+        case CONTAINER_ID_ALBUM_BY_GENRE_PREFIX -> getAlbumByGenreProcessor();
+        case CONTAINER_ID_SONG_BY_GENRE_PREFIX -> getSongByGenreProcessor();
+        case CONTAINER_ID_INDEX_PREFIX -> getIndexProcessor();
+        case CONTAINER_ID_INDEX_ID3_PREFIX -> getIndexId3Processor();
+        case CONTAINER_ID_PODCAST_PREFIX -> getPodcastProcessor();
+        case CONTAINER_ID_RANDOM_ALBUM -> getRandomAlbumProcessor();
+        case CONTAINER_ID_RANDOM_SONG -> getRandomSongProcessor();
+        case CONTAINER_ID_RANDOM_SONG_BY_ARTIST -> getRandomSongByArtistProcessor();
+        case CONTAINER_ID_RANDOM_SONG_BY_FOLDER_ARTIST -> getRandomSongByFolderArtistProcessor();
+        default -> throw new AssertionError(String.format("Unreachable code(%s=%s).", "type", type));
+        };
     }
-
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/spring/AirsonicSpringLiquibase.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/spring/AirsonicSpringLiquibase.java
@@ -62,12 +62,14 @@ public class AirsonicSpringLiquibase extends SpringLiquibase {
             super.afterPropertiesSet();
         } catch (LiquibaseException e) {
             if (LOG.isErrorEnabled()) {
-                LOG.error("===============================================");
-                LOG.error("An exception occurred during database migration");
-                LOG.error("A rollback file has been generated at " + rollbackFile);
-                LOG.error("Execute it within your database to rollback any changes");
-                LOG.error("The exception is as follows\n", e);
-                LOG.error("===============================================");
+                LOG.error("""
+                        ===============================================
+                        An exception occurred during database migration
+                        A rollback file has been generated at %s
+                        Execute it within your database to rollback any changes
+                        The exception is as follows
+                        ===============================================
+                        """.formatted(rollbackFile.getAbsolutePath()), e);
             }
             throw e;
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/LegacyHsqlUtil.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/LegacyHsqlUtil.java
@@ -92,16 +92,20 @@ public final class LegacyHsqlUtil {
                     .asSubclass(JDBCDriver.class).getDeclaredConstructor().newInstance();
             driverVersion = String.format("%d.%d", driver.getMajorVersion(), driver.getMinorVersion());
             if (driver.getMajorVersion() != AirsonicHsqlDatabase.CURRENT_SUPPORTED_MAJOR_VERSION) {
-                LOG.warn(
-                        "HSQLDB database driver version {} is untested ; trying to connect anyway, this may upgrade the database from version {}",
-                        driverVersion, currentVersion);
+                LOG.warn("""
+                        HSQLDB database driver version {} is untested.
+                        Trying to connect anyway,
+                        this may upgrade the database from version {}
+                        """, driverVersion, currentVersion);
                 return;
             }
         } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
                 | NoSuchMethodException | SecurityException | ClassNotFoundException e) {
-            LOG.warn(
-                    "HSQLDB database driver version cannot be determined ; trying to connect anyway, this may upgrade the database from version {}",
-                    currentVersion, e);
+            LOG.warn("""
+                    HSQLDB database driver version cannot be determined.
+                    Trying to connect anyway,
+                    this may upgrade the database from version {}
+                    """, currentVersion, e);
             return;
         }
 
@@ -110,12 +114,14 @@ public final class LegacyHsqlUtil {
             return;
         } else if (UPGRADE_NEEDED_VERSION1.equals(currentVersion) || UPGRADE_NEEDED_VERSION2.equals(currentVersion)) {
             if (LOG.isInfoEnabled()) {
-                LOG.info("HSQLDB database upgrade needed, from version {} to {}", currentVersion, driverVersion);
-                LOG.info(" *");
-                LOG.info(" * This version of Jpsonic does not support HSQLDB 1.x. ");
-                LOG.info(" * Please run with v110.x once to use automatic conversion.");
-                LOG.info(" * https://github.com/jpsonic/jpsonic/releases/tag/v110.2.0");
-                LOG.info(" *");
+                LOG.info("""
+                        HSQLDB database upgrade needed, from version {} to {}.
+                         *
+                         * This version of Jpsonic does not support HSQLDB 1.x.
+                         * Please run with v110.x once to use automatic conversion.
+                         * https://github.com/jpsonic/jpsonic/releases/tag/v110.2.0
+                         *
+                        """, currentVersion, driverVersion);
             }
             return;
         } else {

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MusicFolderSettingsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MusicFolderSettingsControllerTest.java
@@ -192,7 +192,7 @@ class MusicFolderSettingsControllerTest {
         ArgumentCaptor<MusicFolder> captor = ArgumentCaptor.forClass(MusicFolder.class);
         Mockito.doNothing().when(musicFolderService).createMusicFolder(Mockito.any(Instant.class), captor.capture());
         controller.post(command, Mockito.mock(RedirectAttributes.class));
-        assertEquals(captor.getValue(), musicFolder);
+        assertEquals(captor.getValue().getId(), musicFolder.getId());
 
         // double registration
         Mockito.clearInvocations(musicFolderService);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/DaoUnitTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/DaoUnitTest.java
@@ -1,0 +1,220 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2023 tesshucom
+ */
+
+package com.tesshu.jpsonic.dao;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+
+import com.tesshu.jpsonic.NeedsHome;
+import com.tesshu.jpsonic.domain.Album;
+import com.tesshu.jpsonic.domain.Artist;
+import com.tesshu.jpsonic.domain.Avatar;
+import com.tesshu.jpsonic.domain.MediaFile;
+import com.tesshu.jpsonic.domain.MediaFile.MediaType;
+import com.tesshu.jpsonic.domain.MusicFolder;
+import com.tesshu.jpsonic.domain.Playlist;
+import com.tesshu.jpsonic.domain.ScanLog.ScanLogType;
+import com.tesshu.jpsonic.domain.SortCandidate;
+import com.tesshu.jpsonic.util.PlayerUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * Unit tests for Dao methods without coverage since 112.2.1(#2334). With the end of Java 11 support, Dao's SQL will be
+ * rewritten using Text Blocks. These test cases are created to ensure that there are no errors during the work. Note
+ * that no logic is mentioned, nor is it used in integration test cases.
+ */
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+@SpringBootTest
+@ExtendWith(NeedsHome.class)
+class DaoUnitTest {
+
+    private static final String USER_NAME = "admin";
+
+    @Autowired
+    private AlbumDao albumDao;
+    @Autowired
+    private ArtistDao artistDao;
+    @Autowired
+    private AvatarDao avatarDao;
+    @Autowired
+    private BookmarkDao bookmarkDao;
+    @Autowired
+    private InternetRadioDao internetRadioDao;
+    @Autowired
+    private MediaFileDao mediaFileDao;
+    @Autowired
+    private PlaylistDao playlistDao;
+    @Autowired
+    private PodcastDao podcastDao;
+    @Autowired
+    private RatingDao ratingDao;
+    @Autowired
+    private ShareDao shareDao;
+    @Autowired
+    private StaticsDao staticsDao;
+
+    @Test
+    void testAlbumDao() {
+        albumDao.updateAlbum(new Album());
+        List<MusicFolder> folders = List.of(new MusicFolder(null, null, false, null));
+        albumDao.getMostFrequentlyPlayedAlbums(0, 0, folders);
+        albumDao.getMostRecentlyPlayedAlbums(0, 0, folders);
+        albumDao.getAlbumsByYear(0, 0, 1990, 2020, folders);
+        albumDao.getAlbumsByYear(0, 0, 2020, 1990, folders);
+
+        Instant now = PlayerUtils.now();
+        MediaFile file = new MediaFile();
+        file.setPathString("/1/song.mp3");
+        file.setMediaType(MediaType.MUSIC);
+        file.setAlbumName("album");
+        file.setParentPathString("albumPath");
+        file.setDurationSeconds(0);
+        file.setCreated(now);
+        file.setChanged(now);
+        file.setLastScanned(now);
+        file.setChildrenLastUpdated(now);
+        file = mediaFileDao.createMediaFile(file);
+
+        Album album = new Album();
+        album.setName("albumName");
+        album.setArtist("artist");
+        album.setPath("albumPath");
+        album.setCreated(now);
+        album.setLastScanned(now);
+        album = albumDao.createAlbum(album);
+
+        albumDao.starAlbum(album.getId(), USER_NAME);
+        albumDao.unstarAlbum(album.getId(), USER_NAME);
+        albumDao.deleteAll();
+        mediaFileDao.deleteMediaFile(file.getId());
+    }
+
+    @Test
+    void testArtistDao() {
+        artistDao.updateArtist(new Artist());
+
+        Instant now = PlayerUtils.now();
+        Artist artist = new Artist();
+        artist.setName("artistName");
+        artist.setLastScanned(now);
+        artist = artistDao.createArtist(artist);
+
+        artistDao.starArtist(artist.getId(), USER_NAME);
+        artistDao.getArtistStarredDate(artist.getId(), USER_NAME);
+        artistDao.unstarArtist(artist.getId(), USER_NAME);
+        artistDao.deleteAll();
+    }
+
+    @Test
+    void testAvatarDao() {
+        avatarDao.setCustomAvatar(null, USER_NAME);
+
+        Instant now = PlayerUtils.now();
+        Avatar avatar = new Avatar(0, null, now, "image/jpeg", 0, 0, new byte[0]);
+        avatarDao.setCustomAvatar(avatar, USER_NAME);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void testBookmarkDao() {
+        bookmarkDao.getBookmarks();
+    }
+
+    @Test
+    void testInternetRadioDao() {
+        internetRadioDao.getInternetRadioById(0);
+    }
+
+    @Test
+    void testMediaFileDao() {
+
+        mediaFileDao.getMediaFile("path");
+        List<MusicFolder> folders = List.of(new MusicFolder(null, null, false, null));
+        mediaFileDao.getMediaFile(MediaType.MUSIC, 0, 0, folders);
+        mediaFileDao.exists(Path.of("path"));
+        mediaFileDao.updateComment("pathString", "comment");
+        mediaFileDao.getMostFrequentlyPlayedAlbums(0, 0, folders);
+        mediaFileDao.getMostRecentlyPlayedAlbums(0, 0, folders);
+        mediaFileDao.getAlbumsByYear(0, 0, 1990, 2020, folders);
+        mediaFileDao.getAlbumsByYear(0, 0, 2020, 1990, folders);
+        mediaFileDao.getSongByArtistAndTitle("artist", "title", folders);
+        mediaFileDao.getPlayedAlbumCount(folders);
+        mediaFileDao.getStarredAlbumCount(USER_NAME, folders);
+
+        Instant now = PlayerUtils.now();
+        MediaFile file = new MediaFile();
+        file.setPathString("/2/song.mp3");
+        file.setMediaType(MediaType.MUSIC);
+        file.setAlbumName("album");
+        file.setParentPathString("albumPath");
+        file.setDurationSeconds(0);
+        file.setCreated(now);
+        file.setChanged(now);
+        file.setLastScanned(now);
+        file.setChildrenLastUpdated(now);
+        file = mediaFileDao.createMediaFile(file);
+
+        mediaFileDao.starMediaFile(file.getId(), USER_NAME);
+        mediaFileDao.unstarMediaFile(file.getId(), USER_NAME);
+        mediaFileDao.resetLastScanned(file.getId());
+        mediaFileDao.countMediaFile(MediaType.MUSIC, folders);
+        mediaFileDao.getSortOfArtistToBeFixedWithId(List.of(new SortCandidate(1, "name", "sort", 0)));
+        mediaFileDao.deleteMediaFile(file.getId());
+    }
+
+    @Test
+    void testPlaylistDao() {
+        Instant now = PlayerUtils.now();
+        Playlist playlist = new Playlist(0, USER_NAME, false, "playlistName", null, 0, 0, now, now, null);
+        playlistDao.createPlaylist(playlist);
+        playlistDao.addPlaylistUser(playlist.getId(), USER_NAME);
+        playlistDao.deletePlaylistUser(playlist.getId(), USER_NAME);
+    }
+
+    @Test
+    void testPodcastDao() {
+        podcastDao.getChannel(0);
+        podcastDao.getEpisodeByUrl(null);
+    }
+
+    @Test
+    void testRatingDao() {
+        List<MusicFolder> folders = List.of(new MusicFolder(null, null, false, null));
+        ratingDao.getHighestRatedAlbums(0, 10, folders);
+    }
+
+    @Test
+    void testShareDao() {
+        shareDao.getShareByName(null);
+    }
+
+    @Test
+    void testStaticsDao() {
+        staticsDao.getScanLog(ScanLogType.SCAN_ALL);
+        Instant now = PlayerUtils.now();
+        staticsDao.deleteBefore(now);
+        staticsDao.getScanEvents(now);
+        staticsDao.getLastScanEventType(now);
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/MediaFileTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/MediaFileTest.java
@@ -23,6 +23,7 @@ package com.tesshu.jpsonic.domain;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URISyntaxException;
@@ -78,5 +79,22 @@ class MediaFileTest {
         mediaFile.setDurationSeconds(seconds);
         assertEquals(expected, mediaFile.getDurationString(), "Error in getDurationString().");
         return true;
+    }
+
+    @Test
+    void testEquals() {
+        MediaFile m1 = new MediaFile();
+        MediaFile m2 = null;
+        assertNotEquals(m1, m2);
+        m2 = new MediaFile();
+        assertNotEquals(m1, m2);
+        m1.setPathString("path");
+        assertNotEquals(m1, new Object());
+        assertNotEquals(m1, m2);
+        m2.setPathString("pass");
+        assertNotEquals(m1, m2);
+        m2.setPathString("path");
+        assertEquals(m1, m2);
+        assertEquals(m1, m1);
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/MusicFolderTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/MusicFolderTest.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2023 tesshucom
+ */
+
+package com.tesshu.jpsonic.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+class MusicFolderTest {
+
+    @Test
+    void testEquals() {
+        MusicFolder m1 = new MusicFolder(null, null, null, false, null, null);
+        MusicFolder m2 = null;
+        assertNotEquals(m1, m2);
+        m2 = new MusicFolder(null, null, null, false, null, null);
+        assertNotEquals(m1, m2);
+        m1 = new MusicFolder(0, null, null, false, null, null);
+        assertNotEquals(m1, new Object());
+        assertNotEquals(m1, m2);
+        m2 = new MusicFolder(1, null, null, false, null, null);
+        assertNotEquals(m1, m2);
+        m2 = new MusicFolder(0, null, null, false, null, null);
+        assertEquals(m1, m2);
+        assertEquals(m1, m1);
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/MusicIndexTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/MusicIndexTest.java
@@ -14,24 +14,28 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
- * (C) 2021 tesshucom
+ * (C) 2023 tesshucom
  */
 
-package com.tesshu.jpsonic.util.concurrent;
+package com.tesshu.jpsonic.domain;
 
-import java.util.concurrent.ExecutionException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-public final class ConcurrentUtils {
+import org.junit.jupiter.api.Test;
 
-    private ConcurrentUtils() {
-    }
+class MusicIndexTest {
 
-    public static void handleCauseUnchecked(final ExecutionException e) {
-        Throwable cause = e.getCause();
-        if (cause instanceof Error) {
-            throw (Error) cause;
-        } else if (cause instanceof RuntimeException runtimeException) {
-            throw runtimeException;
-        }
+    @Test
+    void testEquals() {
+        MusicIndex m1 = new MusicIndex("0");
+        MusicIndex m2 = null;
+        assertNotEquals(m1, m2);
+        assertNotEquals(m1, new Object());
+        m2 = new MusicIndex("1");
+        assertNotEquals(m1, m2);
+        m2 = new MusicIndex("0");
+        assertEquals(m1, m2);
+        assertEquals(m1, m2);
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/TranscodingTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/TranscodingTest.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2023 tesshucom
+ */
+
+package com.tesshu.jpsonic.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+class TranscodingTest {
+
+    @Test
+    void testEquals() {
+        Transcoding t1 = new Transcoding(null, null, null, null, null, null, null, false);
+        Transcoding t2 = null;
+        assertNotEquals(t1, t2);
+        t2 = new Transcoding(null, null, null, null, null, null, null, false);
+        assertNotEquals(t1, t2);
+        t1 = new Transcoding(0, null, null, null, null, null, null, false);
+        assertNotEquals(t1, new Object());
+        assertNotEquals(t1, t2);
+        t2 = new Transcoding(1, null, null, null, null, null, null, false);
+        assertNotEquals(t1, t2);
+        t2 = new Transcoding(0, null, null, null, null, null, null, false);
+        assertEquals(t1, t2);
+        assertEquals(t1, t1);
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/VersionTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/VersionTest.java
@@ -23,6 +23,7 @@ package com.tesshu.jpsonic.domain;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -91,5 +92,18 @@ class VersionTest {
         assertTrue(ver1.compareTo(ver2) < 0, "Error in compareTo().");
         assertTrue(ver2.compareTo(ver1) > 0, "Error in compareTo().");
         return true;
+    }
+
+    @Test
+    void testEquals() {
+        Version v1 = new Version("0");
+        Version v2 = null;
+        assertNotEquals(v1, v2);
+        assertNotEquals(v1, new Object());
+        v2 = new Version("1");
+        assertNotEquals(v1, v2);
+        v2 = new Version("0");
+        assertEquals(v1, v2);
+        assertEquals(v1, v1);
     }
 }


### PR DESCRIPTION
Prerequisites: #2327

#### Overview

Some source code will be rewritten to Java 17 syntax. 

The Java 11 and below syntax was used for a long time for compatibility with third-party analysis tools.

(Most important is Sonatype-lift -> Facebook Infer -> RacerD. It supports up to Java11. Sonatype-lift entered a dormant period for renewal. All the important issues proposed by RacerD have been resolved, so it has done its part. I would be happy if they support Java 17 or later 😘)


#### Goal

Make it easier to review. JEP 378, JEP 394, JEP 361, JEP 409 will rewrite the applicable code.

#### Non-Goal

Not all code can be rewritten.

#### Details

JEP 378 may be the only one that seems to be of real benefit here.

 - JEP 378: Text Blocks
   - Most of the multi-line string lines are SQL. DIFF will be easier to see. In addition, there were several error messages and email texts.
 - JEP 394: Pattern Matching for instanceof
   - yeah, not a big deal.
 - JEP 361: Switch Expressions
   - No doubt it's pretty good. However, I think that the formatter that can effectively use this is limited so far. (It tends to depend on a specific IDE.) Jpsonic is based on maven-formatter, so the true value of JEP cannot be fully demonstrated yet. Considering only readability, there were places where it was better not to rewrite.
   - Not limited to maven-formatter, formatters traditionally tend to be not good at switch statements. Of course, the idea of getting rid of complex switch statements is sound.
   - A set of test cases is rather important for rewriting, and there is a contradiction that if there are enough test cases, there is not much need for rewriting 😵 I think that it is very good as far as it is used in new code.
   - The area around the controller is untouched. I think it's probably better to introduce it with thorough testing in future refactorings rather than trying hard here.
 - JEP 409: Sealed Classes
   - Since it cannot be used for Spring resource classes, which tend to be complicated, there is very little use for it.

Probably the most useful is Record, which is not covered by this pull request. It seems that it will take a lot of time if we search for a place where we can rewrite to Record and rewrite it. In future feature fixes, the relevant implementation will be rewritten incrementally.