### PR TITLE
Change the number of digits displayed for memory

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/ScanLogController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/ScanLogController.java
@@ -42,7 +42,6 @@ import com.tesshu.jpsonic.domain.UserSettings;
 import com.tesshu.jpsonic.service.ScannerStateService;
 import com.tesshu.jpsonic.service.SecurityService;
 import com.tesshu.jpsonic.service.SettingsService;
-import com.tesshu.jpsonic.util.FileUtil;
 import com.tesshu.jpsonic.util.LegacyMap;
 import com.tesshu.jpsonic.util.StringUtil;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -141,7 +140,6 @@ public class ScanLogController {
         return scanEvents;
     }
 
-    @SuppressWarnings("deprecation")
     private void setStatus(@NonNull LocalDateTime lastStartDate, ScanLogVO scanLog) {
         final ScanEventType lastEventType = staticsDao
                 .getLastScanEventType(scanLog.getStartDate().atZone(ZoneOffset.systemDefault()).toInstant());
@@ -224,9 +222,9 @@ public class ScanLogController {
         private final LocalDateTime executed;
         private final String executedStr;
         private final ScanEventType type;
-        private final String maxMemory;
-        private final String totalMemory;
-        private final String usedMemory;
+        private final long maxMemory;
+        private final long totalMemory;
+        private final long usedMemory;
         private final String comment;
         private String duration;
 
@@ -235,12 +233,9 @@ public class ScanLogController {
             this.executed = LocalDateTime.ofInstant(scanEvent.getExecuted(), ZoneId.systemDefault());
             this.executedStr = DATE_AND_OPTIONAL_MILLI_TIME.format(executed);
             this.type = scanEvent.getType();
-            this.maxMemory = scanEvent.getMaxMemory() > 0 ? FileUtil.byteCountToDisplaySize(scanEvent.getMaxMemory())
-                    : "-";
-            this.totalMemory = scanEvent.getTotalMemory() > 0
-                    ? FileUtil.byteCountToDisplaySize(scanEvent.getTotalMemory()) : "-";
-            this.usedMemory = scanEvent.getFreeMemory() > 0
-                    ? FileUtil.byteCountToDisplaySize(scanEvent.getTotalMemory() - scanEvent.getFreeMemory()) : "-";
+            this.maxMemory = scanEvent.getMaxMemory();
+            this.totalMemory = scanEvent.getTotalMemory();
+            this.usedMemory = scanEvent.getTotalMemory() - scanEvent.getFreeMemory();
             this.comment = scanEvent.getComment();
         }
 
@@ -256,15 +251,15 @@ public class ScanLogController {
             return type;
         }
 
-        public String getMaxMemory() {
+        public long getMaxMemory() {
             return maxMemory;
         }
 
-        public String getTotalMemory() {
+        public long getTotalMemory() {
             return totalMemory;
         }
 
-        public String getUsedMemory() {
+        public long getUsedMemory() {
             return usedMemory;
         }
 

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/scanLog.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/scanLog.jsp
@@ -90,9 +90,9 @@ function refreshScanLogs() {
                     </td>
                     <td>${scanEvent.executedStr}</td>
                     <td>${scanEvent.duration}</td>
-                    <td>${scanEvent.maxMemory}</td>
-                    <td>${scanEvent.totalMemory}</td>
-                    <td>${scanEvent.usedMemory}</td>
+                    <td><sub:formatBytes bytes="${scanEvent.maxMemory}"/></td>
+                    <td><sub:formatBytes bytes="${scanEvent.totalMemory}"/></td>
+                    <td><sub:formatBytes bytes="${scanEvent.usedMemory}"/></td>
                     <td>${scanEvent.comment}</td>
                 </tr>
             </c:forEach>

--- a/jpsonic-main/src/main/webapp/scss/jpsonic/pages/_scanlog.scss
+++ b/jpsonic-main/src/main/webapp/scss/jpsonic/pages/_scanlog.scss
@@ -27,7 +27,7 @@
     }
 
     td {
-      padding-right: 10px;
+      padding-right: 4px;
 
       &:nth-child(1),
       &:nth-child(3),


### PR DESCRIPTION
The number of digits displayed in the scan log memory will be changed. This is a display-only Change. Previous log data will also be displayed correctly.

![image](https://github.com/tesshucom/jpsonic/assets/27724847/8b623734-d8c5-4c81-b3df-bd75ed5a51aa)
