### PR TITLE
Add archived to music_folder table

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MusicFolderSettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/MusicFolderSettingsController.java
@@ -217,7 +217,7 @@ public class MusicFolderSettingsController {
         if (name == null) {
             name = newPath.getFileName().toString();
         }
-        return Optional.of(
-                new MusicFolder(info.getId(), validated.get(), name, info.isEnabled(), now(), info.getFolderOrder()));
+        return Optional.of(new MusicFolder(info.getId(), validated.get(), name, info.isEnabled(), now(),
+                info.getFolderOrder(), false));
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicFolder.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MusicFolder.java
@@ -42,19 +42,21 @@ public class MusicFolder implements Serializable {
     private boolean enabled;
     private Instant changed;
     private Integer folderOrder;
+    private boolean archived;
 
     public MusicFolder(Integer id, String pathString, String name, boolean enabled, Instant changed,
-            Integer folderOrder) {
+            Integer folderOrder, boolean archived) {
         this.id = id;
         this.pathString = pathString;
         this.name = name;
         this.enabled = enabled;
         this.changed = changed;
         this.folderOrder = folderOrder;
+        this.archived = archived;
     }
 
-    public MusicFolder(String pathString, String name, boolean enabled, Instant changed) {
-        this(null, pathString, name, enabled, changed, null);
+    public MusicFolder(String pathString, String name, boolean enabled, Instant changed, boolean archived) {
+        this(null, pathString, name, enabled, changed, null, archived);
     }
 
     public Integer getId() {
@@ -103,6 +105,14 @@ public class MusicFolder implements Serializable {
 
     public void setFolderOrder(int folderOrder) {
         this.folderOrder = folderOrder;
+    }
+
+    public boolean isArchived() {
+        return archived;
+    }
+
+    public void setArchived(boolean archived) {
+        this.archived = archived;
     }
 
     @Override

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
@@ -703,7 +703,7 @@ public class ScannerProcedureService {
             return;
         }
         Path path = Path.of(settingsService.getPodcastFolder());
-        MusicFolder dummy = new MusicFolder(path.toString(), null, true, null);
+        MusicFolder dummy = new MusicFolder(path.toString(), null, true, null, false);
         getRootDirectory(scanDate, path).ifPresent(root -> {
             scanPodcast(scanDate, dummy, root);
             createScanEvent(scanDate, ScanEventType.PARSE_PODCAST, null);

--- a/jpsonic-main/src/main/resources/liquibase/jp113.0.0/changelog.xml
+++ b/jpsonic-main/src/main/resources/liquibase/jp113.0.0/changelog.xml
@@ -33,4 +33,16 @@
             <column name="music_index"/>
         </createIndex>
     </changeSet>
+    <changeSet id="add-archived-to-music-folder" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="music_folder" columnName="archived" />
+            </not>
+        </preConditions>
+        <addColumn tableName="music_folder">
+            <column name="archived" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/MusicFolderTestDataUtils.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/MusicFolderTestDataUtils.java
@@ -61,7 +61,8 @@ public final class MusicFolderTestDataUtils {
 
     public static List<MusicFolder> getTestMusicFolders() {
         return Arrays.asList(
-                new MusicFolder(1, MusicFolderTestDataUtils.resolveMusicFolderPath(), "Music", true, now(), 0),
-                new MusicFolder(2, MusicFolderTestDataUtils.resolveMusic2FolderPath(), "Music2", true, now(), 1));
+                new MusicFolder(1, MusicFolderTestDataUtils.resolveMusicFolderPath(), "Music", true, now(), 0, false),
+                new MusicFolder(2, MusicFolderTestDataUtils.resolveMusic2FolderPath(), "Music2", true, now(), 1,
+                        false));
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/CoverArtServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/CoverArtServiceTest.java
@@ -63,7 +63,8 @@ class CoverArtServiceTest extends AbstractNeedsScan {
     @Override
     public List<MusicFolder> getMusicFolders() {
         if (isEmpty(musicFolders)) {
-            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1));
+            musicFolders = Arrays
+                    .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1, false));
         }
         return musicFolders;
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/MultiServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/ajax/MultiServiceTest.java
@@ -65,7 +65,8 @@ class MultiServiceTest extends AbstractNeedsScan {
     @Override
     public List<MusicFolder> getMusicFolders() {
         if (isEmpty(musicFolders)) {
-            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1));
+            musicFolders = Arrays
+                    .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1, false));
         }
         return musicFolders;
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/ChangeCoverArtControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/ChangeCoverArtControllerTest.java
@@ -50,7 +50,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 class ChangeCoverArtControllerTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1, false));
 
     @Autowired
     private MediaFileDao mediaFileDao;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DLNASettingsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DLNASettingsControllerTest.java
@@ -159,7 +159,7 @@ class DLNASettingsControllerTest {
          * Always false if all folders are not allowed. Because the genre count is a statistical result for all
          * directories.
          */
-        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder("", null, true, null));
+        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder("", null, true, null, false));
         Mockito.when(musicFolderService.getAllMusicFolders()).thenReturn(musicFolders);
         Mockito.when(musicFolderService.getMusicFoldersForUser(User.USERNAME_GUEST)).thenReturn(musicFolders);
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DownloadControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DownloadControllerTest.java
@@ -70,7 +70,8 @@ class DownloadControllerTest extends AbstractNeedsScan {
     @Override
     public List<MusicFolder> getMusicFolders() {
         if (isEmpty(musicFolders)) {
-            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1));
+            musicFolders = Arrays
+                    .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1, false));
         }
         return musicFolders;
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/EditTagsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/EditTagsControllerTest.java
@@ -46,7 +46,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 class EditTagsControllerTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1, false));
 
     private MockMvc mockMvc;
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/ExternalPlayerControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/ExternalPlayerControllerTest.java
@@ -85,7 +85,7 @@ class ExternalPlayerControllerTest {
         mediaFile.setPathString(path.toString());
         List<MediaFile> mediaFiles = Arrays.asList(mediaFile);
 
-        MusicFolder folder = new MusicFolder("", "", true, expires);
+        MusicFolder folder = new MusicFolder("", "", true, expires, false);
         List<MusicFolder> folders = Arrays.asList(folder);
         Mockito.when(musicFolderService.getMusicFoldersForUser(Mockito.anyString())).thenReturn(folders);
         Mockito.when(shareService.getSharedFiles(shareId, folders)).thenReturn(mediaFiles);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/HomeControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/HomeControllerTest.java
@@ -234,7 +234,7 @@ class HomeControllerTest {
             MockHttpServletRequest req = mock(MockHttpServletRequest.class);
             Mockito.when(req.getParameter(Attributes.Request.LIST_TYPE.value()))
                     .thenReturn(AlbumListType.INDEX.getId());
-            List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder("", "name", false, now()));
+            List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder("", "name", false, now(), false));
             Mockito.when(musicFolderService.getMusicFoldersForUser(anyString(), Mockito.nullable(Integer.class)))
                     .thenReturn(musicFolders);
             Mockito.when(musicIndexService.getMusicFolderContent(musicFolders))

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MoreControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MoreControllerTest.java
@@ -63,8 +63,9 @@ class MoreControllerTest {
                 .build();
         Mockito.when(searchService.getGenres(false)).thenReturn(Collections.emptyList());
         Mockito.when(playerService.getPlayer(Mockito.any(), Mockito.any())).thenReturn(new Player());
-        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
-                Path.of(MoreControllerTest.class.getResource("/MEDIAS").toURI()).toString(), "MEDIAS", true, now(), 1));
+        List<MusicFolder> musicFolders = Arrays
+                .asList(new MusicFolder(1, Path.of(MoreControllerTest.class.getResource("/MEDIAS").toURI()).toString(),
+                        "MEDIAS", true, now(), 1, false));
         Mockito.when(musicFolderService.getMusicFoldersForUser(ServiceMockUtils.ADMIN_NAME)).thenReturn(musicFolders);
     }
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MusicFolderSettingsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/MusicFolderSettingsControllerTest.java
@@ -184,7 +184,7 @@ class MusicFolderSettingsControllerTest {
         assertNotNull(command);
 
         MusicFolder musicFolder = new MusicFolder(MusicFolderTestDataUtils.resolveMusicFolderPath(), "Music", true,
-                now());
+                now(), false);
         MusicFolderInfo musicFolderInfo = new MusicFolderInfo(musicFolder);
         command.setNewMusicFolder(musicFolderInfo);
 
@@ -217,21 +217,21 @@ class MusicFolderSettingsControllerTest {
         assertNotNull(command);
 
         MusicFolder musicFolder1 = new MusicFolder(99, MusicFolderTestDataUtils.resolveMusicFolderPath(), "Music", true,
-                now(), 1);
+                now(), 1, false);
         MusicFolderInfo musicFolderInfo1 = new MusicFolderInfo(musicFolder1);
         musicFolderInfo1.setDelete(true);
         MusicFolder musicFolder2 = new MusicFolder(MusicFolderTestDataUtils.resolveMusic2FolderPath(), "Music2", true,
-                now());
+                now(), false);
         MusicFolderInfo musicFolderInfo2 = new MusicFolderInfo(musicFolder2);
         command.setMusicFolders(Arrays.asList(musicFolderInfo1, musicFolderInfo2));
 
         // Case where the registered path is deleted on the web page
         MusicFolder musicFolder3 = new MusicFolder(MusicFolderTestDataUtils.resolveMusic3FolderPath(), null, true,
-                now());
+                now(), false);
         MusicFolderInfo musicFolderInfo3 = new MusicFolderInfo(musicFolder3);
         musicFolderInfo3.setPath(null);
         // Cases that do not (already) exist. Update will be executed but will be ignored in Dao.
-        MusicFolder musicFolder4 = new MusicFolder("UnknownPath", "Music4", true, now());
+        MusicFolder musicFolder4 = new MusicFolder("UnknownPath", "Music4", true, now(), false);
         MusicFolderInfo musicFolderInfo4 = new MusicFolderInfo(musicFolder4);
 
         command.setMusicFolders(Arrays.asList(musicFolderInfo1, musicFolderInfo2, musicFolderInfo3, musicFolderInfo4));
@@ -369,7 +369,8 @@ class MusicFolderSettingsControllerTest {
         @ToMusicFolderDecisions.Conditions.MusicFolderInfo.Path.NonNull.NonTraversal.OldPathStartWithNewPath
         @ToMusicFolderDecisions.Results.Empty
         void c03() {
-            List<MusicFolder> oldMusicFolders = Arrays.asList(new MusicFolder(0, "/jpsonic", "old", false, null, 0));
+            List<MusicFolder> oldMusicFolders = Arrays
+                    .asList(new MusicFolder(0, "/jpsonic", "old", false, null, 0, false));
             Mockito.when(musicFolderService.getAllMusicFolders(true, true)).thenReturn(oldMusicFolders);
             MusicFolderInfo info = new MusicFolderInfo();
             String path = "/jpsonic/subDirectory";
@@ -382,7 +383,7 @@ class MusicFolderSettingsControllerTest {
         @ToMusicFolderDecisions.Results.Empty
         void c04() {
             List<MusicFolder> oldMusicFolders = Arrays
-                    .asList(new MusicFolder(0, "/jpsonic/subDirectory", "old", false, null, 0));
+                    .asList(new MusicFolder(0, "/jpsonic/subDirectory", "old", false, null, 0, false));
             Mockito.when(musicFolderService.getAllMusicFolders(true, true)).thenReturn(oldMusicFolders);
             MusicFolderInfo info = new MusicFolderInfo();
             String path = "/jpsonic";
@@ -395,7 +396,8 @@ class MusicFolderSettingsControllerTest {
         @ToMusicFolderDecisions.Conditions.MusicFolderInfo.Name.NonNull
         @ToMusicFolderDecisions.Results.NotEmpty
         void c05() {
-            List<MusicFolder> oldMusicFolders = Arrays.asList(new MusicFolder(0, "/jpsonic", "old", false, null, 0));
+            List<MusicFolder> oldMusicFolders = Arrays
+                    .asList(new MusicFolder(0, "/jpsonic", "old", false, null, 0, false));
             Mockito.when(musicFolderService.getAllMusicFolders(true, true)).thenReturn(oldMusicFolders);
             MusicFolderInfo info = new MusicFolderInfo();
             String path = "foo/bar";
@@ -409,7 +411,8 @@ class MusicFolderSettingsControllerTest {
         @ToMusicFolderDecisions.Conditions.MusicFolderInfo.Name.NonNull
         @ToMusicFolderDecisions.Results.NotEmpty
         void c06() {
-            List<MusicFolder> oldMusicFolders = Arrays.asList(new MusicFolder(0, "/jpsonic", "old", false, null, 0));
+            List<MusicFolder> oldMusicFolders = Arrays
+                    .asList(new MusicFolder(0, "/jpsonic", "old", false, null, 0, false));
             Mockito.when(musicFolderService.getAllMusicFolders(true, true)).thenReturn(oldMusicFolders);
             MusicFolderInfo info = new MusicFolderInfo();
             String path = "/jpsonic";
@@ -460,7 +463,7 @@ class MusicFolderSettingsControllerTest {
     void testWrap() throws URISyntaxException {
         Mockito.when(settingsService.isRedundantFolderCheck()).thenReturn(false);
 
-        MusicFolder folder = new MusicFolder("/dummy", "Music", true, null);
+        MusicFolder folder = new MusicFolder("/dummy", "Music", true, null, false);
         List<MusicFolder> folders = Arrays.asList(folder);
         var infos = controller.wrap(folders);
         assertEquals(1, infos.size());
@@ -472,12 +475,12 @@ class MusicFolderSettingsControllerTest {
         assertFalse(infos.get(0).isExisting());
 
         Path file = Path.of(MusicFolderSettingsControllerTest.class.getResource("/MEDIAS/piano.mp3").toURI());
-        infos = controller.wrap(Arrays.asList(new MusicFolder(file.toString(), "Music", true, null)));
+        infos = controller.wrap(Arrays.asList(new MusicFolder(file.toString(), "Music", true, null, false)));
         assertEquals(1, infos.size());
         assertFalse(infos.get(0).isExisting());
 
         Path dir = Path.of(MusicFolderSettingsControllerTest.class.getResource("/MEDIAS/Music").toURI());
-        infos = controller.wrap(Arrays.asList(new MusicFolder(dir.toString(), "Music", true, null)));
+        infos = controller.wrap(Arrays.asList(new MusicFolder(dir.toString(), "Music", true, null, false)));
         assertEquals(1, infos.size());
         assertTrue(infos.get(0).isExisting());
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/SubsonicRESTControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/SubsonicRESTControllerTest.java
@@ -239,7 +239,7 @@ class SubsonicRESTControllerTest {
     class IntegreationTest extends AbstractNeedsScan {
 
         private final List<MusicFolder> musicFolders = Arrays
-                .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1));
+                .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1, false));
 
         @Autowired
         private MockMvc mvc;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/TopControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/TopControllerTest.java
@@ -124,7 +124,7 @@ class TopControllerTest {
         void testWithoutSelectedMusicFolders() throws ServletRequestBindingException, URISyntaxException {
             List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
                     Path.of(TopControllerTest.class.getResource("/MEDIAS/Sort/Pagination/Artists").toURI()).toString(),
-                    "MEDIAS", true, now(), 1));
+                    "MEDIAS", true, now(), 1, false));
             Mockito.when(musicFolderService.getMusicFoldersForUser(Mockito.anyString())).thenReturn(musicFolders);
 
             MockHttpServletRequest request = mock(MockHttpServletRequest.class);
@@ -136,7 +136,7 @@ class TopControllerTest {
         void testWithSelectedMusicFolders() throws ServletRequestBindingException, URISyntaxException {
             List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
                     Path.of(TopControllerTest.class.getResource("/MEDIAS/Sort/Pagination/Artists").toURI()).toString(),
-                    "MEDIAS", true, now(), 1));
+                    "MEDIAS", true, now(), 1, false));
             Mockito.when(musicFolderService.getMusicFoldersForUser(Mockito.anyString())).thenReturn(musicFolders);
             Mockito.when(securityService.getSelectedMusicFolder(Mockito.anyString())).thenReturn(musicFolders.get(0));
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/UploadControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/UploadControllerTest.java
@@ -87,7 +87,7 @@ class UploadControllerTest {
     @WithMockUser(username = "admin")
     void testHandleRequestInternalWithFile(@TempDir Path tempDirPath) throws Exception {
 
-        MusicFolder musicFolder = new MusicFolder(0, tempDirPath.toString(), "Incoming1", true, now(), 1);
+        MusicFolder musicFolder = new MusicFolder(0, tempDirPath.toString(), "Incoming1", true, now(), 1, false);
         musicFolderDao.createMusicFolder(musicFolder);
 
         URL url = UploadController.class.getResource(FILE_PATH);
@@ -115,7 +115,7 @@ class UploadControllerTest {
     @WithMockUser(username = "admin")
     void testHandleRequestInternalWithZip(@TempDir Path tempDirPath) throws Exception {
 
-        MusicFolder musicFolder = new MusicFolder(1, tempDirPath.toString(), "Incoming2", true, now(), 1);
+        MusicFolder musicFolder = new MusicFolder(1, tempDirPath.toString(), "Incoming2", true, now(), 1, false);
         musicFolderDao.createMusicFolder(musicFolder);
 
         URL url = UploadController.class.getResource(ZIP_PATH);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/UploadEntryControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/UploadEntryControllerTest.java
@@ -55,7 +55,7 @@ class UploadEntryControllerTest {
     public void setup() throws ExecutionException, URISyntaxException {
         List<MusicFolder> musicFolders = Arrays.asList(
                 new MusicFolder(1, Path.of(UploadEntryControllerTest.class.getResource("/MEDIAS").toURI()).toString(),
-                        "MEDIAS", true, now(), 1));
+                        "MEDIAS", true, now(), 1, false));
         MusicFolderService musicFolderService = mock(MusicFolderService.class);
         Mockito.when(musicFolderService.getMusicFoldersForUser(ServiceMockUtils.ADMIN_NAME)).thenReturn(musicFolders);
         mockMvc = MockMvcBuilders.standaloneSetup(new UploadEntryController(musicFolderService,

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/AlbumDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/AlbumDaoTest.java
@@ -76,7 +76,7 @@ class AlbumDaoTest {
 
         @BeforeEach
         public void setup() {
-            MusicFolder folder = new MusicFolder("/Music", "Music", true, null);
+            MusicFolder folder = new MusicFolder("/Music", "Music", true, null, false);
             folders = List.of(folder);
         }
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/ArtistDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/ArtistDaoTest.java
@@ -37,7 +37,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class ArtistDaoTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Compare"), "Artists", true, now(), 1));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Compare"), "Artists", true, now(), 1, false));
 
     @Autowired
     private ArtistDao artistDao;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/DaoUnitTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/DaoUnitTest.java
@@ -77,7 +77,7 @@ class DaoUnitTest {
     @Test
     void testAlbumDao() {
         albumDao.updateAlbum(new Album());
-        List<MusicFolder> folders = List.of(new MusicFolder(null, null, false, null));
+        List<MusicFolder> folders = List.of(new MusicFolder(null, null, false, null, false));
         albumDao.getMostFrequentlyPlayedAlbums(0, 0, folders);
         albumDao.getMostRecentlyPlayedAlbums(0, 0, folders);
         albumDao.getAlbumsByYear(0, 0, 1990, 2020, folders);
@@ -150,7 +150,7 @@ class DaoUnitTest {
     void testMediaFileDao() {
 
         mediaFileDao.getMediaFile("path");
-        List<MusicFolder> folders = List.of(new MusicFolder(null, null, false, null));
+        List<MusicFolder> folders = List.of(new MusicFolder(null, null, false, null, false));
         mediaFileDao.getMediaFile(MediaType.MUSIC, 0, 0, folders);
         mediaFileDao.exists(Path.of("path"));
         mediaFileDao.updateComment("pathString", "comment");
@@ -200,7 +200,7 @@ class DaoUnitTest {
 
     @Test
     void testRatingDao() {
-        List<MusicFolder> folders = List.of(new MusicFolder(null, null, false, null));
+        List<MusicFolder> folders = List.of(new MusicFolder(null, null, false, null, false));
         ratingDao.getHighestRatedAlbums(0, 10, folders);
     }
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/JAlbumDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/JAlbumDaoTest.java
@@ -37,7 +37,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class JAlbumDaoTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Compare"), "Albums", true, now(), 1));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Compare"), "Albums", true, now(), 1, false));
 
     @Autowired
     private AlbumDao albumDao;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MediaFileDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MediaFileDaoTest.java
@@ -280,7 +280,7 @@ class MediaFileDaoTest {
                 assertFalse(op.isPresent());
 
                 List<MusicFolder> folders = new ArrayList<>();
-                folders.add(new MusicFolder("/", "", false, null));
+                folders.add(new MusicFolder("/", "", false, null, false));
                 criteria = new RandomSearchCriteria(0, null, null, null, folders, null, null, null, null, null, null,
                         false, false, null);
                 builder = new RandomSongsQueryBuilder(criteria);
@@ -611,7 +611,7 @@ class MediaFileDaoTest {
 
                 // folder
                 List<MusicFolder> folders = new ArrayList<>();
-                folders.add(new MusicFolder("/", "", false, null));
+                folders.add(new MusicFolder("/", "", false, null, false));
                 criteria = new RandomSearchCriteria(0, null, null, null, folders, null, null, null, null, null, null,
                         false, false, null);
                 builder = new RandomSongsQueryBuilder(criteria);
@@ -703,7 +703,7 @@ class MediaFileDaoTest {
     class IntegrationTest extends AbstractNeedsScan {
 
         private static final MusicFolder MUSIC_FOLDER = new MusicFolder(0,
-                resolveBaseMediaPath("Browsing/MessyFileStructure/Folder"), "Folder", true, now(), 1);
+                resolveBaseMediaPath("Browsing/MessyFileStructure/Folder"), "Folder", true, now(), 1, false);
 
         @Autowired
         private MediaFileDao mediaFileDao;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MusicFolderDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MusicFolderDaoTest.java
@@ -58,7 +58,7 @@ class MusicFolderDaoTest {
 
     @Test
     void testCreateMusicFolder() {
-        MusicFolder musicFolder = new MusicFolder("path", "name", true, now());
+        MusicFolder musicFolder = new MusicFolder("path", "name", true, now(), false);
         musicFolderDao.createMusicFolder(musicFolder);
 
         MusicFolder newMusicFolder = musicFolderDao.getAllMusicFolders().get(0);
@@ -67,7 +67,7 @@ class MusicFolderDaoTest {
 
     @Test
     void testUpdateMusicFolder() {
-        MusicFolder musicFolder = new MusicFolder("path", "name", true, now());
+        MusicFolder musicFolder = new MusicFolder("path", "name", true, now(), false);
         musicFolderDao.createMusicFolder(musicFolder);
         musicFolder = musicFolderDao.getAllMusicFolders().get(0);
 
@@ -84,10 +84,10 @@ class MusicFolderDaoTest {
     void testDeleteMusicFolder() {
         assertEquals(0, musicFolderDao.getAllMusicFolders().size(), "Wrong number of music folders.");
 
-        musicFolderDao.createMusicFolder(new MusicFolder("path", "name", true, now()));
+        musicFolderDao.createMusicFolder(new MusicFolder("path", "name", true, now(), false));
         assertEquals(1, musicFolderDao.getAllMusicFolders().size(), "Wrong number of music folders.");
 
-        musicFolderDao.createMusicFolder(new MusicFolder("path", "name", true, now()));
+        musicFolderDao.createMusicFolder(new MusicFolder("path", "name", true, now(), false));
         assertEquals(2, musicFolderDao.getAllMusicFolders().size(), "Wrong number of music folders.");
 
         musicFolderDao.deleteMusicFolder(musicFolderDao.getAllMusicFolders().get(0).getId());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JpsonicComparatorsTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/JpsonicComparatorsTest.java
@@ -73,7 +73,7 @@ class JpsonicComparatorsTest extends AbstractNeedsScan {
     protected static final Logger LOG = LoggerFactory.getLogger(JpsonicComparatorsTest.class);
 
     protected static final List<MusicFolder> MUSIC_FOLDERS = Arrays.asList(new MusicFolder(1,
-            resolveBaseMediaPath("Sort" + File.separator + "Compare"), "test date for sorting", true, now(), 1));
+            resolveBaseMediaPath("Sort" + File.separator + "Compare"), "test date for sorting", true, now(), 1, false));
 
     protected static final List<String> INDEX_LIST = Collections.unmodifiableList(Arrays.asList("abcde", "abcいうえおあ", // Turn
                                                                                                                      // over

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/MusicFolderTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/domain/MusicFolderTest.java
@@ -28,17 +28,17 @@ class MusicFolderTest {
 
     @Test
     void testEquals() {
-        MusicFolder m1 = new MusicFolder(null, null, null, false, null, null);
+        MusicFolder m1 = new MusicFolder(null, null, null, false, null, null, false);
         MusicFolder m2 = null;
         assertNotEquals(m1, m2);
-        m2 = new MusicFolder(null, null, null, false, null, null);
+        m2 = new MusicFolder(null, null, null, false, null, null, false);
         assertNotEquals(m1, m2);
-        m1 = new MusicFolder(0, null, null, false, null, null);
+        m1 = new MusicFolder(0, null, null, false, null, null, false);
         assertNotEquals(m1, new Object());
         assertNotEquals(m1, m2);
-        m2 = new MusicFolder(1, null, null, false, null, null);
+        m2 = new MusicFolder(1, null, null, false, null, null, false);
         assertNotEquals(m1, m2);
-        m2 = new MusicFolder(0, null, null, false, null, null);
+        m2 = new MusicFolder(0, null, null, false, null, null, false);
         assertEquals(m1, m2);
         assertEquals(m1, m1);
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/RatingServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/RatingServiceTest.java
@@ -61,7 +61,7 @@ class RatingServiceTest {
         album.setPathString(albumPath.toString());
         Mockito.when(mediaFileService.getMediaFile(albumPath)).thenReturn(album);
 
-        MusicFolder musicFolder = new MusicFolder("path", "Music", true, now());
+        MusicFolder musicFolder = new MusicFolder("path", "Music", true, now(), false);
         List<MusicFolder> musicFolders = Arrays.asList(musicFolder);
         List<MediaFile> highestRatedAlbums = ratingService.getHighestRatedAlbums(0, 0, musicFolders);
         assertEquals(1, highestRatedAlbums.size());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/SecurityServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/SecurityServiceTest.java
@@ -218,7 +218,7 @@ class SecurityServiceTest {
         assertThrows(IllegalArgumentException.class, () -> service.isWriteAllowed(Path.of("/")));
         assertFalse(service.isWriteAllowed(Path.of("")));
         Mockito.when(musicFolderService.getAllMusicFolders(false, true))
-                .thenReturn(Arrays.asList(new MusicFolder("/test", "test", true, null)));
+                .thenReturn(Arrays.asList(new MusicFolder("/test", "test", true, null, false)));
         Mockito.when(settingsService.getPodcastFolder()).thenReturn("");
         assertTrue(service.isWriteAllowed(Path.of("/test/cover.jpg")));
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/MetaDataParserTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/metadata/MetaDataParserTest.java
@@ -253,7 +253,8 @@ class MetaDataParserTest {
         assertEquals("MusicFolder", parser.guessArtist(Path.of("/MusicFolder/artist/album")));
         assertEquals("artist", parser.guessArtist(Path.of("/MusicFolder/artist/album/song.mp3")));
 
-        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder("/MusicFolder", "MusicFolder", true, null));
+        List<MusicFolder> musicFolders = Arrays
+                .asList(new MusicFolder("/MusicFolder", "MusicFolder", true, null, false));
         Mockito.when(musicFolderService.getAllMusicFolders(false, true)).thenReturn(musicFolders);
         assertThrows(IllegalArgumentException.class, () -> parser.guessArtist(Path.of("/")));
         assertThrows(IllegalArgumentException.class, () -> parser.guessArtist(Path.of("/song.mp3")));
@@ -272,7 +273,8 @@ class MetaDataParserTest {
         assertEquals("artist", parser.guessAlbum(Path.of("/MusicFolder/artist/album"), "artist"));
         assertEquals("album", parser.guessAlbum(Path.of("/MusicFolder/artist/album/song.mp3"), "artist"));
 
-        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder("/MusicFolder", "MusicFolder", true, null));
+        List<MusicFolder> musicFolders = Arrays
+                .asList(new MusicFolder("/MusicFolder", "MusicFolder", true, null, false));
         Mockito.when(musicFolderService.getAllMusicFolders(false, true)).thenReturn(musicFolders);
         assertThrows(IllegalArgumentException.class, () -> parser.guessAlbum(Path.of("/"), "artist"));
         assertEquals("", parser.guessAlbum(Path.of("/song.mp3"), "artist"));
@@ -297,7 +299,8 @@ class MetaDataParserTest {
         assertFalse(parser.isRoot(Path.of("/MusicFolder/artist")));
         assertFalse(parser.isRoot(Path.of("/MusicFolder")));
         assertFalse(parser.isRoot(Path.of("/")));
-        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder("/MusicFolder", "MusicFolder", true, null));
+        List<MusicFolder> musicFolders = Arrays
+                .asList(new MusicFolder("/MusicFolder", "MusicFolder", true, null, false));
         Mockito.when(musicFolderService.getAllMusicFolders(false, true)).thenReturn(musicFolders);
         assertFalse(parser.isRoot(Path.of("/MusicFolder/artist")));
         assertTrue(parser.isRoot(Path.of("/MusicFolder")));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImplTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImplTest.java
@@ -404,10 +404,11 @@ class MediaScannerServiceImplTest {
         public List<MusicFolder> getMusicFolders() {
             if (ObjectUtils.isEmpty(musicFolders)) {
                 musicFolders = Arrays.asList(
-                        new MusicFolder(1, resolveBaseMediaPath("Scan/Id3LIFO"), "alphaBeticalProps", true, now(), 0),
-                        new MusicFolder(2, resolveBaseMediaPath("Scan/Null"), "noTagFirstChild", true, now(), 1),
+                        new MusicFolder(1, resolveBaseMediaPath("Scan/Id3LIFO"), "alphaBeticalProps", true, now(), 0,
+                                false),
+                        new MusicFolder(2, resolveBaseMediaPath("Scan/Null"), "noTagFirstChild", true, now(), 1, false),
                         new MusicFolder(3, resolveBaseMediaPath("Scan/Reverse"), "fileAndPropsNameInReverse", true,
-                                now(), 2));
+                                now(), 2, false));
             }
             return musicFolders;
         }
@@ -558,7 +559,8 @@ class MediaScannerServiceImplTest {
             assertNotNull(FileUtil.createDirectories(artist));
             this.album = Path.of(artist.toString(), "ALBUM");
             assertNotNull(FileUtil.createDirectories(album));
-            this.musicFolders = Arrays.asList(new MusicFolder(1, tempDir.toString(), "musicFolder", true, now(), 1));
+            this.musicFolders = Arrays
+                    .asList(new MusicFolder(1, tempDir.toString(), "musicFolder", true, now(), 1, false));
 
             // Copy the song file from the test resource. No tags are registered in this file.
             Path sample = Path.of(MediaScannerServiceImplTest.class
@@ -877,7 +879,7 @@ class MediaScannerServiceImplTest {
                 IOUtils.copy(resource, Files.newOutputStream(musicPath));
             }
 
-            MusicFolder musicFolder = new MusicFolder(1, tempDirPath.toString(), "Music", true, now(), 1);
+            MusicFolder musicFolder = new MusicFolder(1, tempDirPath.toString(), "Music", true, now(), 1, false);
             musicFolderDao.createMusicFolder(musicFolder);
             musicFolderService.clearMusicFolderCache();
             TestCaseUtils.execScan(mediaScannerService);
@@ -897,7 +899,7 @@ class MediaScannerServiceImplTest {
 
             // Add the "Music3" folder to the database
             Path musicFolderPath = Path.of(MusicFolderTestDataUtils.resolveMusic3FolderPath());
-            MusicFolder musicFolder = new MusicFolder(1, musicFolderPath.toString(), "Music3", true, now(), 1);
+            MusicFolder musicFolder = new MusicFolder(1, musicFolderPath.toString(), "Music3", true, now(), 1, false);
             musicFolderDao.createMusicFolder(musicFolder);
             musicFolderService.clearMusicFolderCache();
             TestCaseUtils.execScan(mediaScannerService);
@@ -968,8 +970,9 @@ class MediaScannerServiceImplTest {
             assertNotNull(FileUtil.createDirectories(artist));
             this.album = Path.of(artist.toString(), "ALBUM");
             assertNotNull(FileUtil.createDirectories(album));
-            this.musicFolders = Arrays.asList(new MusicFolder(1, tempDir1.toString(), "musicFolder1", true, now(), 0),
-                    new MusicFolder(2, tempDir2.toString(), "musicFolder2", true, now(), 1));
+            this.musicFolders = Arrays.asList(
+                    new MusicFolder(1, tempDir1.toString(), "musicFolder1", true, now(), 0, false),
+                    new MusicFolder(2, tempDir2.toString(), "musicFolder2", true, now(), 1, false));
 
             Path sample = Path.of(MediaScannerServiceImplTest.class
                     .getResource("/MEDIAS/Scan/Timestamp/ARTIST/ALBUM/sample.mp3").toURI());
@@ -1037,7 +1040,8 @@ class MediaScannerServiceImplTest {
             assertNotNull(FileUtil.createDirectories(artist));
             Path album = Path.of(artist.toString(), "ALBUM");
             assertNotNull(FileUtil.createDirectories(album));
-            this.musicFolders = Arrays.asList(new MusicFolder(1, tempDir.toString(), "musicFolder1", true, now(), 1));
+            this.musicFolders = Arrays
+                    .asList(new MusicFolder(1, tempDir.toString(), "musicFolder1", true, now(), 1, false));
             Path sample = Path.of(MediaScannerServiceImplTest.class
                     .getResource("/MEDIAS/Scan/Timestamp/ARTIST/ALBUM/sample.mp3").toURI());
             this.song = Path.of(album.toString(), "sample.mp3");
@@ -1132,7 +1136,7 @@ class MediaScannerServiceImplTest {
         void testDoScanLibraryWithSortStrict() {
 
             Mockito.when(musicFolderService.getAllMusicFolders())
-                    .thenReturn(Arrays.asList(new MusicFolder(0, "path", "name", true, null, -1)));
+                    .thenReturn(Arrays.asList(new MusicFolder(0, "path", "name", true, null, -1, false)));
             Mockito.when(artistDao.getAlbumCounts()).thenReturn(Arrays.asList(new Artist()));
 
             Mockito.when(scannerStateService.isEnableCleansing()).thenReturn(true);
@@ -1191,7 +1195,7 @@ class MediaScannerServiceImplTest {
         void testDoScanLibraryWithoutSortStrict() {
 
             Mockito.when(musicFolderService.getAllMusicFolders())
-                    .thenReturn(Arrays.asList(new MusicFolder(0, "path", "name", true, null, -1)));
+                    .thenReturn(Arrays.asList(new MusicFolder(0, "path", "name", true, null, -1, false)));
             Mockito.when(artistDao.getAlbumCounts()).thenReturn(Arrays.asList(new Artist()));
 
             Mockito.when(scannerStateService.isEnableCleansing()).thenReturn(true);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MusicFolderServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MusicFolderServiceTest.java
@@ -62,14 +62,14 @@ class MusicFolderServiceTest {
         musicFolderService = new MusicFolderServiceImpl(musicFolderDao, mock(StaticsDao.class), settingsService,
                 scannerStateService);
 
-        MusicFolder m1 = new MusicFolder(1, "/dummy/path", "Disabled&NonExisting", false, null, 0);
-        MusicFolder m2 = new MusicFolder(2, "/dummy/path", "Enabled&NonExisting", true, null, 1);
+        MusicFolder m1 = new MusicFolder(1, "/dummy/path", "Disabled&NonExisting", false, null, 0, false);
+        MusicFolder m2 = new MusicFolder(2, "/dummy/path", "Enabled&NonExisting", true, null, 1, false);
         Path existingPath1 = Path.of(MusicFolderServiceTest.class.getResource("/MEDIAS/Music").toURI());
         assertTrue(Files.exists(existingPath1));
-        MusicFolder m3 = new MusicFolder(3, existingPath1.toString(), "Disabled&Existing", false, null, 3);
+        MusicFolder m3 = new MusicFolder(3, existingPath1.toString(), "Disabled&Existing", false, null, 3, false);
         Path existingPath2 = Path.of(MusicFolderServiceTest.class.getResource("/MEDIAS/Music2").toURI());
         assertTrue(Files.exists(existingPath2));
-        MusicFolder m4 = new MusicFolder(4, existingPath2.toString(), "Enabled&Existing", true, null, 4);
+        MusicFolder m4 = new MusicFolder(4, existingPath2.toString(), "Enabled&Existing", true, null, 4, false);
         List<MusicFolder> folders = Arrays.asList(m1, m2, m3, m4);
         Mockito.when(musicFolderDao.getAllMusicFolders()).thenReturn(folders);
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MusicIndexServiceImplTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MusicIndexServiceImplTest.java
@@ -105,7 +105,7 @@ class MusicIndexServiceImplTest {
         Mockito.when(mediaFileService.getDirectChildFiles(anyList(), anyLong(), anyLong(), any(MediaType.class)))
                 .thenReturn(songs);
 
-        MusicFolder folder = new MusicFolder(0, "path", "name", true, now(), 0);
+        MusicFolder folder = new MusicFolder(0, "path", "name", true, now(), 0, false);
         MusicFolderContent content = musicIndexService.getMusicFolderContent(Arrays.asList(folder));
         assertEquals(2, content.getIndexedArtists().size());
         Iterator<MusicIndex> iterator = content.getIndexedArtists().keySet().iterator();
@@ -148,7 +148,7 @@ class MusicIndexServiceImplTest {
                 .thenReturn(StringUtil.split("Shortcuts \"New Incoming\" Podcast Metadata"));
         MusicFolder folder = new MusicFolder(
                 Path.of(MusicIndexServiceImplTest.class.getResource("/MEDIAS/Music").toURI()).toString(), "Music", true,
-                now());
+                now(), false);
         assertEquals(0, musicIndexService.getShortcuts(Arrays.asList(folder)).size());
 
         MediaFile artist = new MediaFile();

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureServiceTest.java
@@ -91,7 +91,7 @@ class ScannerProcedureServiceTest {
         void testExistenceCheck() throws URISyntaxException {
             MusicFolder existingFolder = new MusicFolder(1,
                     Path.of(ScannerProcedureServiceTest.class.getResource("/MEDIAS/Music").toURI()).toString(),
-                    "Existing", true, now(), 1);
+                    "Existing", true, now(), 1, false);
             List<MusicFolder> folders = Arrays.asList(existingFolder);
             Mockito.when(musicFolderServiceImpl.getAllMusicFolders(false, true)).thenReturn(folders);
             Instant startDate = now();
@@ -99,7 +99,7 @@ class ScannerProcedureServiceTest {
             Mockito.verify(musicFolderServiceImpl, Mockito.never()).updateMusicFolder(startDate, existingFolder);
 
             MusicFolder notExistingFolder = new MusicFolder(2, existingFolder.getPathString() + "99", "Not existing",
-                    true, now(), 2);
+                    true, now(), 2, false);
             folders = Arrays.asList(existingFolder, notExistingFolder);
             Mockito.when(musicFolderServiceImpl.getAllMusicFolders(false, true)).thenReturn(folders);
             scannerProcedureService.checkMudicFolders(startDate);
@@ -109,7 +109,7 @@ class ScannerProcedureServiceTest {
 
             MusicFolder existingFile = new MusicFolder(3,
                     Path.of(ScannerProcedureServiceTest.class.getResource("/MEDIAS/piano.mp3").toURI()).toString(),
-                    "Existing file", true, now(), 3);
+                    "Existing file", true, now(), 3, false);
             folders = Arrays.asList(existingFolder, notExistingFolder, existingFile);
             Mockito.when(musicFolderServiceImpl.getAllMusicFolders(false, true)).thenReturn(folders);
             scannerProcedureService.checkMudicFolders(startDate);
@@ -122,7 +122,7 @@ class ScannerProcedureServiceTest {
         void testOrderCheck() throws URISyntaxException {
             MusicFolder orderedFolder = new MusicFolder(1,
                     Path.of(ScannerProcedureServiceTest.class.getResource("/MEDIAS/Music").toURI()).toString(),
-                    "Ordered", true, now(), 1);
+                    "Ordered", true, now(), 1, false);
             List<MusicFolder> folders = Arrays.asList(orderedFolder);
             Mockito.when(musicFolderServiceImpl.getAllMusicFolders(false, true)).thenReturn(folders);
             Instant startDate = now();
@@ -132,10 +132,10 @@ class ScannerProcedureServiceTest {
 
             MusicFolder notOrderedFolder1 = new MusicFolder(2,
                     Path.of(ScannerProcedureServiceTest.class.getResource("/MEDIAS/Music2").toURI()).toString(),
-                    "Music2", true, now(), -1);
+                    "Music2", true, now(), -1, false);
             MusicFolder notOrderedFolder2 = new MusicFolder(3,
                     Path.of(ScannerProcedureServiceTest.class.getResource("/MEDIAS/Music3").toURI()).toString(),
-                    "Music3", true, now(), -1);
+                    "Music3", true, now(), -1, false);
             folders = Arrays.asList(orderedFolder, notOrderedFolder1, notOrderedFolder2);
             Mockito.when(musicFolderServiceImpl.getAllMusicFolders(false, true)).thenReturn(folders);
             ArgumentCaptor<MusicFolder> folderCaptor = ArgumentCaptor.forClass(MusicFolder.class);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/SortProcedureServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/SortProcedureServiceTest.java
@@ -65,7 +65,7 @@ class SortProcedureServiceTest {
     class CompensateSortOfArtistTest extends AbstractNeedsScan {
 
         private final List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
-                resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Compensation"), "Duplicate", true, now(), 1));
+                resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Compensation"), "Duplicate", true, now(), 1, false));
 
         @Autowired
         private MediaFileDao mediaFileDao;
@@ -231,7 +231,7 @@ class SortProcedureServiceTest {
     class CopySortOfArtistTest extends AbstractNeedsScan {
 
         private final List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
-                resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Copy"), "Duplicate", true, now(), 1));
+                resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Copy"), "Duplicate", true, now(), 1, false));
 
         @Autowired
         private MediaFileDao mediaFileDao;
@@ -290,7 +290,7 @@ class SortProcedureServiceTest {
     class MergeSortOfArtistTest extends AbstractNeedsScan {
 
         private final List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
-                resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Merge"), "Duplicate", true, now(), 1));
+                resolveBaseMediaPath("Sort/Cleansing/ArtistSort/Merge"), "Duplicate", true, now(), 1, false));
 
         @Autowired
         private MediaFileDao mediaFileDao;
@@ -776,8 +776,8 @@ class SortProcedureServiceTest {
     @Order(4)
     class UpdateSortOfAlbumTest extends AbstractNeedsScan {
 
-        private final List<MusicFolder> musicFolders = Arrays.asList(
-                new MusicFolder(1, resolveBaseMediaPath("Sort/Cleansing/AlbumSort"), "Duplicate", true, now(), 1));
+        private final List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder(1,
+                resolveBaseMediaPath("Sort/Cleansing/AlbumSort"), "Duplicate", true, now(), 1, false));
         @Autowired
         private MediaFileDao mediaFileDao;
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/DocumentFactoryTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/DocumentFactoryTest.java
@@ -155,7 +155,7 @@ class DocumentFactoryTest {
         artist.setSort("sort");
         artist.setFolderId(10);
         MusicFolder musicFolder = new MusicFolder(100, MusicFolderTestDataUtils.resolveMusicFolderPath(), "Music", true,
-                now(), 0);
+                now(), 0, false);
         Document document = documentFactory.createArtistId3Document(artist, musicFolder);
         assertEquals(6, document.getFields().size(), "fields.size");
         assertEquals("1", document.get(FieldNamesConstants.ID));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
@@ -85,7 +85,8 @@ class IndexManagerTest extends AbstractNeedsScan {
     @Override
     public List<MusicFolder> getMusicFolders() {
         if (ObjectUtils.isEmpty(musicFolders)) {
-            musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1));
+            musicFolders = Arrays
+                    .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1, false));
         }
         return musicFolders;
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/QueryFactoryTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/QueryFactoryTest.java
@@ -62,8 +62,8 @@ class QueryFactoryTest {
     private static final int FID1 = 10;
     private static final int FID2 = 20;
 
-    private static final MusicFolder MUSIC_FOLDER1 = new MusicFolder(FID1, PATH1, "music1", true, now(), 0);
-    private static final MusicFolder MUSIC_FOLDER2 = new MusicFolder(FID2, PATH2, "music2", true, now(), 1);
+    private static final MusicFolder MUSIC_FOLDER1 = new MusicFolder(FID1, PATH1, "music1", true, now(), 0, false);
+    private static final MusicFolder MUSIC_FOLDER2 = new MusicFolder(FID2, PATH2, "music2", true, now(), 1, false);
 
     private static final List<MusicFolder> SINGLE_FOLDERS = Arrays.asList(MUSIC_FOLDER1);
     private static final List<MusicFolder> MULTI_FOLDERS = Arrays.asList(MUSIC_FOLDER1, MUSIC_FOLDER2);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/SearchServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/SearchServiceTest.java
@@ -551,8 +551,8 @@ class SearchServiceTest {
         @Override
         public List<MusicFolder> getMusicFolders() {
             if (isEmpty(musicFolders)) {
-                musicFolders = Arrays.asList(
-                        new MusicFolder(1, resolveBaseMediaPath("Search/SpecialGenre"), "accessible", true, now(), 1));
+                musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Search/SpecialGenre"),
+                        "accessible", true, now(), 1, false));
             }
             return musicFolders;
         }
@@ -817,11 +817,11 @@ class SearchServiceTest {
             if (isEmpty(musicFolders)) {
                 musicFolders = Arrays.asList(
                         new MusicFolder(1, resolveBaseMediaPath("Search/SpecialPath/accessible"), "accessible", true,
-                                now(), 0),
+                                now(), 0, false),
                         new MusicFolder(2, resolveBaseMediaPath("Search/SpecialPath/accessible's"), "accessible's",
-                                true, now(), 1),
+                                true, now(), 1, false),
                         new MusicFolder(3, resolveBaseMediaPath("Search/SpecialPath/accessible+s"), "accessible+s",
-                                true, now(), 2));
+                                true, now(), 2, false));
             }
             return musicFolders;
         }
@@ -881,7 +881,7 @@ class SearchServiceTest {
         public List<MusicFolder> getMusicFolders() {
             if (isEmpty(musicFolders)) {
                 musicFolders = Arrays.asList(new MusicFolder(1, resolveBaseMediaPath("Search/StartWithStopwards"),
-                        "accessible", true, now(), 1));
+                        "accessible", true, now(), 1, false));
             }
             return musicFolders;
         }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/UPnPSearchCriteriaDirectorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/UPnPSearchCriteriaDirectorTest.java
@@ -244,7 +244,7 @@ public class UPnPSearchCriteriaDirectorTest {
         Mockito.when(settingsService.isSearchComposer()).thenReturn(true);
 
         List<MusicFolder> musicFolders = new ArrayList<>();
-        musicFolders.add(new MusicFolder(1, "dummy", "accessible", true, now(), 1));
+        musicFolders.add(new MusicFolder(1, "dummy", "accessible", true, now(), 1, false));
         musicFolderService = mock(MusicFolderService.class);
         Mockito.when(musicFolderService.getMusicFoldersForUser(User.USERNAME_GUEST)).thenReturn(musicFolders);
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/AlbumProcTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/AlbumProcTest.java
@@ -53,8 +53,8 @@ import org.springframework.context.annotation.ComponentScan;
 @SpringBootTest
 class AlbumProcTest extends AbstractNeedsScan {
 
-    private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Albums"), "Albums", true, now(), 1));
+    private static final List<MusicFolder> MUSIC_FOLDERS = Arrays.asList(
+            new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Albums"), "Albums", true, now(), 1, false));
 
     @Autowired
     private SettingsService settingsService;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/ArtistByFolderProcTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/ArtistByFolderProcTest.java
@@ -93,7 +93,7 @@ class ArtistByFolderProcTest {
 
     @Test
     void testGetChildrenWithFolder() {
-        MusicFolder folder = new MusicFolder(0, "/folder1", "folder1", true, now(), 1);
+        MusicFolder folder = new MusicFolder(0, "/folder1", "folder1", true, now(), 1, false);
         Mockito.when(artistDao.getAlphabetialArtists(anyInt(), anyInt(), anyList())).thenReturn(List.of(new Artist()));
         FolderOrArtist folderOrArtist = new FolderOrArtist(folder);
         assertEquals(1, proc.getChildren(folderOrArtist, 0, 2).size());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/ArtistProcTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/ArtistProcTest.java
@@ -50,8 +50,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 
 class ArtistProcTest extends AbstractNeedsScan {
 
-    private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now(), 1));
+    private static final List<MusicFolder> MUSIC_FOLDERS = Arrays.asList(
+            new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now(), 1, false));
 
     @Autowired
     private ArtistProc proc;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/FolderOrArtistLogicTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/FolderOrArtistLogicTest.java
@@ -67,7 +67,7 @@ class FolderOrArtistLogicTest {
 
     @Test
     void testCreateContainerWithFolder() {
-        MusicFolder folder = new MusicFolder(99, "/Nusic", "Music", true, null, null);
+        MusicFolder folder = new MusicFolder(99, "/Nusic", "Music", true, null, null, false);
         FolderOrArtist folderOrArtist = new FolderOrArtist(folder);
         Mockito.when(artistDao.getArtistsCount(Mockito.anyList())).thenReturn(100);
         Container container = logic.createContainer(ProcId.RANDOM_SONG_BY_FOLDER_ARTIST, folderOrArtist);
@@ -95,9 +95,9 @@ class FolderOrArtistLogicTest {
 
     @Test
     void testGetDirectChildren() {
-        MusicFolder folder1 = new MusicFolder("/folder1", "folder1", true, now());
-        MusicFolder folder2 = new MusicFolder("/folder2", "folder2", true, now());
-        MusicFolder folder3 = new MusicFolder("/folder3", "folder3", true, now());
+        MusicFolder folder1 = new MusicFolder("/folder1", "folder1", true, now(), false);
+        MusicFolder folder2 = new MusicFolder("/folder2", "folder2", true, now(), false);
+        MusicFolder folder3 = new MusicFolder("/folder3", "folder3", true, now(), false);
         List<MusicFolder> folders = List.of(folder1, folder2, folder3);
         Mockito.when(util.getGuestFolders()).thenReturn(folders);
         assertEquals(3, logic.getDirectChildren(0, 4).size());
@@ -116,9 +116,9 @@ class FolderOrArtistLogicTest {
 
     @Test
     void testGetDirectChildrenCount() {
-        MusicFolder folder1 = new MusicFolder("/folder1", "folder1", true, now());
-        MusicFolder folder2 = new MusicFolder("/folder2", "folder2", true, now());
-        MusicFolder folder3 = new MusicFolder("/folder3", "folder3", true, now());
+        MusicFolder folder1 = new MusicFolder("/folder1", "folder1", true, now(), false);
+        MusicFolder folder2 = new MusicFolder("/folder2", "folder2", true, now(), false);
+        MusicFolder folder3 = new MusicFolder("/folder3", "folder3", true, now(), false);
         List<MusicFolder> folders = List.of(folder1, folder2, folder3);
         Mockito.when(util.getGuestFolders()).thenReturn(folders);
         assertEquals(3, logic.getDirectChildrenCount());
@@ -146,9 +146,9 @@ class FolderOrArtistLogicTest {
 
     @Test
     void testGetDirectChildWithFolder() {
-        MusicFolder folder1 = new MusicFolder(0, "/folder1", "folder1", true, now(), 1);
-        MusicFolder folder2 = new MusicFolder(1, "/folder2", "folder2", true, now(), 2);
-        MusicFolder folder3 = new MusicFolder(2, "/folder3", "folder3", true, now(), 3);
+        MusicFolder folder1 = new MusicFolder(0, "/folder1", "folder1", true, now(), 1, false);
+        MusicFolder folder2 = new MusicFolder(1, "/folder2", "folder2", true, now(), 2, false);
+        MusicFolder folder3 = new MusicFolder(2, "/folder3", "folder3", true, now(), 3, false);
         List<MusicFolder> folders = List.of(folder1, folder2, folder3);
         Mockito.when(musicFolderDao.getAllMusicFolders()).thenReturn(folders);
         assertEquals(folder3, logic.getDirectChild("2").getFolder());
@@ -166,7 +166,7 @@ class FolderOrArtistLogicTest {
 
     @Test
     void testGetChildSizeOfWithFolder() {
-        MusicFolder folder = new MusicFolder(0, "/folder1", "folder1", true, now(), 1);
+        MusicFolder folder = new MusicFolder(0, "/folder1", "folder1", true, now(), 1, false);
         FolderOrArtist folderOrArtist = new FolderOrArtist(folder);
         assertEquals(0, logic.getChildSizeOf(folderOrArtist));
         Mockito.verify(artistDao, Mockito.times(1)).getArtistsCount(anyList());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/IndexId3ProcTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/IndexId3ProcTest.java
@@ -41,7 +41,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class IndexId3ProcTest extends AbstractNeedsScan {
 
     private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Compare"), "Artists", true, now(), 1));
+            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Compare"), "Artists", true, now(), 1, false));
 
     @Autowired
     private ArtistDao artistDao;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/IndexProcTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/IndexProcTest.java
@@ -261,8 +261,8 @@ class IndexProcTest {
     @Order(2)
     class IntegrationTest extends AbstractNeedsScan {
 
-        private final List<MusicFolder> musicFolders = Arrays
-                .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now(), 1));
+        private final List<MusicFolder> musicFolders = Arrays.asList(
+                new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now(), 1, false));
 
         @Autowired
         private IndexProc indexProc;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/IndexProcTest2.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/IndexProcTest2.java
@@ -52,7 +52,7 @@ class IndexProcTest2 {
     class MessyFileStructureTest extends AbstractNeedsScan {
 
         private static final MusicFolder MUSIC_FOLDER = new MusicFolder(0,
-                resolveBaseMediaPath("Browsing/MessyFileStructure/Folder"), "Folder", true, now(), 1);
+                resolveBaseMediaPath("Browsing/MessyFileStructure/Folder"), "Folder", true, now(), 1, false);
 
         @Autowired
         private IndexProc indexProc;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/MediaFileProcTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/MediaFileProcTest.java
@@ -140,7 +140,7 @@ class MediaFileProcTest {
         @Nested
         class GetGetDirectChildrenTest {
 
-            private final MusicFolder folder1 = new MusicFolder("path1", "name1", true, null);
+            private final MusicFolder folder1 = new MusicFolder("path1", "name1", true, null, false);
             private final MediaFile mfolder1 = new MediaFile();
             private final MediaFile mfolder2 = new MediaFile();
             private final MediaFile mfolder3 = new MediaFile();
@@ -172,8 +172,8 @@ class MediaFileProcTest {
             void testMultiFolder() {
                 when(mediaFileService.getMediaFile(any(Path.class))).thenReturn(mfolder1, mfolder2,
                         mfolder3);
-                MusicFolder folder2 = new MusicFolder("path2", "name2", true, null);
-                MusicFolder folder3 = new MusicFolder("path3", "name3", true, null);
+                MusicFolder folder2 = new MusicFolder("path2", "name2", true, null, false);
+                MusicFolder folder3 = new MusicFolder("path3", "name3", true, null, false);
                 when(util.getGuestFolders()).thenReturn(List.of(folder1, folder2, folder3));
                 assertEquals(0, proc.getDirectChildren(10, 0).size());
                 assertEquals(3, proc.getDirectChildren(0, 3).size());
@@ -187,7 +187,7 @@ class MediaFileProcTest {
         @Nested
         class GetGetDirectChildrenCountTest {
 
-            private final MusicFolder folder1 = new MusicFolder("path1", "name1", true, null);
+            private final MusicFolder folder1 = new MusicFolder("path1", "name1", true, null, false);
 
             @BeforeEach
             public void setup() {
@@ -218,8 +218,8 @@ class MediaFileProcTest {
                 MediaFile mfolder3 = new MediaFile();
                 mfolder3.setPathString("/path3");
                 when(mediaFileService.getMediaFile(any(Path.class))).thenReturn(mfolder1, mfolder2, mfolder3);
-                MusicFolder folder2 = new MusicFolder("path2", "name2", true, null);
-                MusicFolder folder3 = new MusicFolder("path3", "name3", true, null);
+                MusicFolder folder2 = new MusicFolder("path2", "name2", true, null, false);
+                MusicFolder folder3 = new MusicFolder("path3", "name3", true, null, false);
                 when(util.getGuestFolders()).thenReturn(List.of(folder1, folder2, folder3));
                 assertEquals(0, proc.getDirectChildren(10, 0).size());
                 assertEquals(3, proc.getDirectChildren(0, 3).size());
@@ -295,7 +295,7 @@ class MediaFileProcTest {
         public void setup() throws URISyntaxException {
             musicFolders = Arrays.asList(new MusicFolder(1,
                     Path.of(MediaFileProcTest.class.getResource("/MEDIAS/Sort/Pagination/Artists").toURI()).toString(),
-                    "Artists", true, now(), 1));
+                    "Artists", true, now(), 1, false));
 
             setSortStrict(true);
             setSortAlphanum(true);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/PlaylistProcTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/PlaylistProcTest.java
@@ -143,8 +143,8 @@ class PlaylistProcTest {
     @Nested
     class IntegrationTest extends AbstractNeedsScan {
 
-        private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-                .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now(), 1));
+        private static final List<MusicFolder> MUSIC_FOLDERS = Arrays.asList(
+                new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now(), 1, false));
 
         @Autowired
         private PlaylistProc playlistProc;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RandomSongByArtistProcTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RandomSongByArtistProcTest.java
@@ -152,8 +152,8 @@ class RandomSongByArtistProcTest {
     @Nested
     class IntegrationTest extends AbstractNeedsScan {
 
-        private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-                .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now(), 1));
+        private static final List<MusicFolder> MUSIC_FOLDERS = Arrays.asList(
+                new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now(), 1, false));
 
         @Autowired
         private RandomSongByArtistProc randomSongByArtistProc;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RandomSongByFolderArtistProcTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RandomSongByFolderArtistProcTest.java
@@ -102,7 +102,7 @@ class RandomSongByFolderArtistProcTest {
 
         @Test
         void testGetChildrenWithFolder() {
-            MusicFolder folder = new MusicFolder(0, "/folder1", "folder1", true, now(), 1);
+            MusicFolder folder = new MusicFolder(0, "/folder1", "folder1", true, now(), 1, false);
             Mockito.when(artistDao.getAlphabetialArtists(anyInt(), anyInt(), anyList()))
                     .thenReturn(List.of(new Artist()));
             FolderOrArtist folderOrArtist = new FolderOrArtist(folder);
@@ -138,8 +138,8 @@ class RandomSongByFolderArtistProcTest {
     @Nested
     class IntegrationTest extends AbstractNeedsScan {
 
-        private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-                .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now(), 1));
+        private static final List<MusicFolder> MUSIC_FOLDERS = Arrays.asList(
+                new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now(), 1, false));
 
         @Autowired
         private RandomSongByFolderArtistProc proc;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumId3ProcTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumId3ProcTest.java
@@ -97,8 +97,8 @@ class RecentAlbumId3ProcTest {
     @Nested
     class IntegrationTest extends AbstractNeedsScan {
 
-        private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-                .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Albums"), "Albums", true, now(), 1));
+        private static final List<MusicFolder> MUSIC_FOLDERS = Arrays.asList(
+                new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Albums"), "Albums", true, now(), 1, false));
 
         @Autowired
         private RecentAlbumId3Proc processor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumProcTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumProcTest.java
@@ -40,8 +40,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 class RecentAlbumProcTest extends AbstractNeedsScan {
 
-    private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-            .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Albums"), "Albums", true, now(), 1));
+    private static final List<MusicFolder> MUSIC_FOLDERS = Arrays.asList(
+            new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Albums"), "Albums", true, now(), 1, false));
 
     @Autowired
     private RecentAlbumProc processor;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/SongByGenreProcTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/SongByGenreProcTest.java
@@ -159,8 +159,8 @@ class SongByGenreProcTest {
     @Nested
     class IntegrationTest extends AbstractNeedsScan {
 
-        private static final List<MusicFolder> MUSIC_FOLDERS = Arrays
-                .asList(new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now(), 1));
+        private static final List<MusicFolder> MUSIC_FOLDERS = Arrays.asList(
+                new MusicFolder(1, resolveBaseMediaPath("Sort/Pagination/Artists"), "Artists", true, now(), 1, false));
 
         @Autowired
         private SongByGenreProc songByGenreProc;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/UpnpProcessorUtilTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/UpnpProcessorUtilTest.java
@@ -64,7 +64,7 @@ class UpnpProcessorUtilTest {
         assertFalse(util.isGenreCountAvailable());
 
         Mockito.when(settingsService.isDlnaGenreCountVisible()).thenReturn(true);
-        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder("", null, true, null));
+        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder("", null, true, null, false));
         Mockito.when(musicFolderService.getAllMusicFolders()).thenReturn(musicFolders);
         Mockito.when(musicFolderService.getMusicFoldersForUser(User.USERNAME_GUEST)).thenReturn(musicFolders);
         assertTrue(util.isGenreCountAvailable());

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/WMPProcTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/WMPProcTest.java
@@ -178,7 +178,7 @@ class WMPProcTest {
             m.setPathString("path2");
             m.setTitle("dummy title");
             List<MediaFile> songs = Arrays.asList(m);
-            MusicFolder mf = new MusicFolder(0, "path3", "dummy", true, null, 0);
+            MusicFolder mf = new MusicFolder(0, "path3", "dummy", true, null, 0, false);
             List<MusicFolder> folders = Arrays.asList(mf);
             when(util.getGuestFolders()).thenReturn(folders);
             when(mediaFileService.getSongs(anyLong(), anyLong(), anyList())).thenReturn(songs);
@@ -232,7 +232,7 @@ class WMPProcTest {
             m.setPathString("path5");
             m.setTitle("dummy title");
             List<MediaFile> songs = Arrays.asList(m);
-            MusicFolder mf = new MusicFolder(0, "path6", "dummy", true, null, 0);
+            MusicFolder mf = new MusicFolder(0, "path6", "dummy", true, null, 0, false);
             List<MusicFolder> folders = Arrays.asList(mf);
             when(util.getGuestFolders()).thenReturn(folders);
             when(mediaFileService.getVideos(anyLong(), anyLong(), anyList())).thenReturn(songs);


### PR DESCRIPTION
Prerequisites: #2276

#### Overview

A new field called 'archived' will be added to the MusicFolder table. This is used to suppress data scanning and deletion, on a per MusicFolder basis at the user's discretion. That in itself seems like a very simple fix, but it's not. We guarantee that we will work on this, but it will take some time as we will be exhaustively checking the scope of the impact. 😉　

Therefore, only database schema changes are performed at the time of major releases, and full-scale modifications are postponed until after that. This is a planned, gradual renovation.