### PR TITLE
Fix getAlbumList2 sorting to ignore case

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SubsonicRESTController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/SubsonicRESTController.java
@@ -1229,9 +1229,9 @@ public class SubsonicRESTController implements CoverArtPresentation {
         } else if ("newest".equals(type)) {
             albums = albumDao.getNewestAlbums(offset, size, musicFolders);
         } else if ("alphabeticalByArtist".equals(type)) {
-            albums = albumDao.getAlphabeticalAlbums(offset, size, true, false, musicFolders);
+            albums = albumDao.getAlphabeticalAlbums(offset, size, true, true, musicFolders);
         } else if ("alphabeticalByName".equals(type)) {
-            albums = albumDao.getAlphabeticalAlbums(offset, size, false, false, musicFolders);
+            albums = albumDao.getAlphabeticalAlbums(offset, size, false, true, musicFolders);
         } else if ("byGenre".equals(type)) {
             albums = searchService.getAlbumId3sByGenres(
                     ServletRequestUtils.getRequiredStringParameter(request, Attributes.Request.GENRE.value()), offset,

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
@@ -923,7 +923,7 @@ public class ScannerProcedureService {
             return;
         }
         List<MusicFolder> folders = musicFolderService.getAllMusicFolders();
-        List<Album> albums = albumDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, false, false, folders);
+        List<Album> albums = albumDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, false, true, folders);
         int count = invokeUpdateOrder(albums, comparators.albumOrderByAlpha(),
                 (album) -> albumDao.updateOrder(album.getId(), album.getOrder()));
         String comment = "Updated order of (%d) ID3 albums.".formatted(count);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/AlbumDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/AlbumDaoTest.java
@@ -1,0 +1,123 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2023 tesshucom
+ */
+
+package com.tesshu.jpsonic.dao;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Documented;
+import java.util.Collections;
+import java.util.List;
+
+import com.tesshu.jpsonic.dao.base.TemplateWrapper;
+import com.tesshu.jpsonic.domain.MusicFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.jdbc.core.RowMapper;
+
+class AlbumDaoTest {
+
+    private TemplateWrapper templateWrapper;
+    private AlbumDao albumDao;
+
+    @BeforeEach
+    public void setup() {
+        this.templateWrapper = Mockito.mock(TemplateWrapper.class);
+        albumDao = new AlbumDao(templateWrapper);
+    }
+
+    @Documented
+    private @interface AlphabeticalOps {
+        @interface Conditions {
+            @interface ByArtist {
+                @interface True {
+                }
+
+                @interface False {
+                }
+            }
+
+            @interface IgnoreCase {
+                @interface True {
+                }
+
+                @interface False {
+                }
+            }
+        }
+    }
+
+    @Nested
+    class GetAlphabeticalAlbumsTest {
+
+        List<MusicFolder> folders;
+
+        @BeforeEach
+        public void setup() {
+            MusicFolder folder = new MusicFolder("/Music", "Music", true, null);
+            folders = List.of(folder);
+        }
+
+        private String getOrderBy(ArgumentCaptor<String> queryCaptor) {
+            String query = queryCaptor.getValue();
+            return query.replaceAll("\n", "").replaceAll("^.*order\sby", "").replaceAll("limit.*$", "").trim();
+        }
+
+        @SuppressWarnings("unchecked")
+        private ArgumentCaptor<String> getQuery(boolean byArtist, boolean ignoreCase) {
+            ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
+            Mockito.when(
+                    templateWrapper.namedQuery(queryCaptor.capture(), Mockito.any(RowMapper.class), Mockito.anyMap()))
+                    .thenReturn(Collections.emptyList());
+            albumDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, byArtist, ignoreCase, folders);
+            return queryCaptor;
+        }
+
+        @AlphabeticalOps.Conditions.ByArtist.True
+        @AlphabeticalOps.Conditions.IgnoreCase.True
+        @Test
+        void c00() {
+            assertEquals("LOWER(artist_reading), album_order, LOWER(name_reading)", getOrderBy(getQuery(true, true)));
+        }
+
+        @AlphabeticalOps.Conditions.ByArtist.True
+        @AlphabeticalOps.Conditions.IgnoreCase.False
+        @Test
+        void c01() {
+            assertEquals("artist_reading, album_order", getOrderBy(getQuery(true, false)));
+        }
+
+        @AlphabeticalOps.Conditions.ByArtist.False
+        @AlphabeticalOps.Conditions.IgnoreCase.True
+        @Test
+        void c02() {
+            assertEquals("album_order, LOWER(name_reading)", getOrderBy(getQuery(false, true)));
+        }
+
+        @AlphabeticalOps.Conditions.ByArtist.False
+        @AlphabeticalOps.Conditions.IgnoreCase.False
+        @Test
+        void c03() {
+            assertEquals("album_order", getOrderBy(getQuery(false, false)));
+        }
+    }
+}


### PR DESCRIPTION
### Overview

Fix for getAlbumList2 of Subsonic API . If alphabeticalByName or alphabeticalByArtist is used in API Options, it will be fixed to be case insensitive.

### Details

As for internal processing, byArtist/ignoreCase is defined as an argument of the Dao method.

https://github.com/airsonic/airsonic/blob/5ccca059d5cfe3dd19734c27861b434ea21b43d8/airsonic-main/src/main/java/org/airsonic/player/controller/SubsonicRESTController.java#L1136-L1138

 - Letter case issue often comes up on the agenda even on general media servers. It is a common opinion that uppercase and lowercase letters are ignored in Alphabetical's natural sort.
 - Traditional servers avoided case-insensitive sorting on the database side for performance reasons. (Perhaps. A large number of string conversions were avoided.)

Therefore, it is thought that there is no major problem in changing this specification.

### Note1
getAlbumList2 (get all ID3 albums) will be the change with the greatest impact among these sort-fixes. ID3 has a normalized table, so in the case of Album, a join may be necessary depending on the conditions. 

 - **1** --- If it is only Album, it will be sorted by album_order
 - **2** --- If you want to sort albums by artist and album, they will be sorted by artist_order, album_order. Therefore we will need JOIN

Please note the following points.

 - In the current Jpsonic, only **1** is used. It's used in UPnP album view.
 - The album list on the web page is sorted by Artist -> Album. However, this is a File Structure (media_file table). No JOIN.

Performance verification will be required when replacing Album All View on the Wave page with ID3. Related #2349.

### Note2

The Dao design will be maintained internally for some time. However, implementations related to Letter case in Dao may be removed at an appropriate stage.

 - I believe that the legacy server implementation was never intended to have a case-sensitive use case and is simply a result of technical constraints.
 - There is no point in sticking only to case-sensitive. 
   - This is because we need many other perspectives for sort by name. Advanced natural sort of strings is not possible on Database. 








