### PR TITLE
Dockerfile maintenance

### DIFF
--- a/install/docker/alpine-jdk17/Dockerfile
+++ b/install/docker/alpine-jdk17/Dockerfile
@@ -17,7 +17,7 @@ ENV JPSONIC_DIR=/jpsonic \
     EMBEDDED_FONT=false \
     MIME_DSF=audio/x-dsd \
     MIME_DFF=audio/x-dsd \
-    JAVA_OPTS=-Xmx512m
+    JAVA_OPTS="-Xms512m -Xmx512m -XX:+UseG1GC -XX:MaxGCPauseMillis=500"
 
 WORKDIR $JPSONIC_DIR
 

--- a/install/docker/alpine-jdk17/Dockerfile
+++ b/install/docker/alpine-jdk17/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17-jdk-alpine
 
 LABEL description="Jpsonic is a free, web-based media streamer, providing ubiquitious access to your music." \
       url="https://github.com/jpsonic/jpsonic"

--- a/install/docker/jammy/Dockerfile
+++ b/install/docker/jammy/Dockerfile
@@ -17,7 +17,7 @@ ENV JPSONIC_DIR=/jpsonic \
     EMBEDDED_FONT=false \
     MIME_DSF=audio/x-dsd \
     MIME_DFF=audio/x-dsd \
-    JAVA_OPTS=-Xmx512m
+    JAVA_OPTS="-Xms512m -Xmx512m -XX:+UseG1GC -XX:MaxGCPauseMillis=500"
 
 WORKDIR $JPSONIC_DIR
 


### PR DESCRIPTION

Small Dockerfile maintenance. Neither has any impact on the user's environment.

 - Fix that JDK is used for jpsonic/jpsonic:ea
   - JRE was used until now. 
 - Update the default value of JAVA_OPTS according to Requirements
   - The initial value if JAVA_OPTS is not specified will be new according to [Memory Requirements](https://github.com/jpsonic/jpsonic/wiki/Requirements-%E2%80%90-Memory-configuration#memory-requirements) / [Garbage collector](https://github.com/jpsonic/jpsonic/wiki/Requirements-%E2%80%90-Memory-configuration#selection-of-garbage-collectors)