### PR TITLE
Fix Send buffer size

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StreamController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StreamController.java
@@ -302,7 +302,7 @@ public class StreamController {
     @SuppressFBWarnings(value = "UC_USELESS_CONDITION", justification = "False positive. #1078")
     private void writeStream(Player player, InputStream in, OutputStream out, Long fileLengthExpected,
             boolean isPodcast, boolean isSingleFile) throws IOException {
-        byte[] buf = new byte[settingsService.getBufferSize()];
+        byte[] buf = new byte[4096];
         long bytesWritten = 0;
 
         boolean alive = isAliveStream(player);
@@ -425,6 +425,7 @@ public class StreamController {
         try (InputStream in = streamService.createInputStream(player, status, maxBitRate, format,
                 result.getVideoTranscodingSettings());
                 OutputStream out = RangeOutputStream.wrap(res.getOutputStream(), result.getRange())) {
+            res.setBufferSize(settingsService.getBufferSize());
             writeStream(player, in, out, result.getFileLengthExpected(), isPodcast, isSingleFile);
         } catch (IOException e) {
             writeErrorLog(e, req);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SettingsConstants.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SettingsConstants.java
@@ -178,7 +178,7 @@ final class SettingsConstants {
 
             static final Pair<Long> DOWNLOAD_BITRATE_LIMIT = Pair.of("DownloadBitrateLimit", 0L);
             static final Pair<Long> UPLOAD_BITRATE_LIMIT = Pair.of("UploadBitrateLimit", 0L);
-            static final Pair<Integer> BUFFER_SIZE = Pair.of("BufferSize", 4096);
+            static final Pair<Integer> BUFFER_SIZE = Pair.of("SendBufferSize", 32_768);
 
             private Bandwidth() {
             }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SettingsService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SettingsService.java
@@ -96,7 +96,8 @@ public class SettingsService {
             "database.config.jndi.name", "database.usertable.quote", "ShowJavaJukebox", "AnonymousTranscoding",
             "UseSonos", "SearchMethodLegacy", "SearchMethodChanged", "FastCacheEnabled", "UseRefresh", "ShowRefresh",
             "VerboseLogStart", "VerboseLogScanning", "VerboseLogPlaying", "VerboseLogShutdown",
-            "IgnoreFileTimestampsNext", "FileModifiedCheckSchemeName", "IgnoreFileTimestampsForEachAlbum");
+            "IgnoreFileTimestampsNext", "FileModifiedCheckSchemeName", "IgnoreFileTimestampsForEachAlbum",
+            "BufferSize");
 
     private static final int ELEMENT_COUNT_IN_LINE_OF_THEME = 2;
 

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/advancedSettings.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/advancedSettings.jsp
@@ -12,7 +12,7 @@ const scanning = ${command.scanning};
 function resetBandwidth() {
     $('[name="downloadLimit"]').val(0);
     $('[name="uploadLimit"]').val(0);
-    $('[name="bufferSize"]').prop("selectedIndex", 1);
+    $('[name="bufferSize"]').prop("selectedIndex", 3);
 }
 
 function resetScanLog() {
@@ -107,9 +107,14 @@ document.addEventListener('DOMContentLoaded', function () {
             <dt><fmt:message key="advancedsettings.buffersize"/></dt>
             <dd>
                 <form:select path="bufferSize">
-                    <c:forEach begin="1" end="16" var="base">
-                        <form:option value="${base * 2048}" />
-                    </c:forEach>
+                    <form:option value="4096" label="4Kb: tcp_rmem#min"/>
+                    <form:option value="8192" label="8Kb"/>
+                    <form:option value="16384" label="16KB"/>
+                    <form:option value="32768" label="32KB: Default"/>
+                    <form:option value="65536" label="64KB"/>
+                    <form:option value="87380" label="87,380: tcp_rmem#mid"/>
+                    <form:option value="1048576" label="1Mb"/>
+                    <form:option value="6291456" label="6Mb: tcp_rmem#max"/>
                 </form:select>
             </dd>
         </dl>

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/SettingsServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/SettingsServiceTest.java
@@ -422,7 +422,7 @@ class SettingsServiceTest {
 
     @Test
     void testGetBufferSize() {
-        assertEquals(4096, settingsService.getBufferSize());
+        assertEquals(32_768, settingsService.getBufferSize());
     }
 
     @Test


### PR DESCRIPTION
## Problem description

![image](https://github.com/tesshucom/jpsonic/assets/27724847/397512a0-8332-42eb-b185-9773a70f1726)

### Steps to reproduce

Changing this value does not actually change the data being sent.

## System information

 * **Jpsonic version**: v110.0.0

Quite old!

## Cause

 - Jpsonic once took measures to reduce the load on StreamController. Coding mistake at that time.
   - Sonic servers are recognized as capable of streaming Raw. That's partly true. When referring to the performance of a song, this is not possible depending on the compression rate of the format.
   - Airsonic's StreamController performs fairly congested loop processing. Due to slow processing, the client app may not be able to ensure sufficient buffering when starting a performance. There are some bad cases. A typical example is that Streaming cannot keep up with the playing and often interrupts the playing. Another problem is that the beginning of the song is missing. 　Some Player Apps have an implementation that starts buffering and starts playing at the same time, and adjusts the playing position once buffering has progressed, in order to create an appearance of lightness. (I think it was foobar2000. . .) When a local hard disk or compressed audio source is played, humans do not notice the slight loss. Apps with such implementations may exhibit problems with DSD streaming, where the song indicator will progress but the first few seconds will be silent. A fix for this issue is a necessary one.
   - To avoid this, Jpsonic reduced processing and adjusted buffering size.
     - The buffering size when reading files for transmission and writing them to streaming is fixed at 2048 bytes for Airsonic. [org/airsonic/player/controller/StreamController#L233-L234](https://github.com/airsonic/airsonic/blob/5ccca059d5cfe3dd19734c27861b434ea21b43d8/airsonic-main/src/main/java/org/airsonic/player/controller/StreamController.java#L233-L234C47)
     - Jpsonic set 4096 by default.

The problem is that the HttpServletResponse's buffer size hasn't changed at all. What the web page is changing is the buffering size when reading from the file and writing to the stream. (As a result, the network flow rate per unit time is affected, but of course this cannot be said to be correct control.)

## Goal

The value set by the web page will be modified to reflect the buffer size of HttpServletResponse.

## Non-Goal

It doesn't solve all the so-called skipping and unreasonable skipping of songs. Most of them are caused by the receiving platform or app, and such problems are potentially present on most platforms. This buffering adjustment only prevents network-based problems. 

## Note

 - The default value will be changed to 32,768 bytes to avoid breaking things. Intuitively, it is larger than expected, but that value has been used until now in Spring & Jetty. However, these values naturally increase year by year. For now, let's use the default values used by proven Frame work. If in doubt, try other values.
 - When you apply this patch, the old Property will be deleted internally and replaced with the new value. In other words, nothing changes for users using the default.


