### PR TITLE
Upgrade production.synology.yaml

### DIFF
--- a/install/docker/production.synology.yml
+++ b/install/docker/production.synology.yml
@@ -1,14 +1,13 @@
-# 
+#
 # This is a JPSONIC boot configuration sample in Synology DS220+ or in Linux with UPnP.
 # You can easily start Jpsonic by changing the volume, port and so on.
 #
 # usage: 
 #   docker-compose -f production.synology.yml up -d
 #
-# @since v112.2.0
+# @since v112.2.2
 #
 
-version: '3.9'
 services:
   app:
     image: 'jpsonic/jpsonic:latest'
@@ -30,19 +29,40 @@ services:
      - '/volume1/Podcasts:/jpsonic/podcasts'
      - '/volume1/Playlists:/jpsonic/playlists'
 
-     # If you want to add a large number of music folders, please add more volumes
-     # - '/volume1/Music2:/jpsonic/music2'
-     # - '/volume1/Music3:/jpsonic/music3'
+    # If you want to add a large number of music folders, add more volumes.
+    # Please add <internal> from Settings pages as Music foldres after login.
+    #
+    # - '/volume1/Music2:/jpsonic/music2'
+    # - '/volume1/Music3:/jpsonic/music3'
 
-    deploy:
-      resources:
-        limits:
-
-          # Jpsonic container is limited to 1Gb so that it can run on DS220+'s standard memory.
-          # Add 512m to the number assigned to -Xmx. See 'JAVA_OPTS'.
-          memory: 1g
+    # Jpsonic container is limited to 1Gb so that it can run on DS220+'s standard memory.
+    # Please change this depending on the number of songs in your library.
+    # Note that you need to change both Java and Docker memory settings.
+    #
+    # ---------------------------------------------------------
+    # Songs count    Java(Xms, Xmx)  Docker(mem_limit)
+    # 70K            512m            896m
+    # 100K           640m            1024m
+    # 130K           768m            1152m
+    # 200K           1024m           1.5g
+    # 300K           1280m           1.75g
+    # 400K           1536m           2g
+    # ---------------------------------------------------------
+    mem_limit: 1024m
+    mem_swappiness: 1
 
     environment:
+     # Specify the appropriate Java options.
+     #
+     # When using a CPU with lower performance than DS220+(Intel Celeron J4025),
+     # please remove the -XX:+UseG1GC Option. Or specify -XX:+UseSerialGC.
+     # Jpsonic has been tested for both Serial GC and G1 GC.
+
+     JAVA_OPTS: >
+       -Xms640m
+       -Xmx640m
+       -XX:+UseG1GC
+       -XX:MaxGCPauseMillis=500
 
      # Set the jpsonic and upnp ports.
      # Containers share the host networking name space,
@@ -76,52 +96,6 @@ services:
      # You can override the MIME of DSD according to your device.
      MIME_DSF: 'audio/x-dsd'
      MIME_DFF: 'audio/x-dsd'
-
-     # Specify the appropriate Java options.
-     # If you are using a pure DLNA player (not UPnP) and have problems, remove XX:MaxGCPauseMillis.
-     # Note, however, that scanning will be slightly slower.
-
-     # The following settings are standard settings. 100K songs or less.
-     # Specify 1g for Docker memory.
-     JAVA_OPTS: '-Xms512m -Xmx512m -XX:MaxGCPauseMillis=500'
-
-     # 70K-10K songs (Maybe just a little faster). Specify 1.25g for Docker memory.
-     # JAVA_OPTS: '-Xms768m -Xmx768m -XX:MaxGCPauseMillis=500'
-
-     # 200K songs or less. Specify 1.5g for Docker memory.
-     # JAVA_OPTS: '-Xms1024m -Xmx1024m -XX:MaxGCPauseMillis=500'
-
-     # 300K songs or less. Specify 1.75g for Docker memory.
-     # JAVA_OPTS: '-Xms1280m -Xmx1280m -XX:MaxGCPauseMillis=500'
-
-     # 400K songs or less. Specify 2g for Docker memory.
-     # JAVA_OPTS: '-Xms1536m -Xmx1536m -XX:MaxGCPauseMillis=500'
-
-     #　Option example when using JMX. The "ea" tag image is required to use JMX.
-     #　For VisualVM, you need to specify the port in File-Add JMX Connection.
-     #　e.g. localhost:3333
-     #
-     # JAVA_OPTS: >
-     #   -Xms512m
-     #   -Xmx512m
-     #   -XX:MaxGCPauseMillis=500
-     #   -Dcom.sun.management.jmxremote
-     #   -Dcom.sun.management.jmxremote.port=3333
-     #   -Dcom.sun.management.jmxremote.rmi.port=3333
-     #   -Dcom.sun.management.jmxremote.local.only=false
-     #   -Dcom.sun.management.jmxremote.ssl=false
-     #   -Dcom.sun.management.jmxremote.authenticate=false
-     #   -Djava.rmi.server.hostname=localhost
-
-     # If you want to perform long-term profiling such as scan performance adjustment,
-     # it is a good idea to output GC Log.
-     # See Universal GC Log Analyzer (https://gceasy.io/)
-     #
-     # JAVA_OPTS: >
-     #   -Xms512m
-     #   -Xmx512m
-     #   -XX:MaxGCPauseMillis=500
-     #   -Xlog:gc*:file=/jpsonic/data/jpsonic_gc.log:time,level,tags:filecount=0'
 
     # Usually no need to change.
     # Unlike other Sonic servers, Jpsonic has a graceful shutdown implemented.


### PR DESCRIPTION
Prerequisites: #2345

### Overview

 [production.synology.yml](https://raw.githubusercontent.com/jpsonic/jpsonic/master/install/docker/production.synology.yml) will be changed to reflect the latest performance verification results. There are no changes to Jpsonic itself, so
you can also continue to use the previous production.synology.yml. However, using the new production.synology.yml will improve performance.

### Details

Contains:

 - Tiny format change
   - Remove deprecated tag (version)
   - Change memory setting hierarchy
   - Fix comment
 - Add mem_swappiness
 - Add +UseG1GC to Java options

### Breaking changes

The correspondence between Java memory and Docker memory limits will change as follows. 

![image](https://github.com/tesshucom/jpsonic/assets/27724847/52c1cbee-3dd6-47b4-ba13-c9f85ce0a19e)

Docker's default is still 1G, but the ratio with Java has changed slightly. It is possible to operate with the previous settings, but there is an area where it slows-down-zone around 10K. There may be no impact if you use it with plenty of time.

### Why Tuning Improves Performance

Rather than overusing the hardware, this fixes was based on the idea of eliminating waste. Very healthy.

 - This commit was originally scheduled to reduce Docker's memory. Of course, **memory reduction is possible**.
 - At the same time, swappiness was reviewed.
   - There are no memory leaks in Jpsonic. It is originally possible to operate with swappiness 1.
   - Synology's DS series has models equipped with SSD cache. Prevent wear and tear on your device.
   - If the value of swappiness is high, swap may be executed during the scan, contrary to the intention. Suppressing this will **improve CPU/IO efficiency**.
 - In the case of DS220+(Dual Core), if you leave it to the JVM's automatic selection, Serial GC will be selected up to a setting of 200K. A memory setting of 300K selects G1 GC. There were attempts to use G1 GC below 200K, but the problem was running out of memory. This is because G1 GC requires slightly more memory.
   - However, we are able to secure memory for that amount. Rather than simply reducing Docker's memory, we shifted the remaining memory to a strategy that utilizes G1 GC. This will **improve the throughput of GCs** below 200K by nearly 10%. Also, **Avg STW will be less than 100ms**.

### Effect


 - Especially affects scans. Subsonic series servers traditionally output logs for every 250 path and file parses. In Jpsonic, you can refer to SCANNED_COUNT from the log page. For the combination of Seagate IronWolf Pro 3.5 HDD 4TB 7200rpm and DS220+, this average Duration will be less than 1000ms. For 5min FLAC * 100K songs, scanning takes about 8 minutes (Reasonable effort). 
 - Switching to G1 GC will benefit you beyond scanning. At Jpsonic, the target value for UPnP response speed is 500ms. Serial GC is a bit unsettling to achieve this. G1 GC can handle that.





