### PR TITLE
Add menu_item table

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MenuItemDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MenuItemDao.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2023 tesshucom
+ */
+
+package com.tesshu.jpsonic.dao;
+
+import java.sql.ResultSet;
+import java.util.List;
+
+import com.tesshu.jpsonic.dao.base.TemplateWrapper;
+import com.tesshu.jpsonic.domain.MenuItem;
+import com.tesshu.jpsonic.domain.MenuItem.ViewType;
+import com.tesshu.jpsonic.domain.MenuItemId;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class MenuItemDao {
+
+    private static final String QUERY_COLUMNS = """
+            view_type, id, parent, name, enabled, menu_item_order\s
+            """;
+    private final TemplateWrapper template;
+    private final RowMapper<MenuItem> rowMapper = (ResultSet rs, int num) -> new MenuItem(ViewType.of(rs.getInt(1)),
+            MenuItemId.of(rs.getInt(2)), MenuItemId.of(rs.getInt(3)), rs.getString(4), rs.getBoolean(5), rs.getInt(6));
+
+    public MenuItemDao(TemplateWrapper templateWrapper) {
+        template = templateWrapper;
+    }
+
+    public List<MenuItem> getTopMenuItems(ViewType viewType) {
+        return template.query("select " + QUERY_COLUMNS + """
+                from menu_item
+                where view_type=? and parent=?
+                order by menu_item_order, id
+                """, rowMapper, viewType.value(), MenuItemId.ROOT.value());
+    }
+
+    public List<MenuItem> getChildlenOf(ViewType viewType, MenuItemId id) {
+        return template.query("select " + QUERY_COLUMNS + """
+                from menu_item
+                where view_type=? and parent=?
+                order by menu_item_order, id
+                """, rowMapper, viewType.value(), id.value());
+    }
+}

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MenuItem.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MenuItem.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2023 tesshucom
+ */
+
+package com.tesshu.jpsonic.domain;
+
+import java.util.stream.Stream;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public class MenuItem {
+
+    private ViewType viewType;
+    private MenuItemId id;
+    private MenuItemId parent;
+    private String name;
+    private boolean enabled;
+    private int menuItemOrder;
+
+    public MenuItem(ViewType viewType, MenuItemId id, MenuItemId parent, String name, boolean enabled,
+            int menuItemOrder) {
+        super();
+        this.viewType = viewType;
+        this.id = id;
+        this.parent = parent;
+        this.name = name;
+        this.enabled = enabled;
+        this.menuItemOrder = menuItemOrder;
+    }
+
+    public ViewType getViewType() {
+        return viewType;
+    }
+
+    public void setViewType(ViewType viewType) {
+        this.viewType = viewType;
+    }
+
+    public MenuItemId getId() {
+        return id;
+    }
+
+    public void setId(MenuItemId id) {
+        this.id = id;
+    }
+
+    public MenuItemId getParent() {
+        return parent;
+    }
+
+    public void setParent(MenuItemId parent) {
+        this.parent = parent;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public int getMenuItemOrder() {
+        return menuItemOrder;
+    }
+
+    public void setMenuItemOrder(int menuItemOrder) {
+        this.menuItemOrder = menuItemOrder;
+    }
+
+    public enum ViewType {
+
+        ANY(0), UPNP(1), WEB(2);
+
+        private final int v;
+
+        ViewType(int v) {
+            this.v = v;
+        }
+
+        public int value() {
+            return v;
+        }
+
+        public static @NonNull ViewType of(int value) {
+            return Stream.of(ViewType.values()).filter(id -> id.v == value).findFirst().orElse(ANY);
+        }
+    }
+}

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MenuItemId.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/MenuItemId.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2023 tesshucom
+ */
+
+package com.tesshu.jpsonic.domain;
+
+import java.util.stream.Stream;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+public enum MenuItemId {
+
+    ROOT(0),
+
+    FOLDER(10), INDEX(11), MEDIA_FILE(12),
+
+    ARTIST(20), INDEX_ID3(21), ALBUM_ARTIST(22), ALBUM_ARTIST_BY_FOLDER(23),
+
+    ALBUM(30), ALBUM_ID3(31),
+
+    GENRE(40), ALBUM_BY_GENRE(41), SONG_BY_GENRE(42),
+
+    PODCAST(50), PODCAST_DEFALT(51),
+
+    PLAYLISTS(60), PLAYLISTS_DEFALT(61),
+
+    RECENTLY(70), RECENTLY_ADDED_ALBUM(71), RECENTLY_TAGGED_ALBUM(72),
+
+    SHUFFLE(80), RANDOM_ALBUM(81), RANDOM_SONG(82), RANDOM_SONG_BY_ARTIST(83), RANDOM_SONG_BY_FOLDER_ARTIST(84),
+
+    YEAR(90),
+
+    AUDIOBOOK(100),
+
+    VIDEO(110),
+
+    RADIO(120),
+
+    BOOKMARK(130);
+
+    private final int v;
+
+    MenuItemId(int v) {
+        this.v = v;
+    }
+
+    public int value() {
+        return v;
+    }
+
+    public static @NonNull MenuItemId of(int value) {
+        return Stream.of(MenuItemId.values()).filter(id -> id.v == value).findFirst().orElse(ROOT);
+    }
+}

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MenuItemService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/MenuItemService.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2023 tesshucom
+ */
+
+package com.tesshu.jpsonic.service;
+
+import java.util.List;
+import java.util.Locale;
+
+import javax.annotation.Resource;
+
+import com.tesshu.jpsonic.dao.MenuItemDao;
+import com.tesshu.jpsonic.domain.MenuItem;
+import com.tesshu.jpsonic.domain.MenuItem.ViewType;
+import com.tesshu.jpsonic.domain.MenuItemId;
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MenuItemService {
+
+    private final SettingsService settingsService;
+    private final MenuItemDao menuItemDao;
+    @Lazy
+    @Resource(name = "menuItemSource")
+    private final MessageSource menuItemSource;
+
+    public MenuItemService(SettingsService settingsService, MenuItemDao menuItemDao, MessageSource menuItemSource) {
+        this.settingsService = settingsService;
+        this.menuItemDao = menuItemDao;
+        this.menuItemSource = menuItemSource;
+    }
+
+    String getItemName(MenuItemId id) {
+        Locale locale = Locale.JAPAN.getLanguage().equals(settingsService.getLocale().getLanguage()) ? Locale.JAPAN
+                : Locale.US;
+        return menuItemSource.getMessage("defaultname." + id.toString().toLowerCase(Locale.US), null, locale);
+    }
+
+    public List<MenuItem> getTopMenuItems(ViewType viewType) {
+        List<MenuItem> menuItems = menuItemDao.getTopMenuItems(viewType);
+        menuItems.stream().filter(item -> item.getName().isBlank())
+                .forEach(item -> item.setName(getItemName(item.getId())));
+        return menuItems;
+    }
+
+    public List<MenuItem> getChildlenOf(ViewType viewType, MenuItemId id) {
+        List<MenuItem> menuItems = menuItemDao.getChildlenOf(viewType, id);
+        menuItems.stream().filter(item -> item.getName().isBlank())
+                .forEach(item -> item.setName(getItemName(item.getId())));
+        return menuItems;
+    }
+}

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/spring/MessageSourceConfiguration.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/spring/MessageSourceConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2023 tesshucom
+ */
+
+package com.tesshu.jpsonic.spring;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+
+@Configuration
+public class MessageSourceConfiguration {
+
+    @Bean
+    public MessageSource menuItemSource() {
+        final ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
+        messageSource.setBasename("classpath:com/tesshu/jpsonic/i18n/menuItem");
+        messageSource.setFallbackToSystemLocale(false);
+        messageSource.setCacheSeconds(0);
+        return messageSource;
+    }
+}

--- a/jpsonic-main/src/main/resources/com/tesshu/jpsonic/i18n/menuItem.properties
+++ b/jpsonic-main/src/main/resources/com/tesshu/jpsonic/i18n/menuItem.properties
@@ -1,0 +1,40 @@
+defaultname.folder=Folder
+defaultname.artist=Album Artist
+defaultname.album=Album
+defaultname.genre=Genre
+defaultname.podcast=Podcast
+defaultname.playlists=Playlists
+defaultname.recently=Recently
+defaultname.shuffle=Shuffle
+
+#Folder
+defaultname.index=Folder with Index
+defaultname.media_file=File Structure
+
+#Album Artist
+defaultname.index_id3=Album Artist with Index
+defaultname.album_artist=Album Artist All
+defaultname.album_artist_by_folder=Album Artist All(by Folder)
+
+#Album
+defaultname.album_id3=Album All(ID3)
+
+#Genre
+defaultname.album_by_genre=Albums by Genre(File Structure)
+defaultname.song_by_genre=All Music by Genre
+
+#Podcast
+defaultname.podcast_defalt=Podcast Channels All
+
+#Playlists
+defaultname.playlists_defalt=Playlists All
+
+#Recently
+defaultname.recently_added_album=Recently Added Albums
+defaultname.recently_tagged_album=Recently Tagged Albums
+
+#Shuffle
+defaultname.random_album=Random Album(ID3)
+defaultname.random_song=Random Music
+defaultname.random_song_by_artist=Random Music by Artist(ID3)
+defaultname.random_song_by_folder_artist=Random Music by Artist(by Folder/ID3)

--- a/jpsonic-main/src/main/resources/com/tesshu/jpsonic/i18n/menuItem_ja.properties
+++ b/jpsonic-main/src/main/resources/com/tesshu/jpsonic/i18n/menuItem_ja.properties
@@ -1,0 +1,40 @@
+defaultname.folder=\u30D5\u30A9\u30EB\u30C0
+defaultname.artist=\u30A2\u30EB\u30D0\u30E0\u30A2\u30FC\u30C6\u30A3\u30B9\u30C8
+defaultname.album=\u30A2\u30EB\u30D0\u30E0
+defaultname.genre=\u30B8\u30E3\u30F3\u30EB
+defaultname.podcast=\u30DD\u30C3\u30C9\u30AD\u30E3\u30B9\u30C8
+defaultname.playlists=\u30D7\u30EC\u30A4\u30EA\u30B9\u30C8
+defaultname.recently=\u6700\u8FD1\u306E\u66F2
+defaultname.shuffle=\u30B7\u30E3\u30C3\u30D5\u30EB
+
+#Folder
+defaultname.index=\u30D5\u30A9\u30EB\u30C0\u306E\u7D22\u5F15
+defaultname.media_file=File Structure
+
+#Album Artist
+defaultname.index_id3=\u30A2\u30EB\u30D0\u30E0\u30A2\u30FC\u30C6\u30A3\u30B9\u30C8\u306E\u7D22\u5F15
+defaultname.album_artist=\u5168\u3066\u306E\u30A2\u30EB\u30D0\u30E0\u30A2\u30FC\u30C6\u30A3\u30B9\u30C8
+defaultname.album_artist_by_folder=\u30A2\u30EB\u30D0\u30E0\u30A2\u30FC\u30C6\u30A3\u30B9\u30C8(\u30D5\u30A9\u30EB\u30C0\u5225)
+
+#Album
+defaultname.album_id3=\u5168\u3066\u306E\u30A2\u30EB\u30D0\u30E0(ID3)
+
+#Genre
+defaultname.album_by_genre=\u30B8\u30E3\u30F3\u30EB\u5225\u306E\u30A2\u30EB\u30D0\u30E0(File Structure)
+defaultname.song_by_genre=\u30B8\u30E3\u30F3\u30EB\u5225\u306E\u66F2
+
+#Podcast
+defaultname.podcast_defalt=\u5168\u3066\u306E\u30DD\u30C3\u30C9\u30AD\u30E3\u30B9\u30C8\u30C1\u30E3\u30F3\u30CD\u30EB
+
+#Playlists
+defaultname.playlists_defalt=\u5168\u3066\u306E\u30D7\u30EC\u30A4\u30EA\u30B9\u30C8
+
+#Recently
+defaultname.recently_added_album=\u6700\u8FD1\u8FFD\u52A0\u3055\u308C\u305F\u30A2\u30EB\u30D0\u30E0
+defaultname.recently_tagged_album=\u6700\u8FD1\u30BF\u30B0\u66F4\u65B0\u3055\u308C\u305F\u30A2\u30EB\u30D0\u30E0
+
+#Shuffle
+defaultname.random_album=\u30E9\u30F3\u30C0\u30E0\u30A2\u30EB\u30D0\u30E0(ID3)
+defaultname.random_song=\u30E9\u30F3\u30C0\u30E0\u66F2
+defaultname.random_song_by_artist=\u30A2\u30FC\u30C6\u30A3\u30B9\u30C8\u5225\u30E9\u30F3\u30C0\u30E0\u66F2(ID3)
+defaultname.random_song_by_folder_artist=\u30A2\u30FC\u30C6\u30A3\u30B9\u30C8\u5225\u30E9\u30F3\u30C0\u30E0\u66F2(by Folder/ID3)

--- a/jpsonic-main/src/main/resources/liquibase/jp113.0.0/add-menu-item.xml
+++ b/jpsonic-main/src/main/resources/liquibase/jp113.0.0/add-menu-item.xml
@@ -1,0 +1,457 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-manu-root" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 0</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="0" />
+            <column name="id" valueNumeric="0" />
+            <column name="parent" valueNumeric="0" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="false" />
+            <column name="menu_item_order" valueNumeric="0" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 0</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-folder" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 10</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="10" />
+            <column name="parent" valueNumeric="0" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="true" />
+            <column name="menu_item_order" valueNumeric="1" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 10</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-index" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 11</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="11" />
+            <column name="parent" valueNumeric="10" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="true" />
+            <column name="menu_item_order" valueNumeric="10" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 11</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-media-file" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 12</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="12" />
+            <column name="parent" valueNumeric="10" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="false" />
+            <column name="menu_item_order" valueNumeric="20" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 12</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-artist" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 20</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="20" />
+            <column name="parent" valueNumeric="0" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="true" />
+            <column name="menu_item_order" valueNumeric="2" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 20</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-index-id3" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 21</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="21" />
+            <column name="parent" valueNumeric="20" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="true" />
+            <column name="menu_item_order" valueNumeric="10" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 21</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-index-album-artist" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 22</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="22" />
+            <column name="parent" valueNumeric="20" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="false" />
+            <column name="menu_item_order" valueNumeric="20" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 22</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-index-album-artist-by-folder" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 23</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="23" />
+            <column name="parent" valueNumeric="20" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="false" />
+            <column name="menu_item_order" valueNumeric="30" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 23</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-album" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 30</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="30" />
+            <column name="parent" valueNumeric="0" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="true" />
+            <column name="menu_item_order" valueNumeric="3" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 30</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-album-id3" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 31</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="31" />
+            <column name="parent" valueNumeric="30" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="true" />
+            <column name="menu_item_order" valueNumeric="10" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 31</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-genre" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 40</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="40" />
+            <column name="parent" valueNumeric="0" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="true" />
+            <column name="menu_item_order" valueNumeric="4" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 40</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-album-by-genre" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 41</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="41" />
+            <column name="parent" valueNumeric="40" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="true" />
+            <column name="menu_item_order" valueNumeric="10" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 41</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-song-by-genre" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 42</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="42" />
+            <column name="parent" valueNumeric="40" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="false" />
+            <column name="menu_item_order" valueNumeric="20" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 42</where>
+            </delete>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="add-menu-item-upnp-podcast" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 50</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="50" />
+            <column name="parent" valueNumeric="0" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="true" />
+            <column name="menu_item_order" valueNumeric="5" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 50</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-podcast-default" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 51</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="51" />
+            <column name="parent" valueNumeric="50" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="true" />
+            <column name="menu_item_order" valueNumeric="10" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 51</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-playlists" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 60</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="60" />
+            <column name="parent" valueNumeric="0" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="true" />
+            <column name="menu_item_order" valueNumeric="6" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 60</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-playlists-default" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 61</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="61" />
+            <column name="parent" valueNumeric="60" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="true" />
+            <column name="menu_item_order" valueNumeric="10" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 61</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-recently" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 70</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="70" />
+            <column name="parent" valueNumeric="0" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="true" />
+            <column name="menu_item_order" valueNumeric="7" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 70</where>
+            </delete>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="add-menu-item-upnp-recently-added-album" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 71</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="71" />
+            <column name="parent" valueNumeric="70" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="true" />
+            <column name="menu_item_order" valueNumeric="10" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 71</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-recently-tagged-album" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 72</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="72" />
+            <column name="parent" valueNumeric="70" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="false" />
+            <column name="menu_item_order" valueNumeric="20" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 72</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-shuffle" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 80</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="80" />
+            <column name="parent" valueNumeric="0" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="true" />
+            <column name="menu_item_order" valueNumeric="8" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 80</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-random-album" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 81</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="81" />
+            <column name="parent" valueNumeric="80" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="true" />
+            <column name="menu_item_order" valueNumeric="10" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 81</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-random-song" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 82</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="82" />
+            <column name="parent" valueNumeric="80" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="false" />
+            <column name="menu_item_order" valueNumeric="20" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 82</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-random-song-by-artist" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 83</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="83" />
+            <column name="parent" valueNumeric="80" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="false" />
+            <column name="menu_item_order" valueNumeric="30" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 83</where>
+            </delete>
+        </rollback>
+    </changeSet>
+    <changeSet id="add-menu-item-upnp-random-song-by-folder-artist" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">select count(*) from menu_item where id = 84</sqlCheck>
+        </preConditions>
+        <insert tableName="menu_item">
+            <column name="view_type" valueNumeric="1" />
+            <column name="id" valueNumeric="84" />
+            <column name="parent" valueNumeric="80" />
+            <column name="name" value="" />
+            <column name="enabled" valueBoolean="false" />
+            <column name="menu_item_order" valueNumeric="40" />
+        </insert>
+        <rollback>
+            <delete tableName="menu_item">
+                <where>id = 84</where>
+            </delete>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/jpsonic-main/src/main/resources/liquibase/jp113.0.0/add-music-index.xml
+++ b/jpsonic-main/src/main/resources/liquibase/jp113.0.0/add-music-index.xml
@@ -1,0 +1,47 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="add-music-index-to-media-file" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="media_file" columnName="music_index" />
+            </not>
+        </preConditions>
+        <addColumn tableName="media_file">
+            <column name="music_index" type="${varchar_type}" defaultValue="">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+        <createIndex tableName="media_file" indexName="idx_media_file_music_index">
+            <column name="music_index"/>
+        </createIndex>
+    </changeSet>
+    <changeSet id="add-music-index-to-artist" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="artist" columnName="music_index" />
+            </not>
+        </preConditions>
+        <addColumn tableName="artist">
+            <column name="music_index" type="${varchar_type}" defaultValue="">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+        <createIndex tableName="artist" indexName="idx_artist_music_index">
+            <column name="music_index"/>
+        </createIndex>
+    </changeSet>
+    <changeSet id="add-archived-to-music-folder" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="music_folder" columnName="archived" />
+            </not>
+        </preConditions>
+        <addColumn tableName="music_folder">
+            <column name="archived" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/jpsonic-main/src/main/resources/liquibase/jp113.0.0/changelog.xml
+++ b/jpsonic-main/src/main/resources/liquibase/jp113.0.0/changelog.xml
@@ -2,47 +2,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
-
-    <changeSet id="add-music-index-to-media-file" author="tesshucom">
-        <preConditions onFail="MARK_RAN">
-            <not>
-                <columnExists tableName="media_file" columnName="music_index" />
-            </not>
-        </preConditions>
-        <addColumn tableName="media_file">
-            <column name="music_index" type="${varchar_type}" defaultValue="">
-                <constraints nullable="false" />
-            </column>
-        </addColumn>
-        <createIndex tableName="media_file" indexName="idx_media_file_music_index">
-            <column name="music_index"/>
-        </createIndex>
-    </changeSet>
-    <changeSet id="add-music-index-to-artist" author="tesshucom">
-        <preConditions onFail="MARK_RAN">
-            <not>
-                <columnExists tableName="artist" columnName="music_index" />
-            </not>
-        </preConditions>
-        <addColumn tableName="artist">
-            <column name="music_index" type="${varchar_type}" defaultValue="">
-                <constraints nullable="false" />
-            </column>
-        </addColumn>
-        <createIndex tableName="artist" indexName="idx_artist_music_index">
-            <column name="music_index"/>
-        </createIndex>
-    </changeSet>
-    <changeSet id="add-archived-to-music-folder" author="tesshucom">
-        <preConditions onFail="MARK_RAN">
-            <not>
-                <columnExists tableName="music_folder" columnName="archived" />
-            </not>
-        </preConditions>
-        <addColumn tableName="music_folder">
-            <column name="archived" type="boolean" defaultValueBoolean="false">
-                <constraints nullable="false" />
-            </column>
-        </addColumn>
-    </changeSet>
+    <include file="add-music-index.xml" relativeToChangelogFile="true"/>
+    <include file="create-menu-item-table.xml" relativeToChangelogFile="true"/>
+    <include file="add-menu-item.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/jpsonic-main/src/main/resources/liquibase/jp113.0.0/create-menu-item-table.xml
+++ b/jpsonic-main/src/main/resources/liquibase/jp113.0.0/create-menu-item-table.xml
@@ -1,0 +1,36 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="create-menu-item" author="tesshucom">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="menu_item"/>
+            </not>
+        </preConditions>
+        <createTable tableName="menu_item">
+            <column name="view_type" type="int">
+                <constraints nullable="false" />
+            </column>
+            <column name="id" type="int">
+                <constraints nullable="false" />
+            </column>
+            <column name="parent" type="int">
+                <constraints nullable="false" />
+            </column>
+            <column name="name" type="${varchar_type}" defaultValue="">
+                <constraints nullable="false" />
+            </column>
+            <column name="enabled" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false" />
+            </column>
+            <column name="menu_item_order" type="int">
+                <constraints nullable="false" />
+            </column>
+        </createTable>
+        <addUniqueConstraint tableName="menu_item" columnNames="view_type,id" />
+        <rollback>
+            <dropTable tableName="menu_item" />
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MenuItemDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MenuItemDaoTest.java
@@ -1,0 +1,120 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2023 tesshucom
+ */
+
+package com.tesshu.jpsonic.dao;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import com.tesshu.jpsonic.AbstractNeedsScan;
+import com.tesshu.jpsonic.domain.MenuItem;
+import com.tesshu.jpsonic.domain.MenuItem.ViewType;
+import com.tesshu.jpsonic.domain.MenuItemId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class MenuItemDaoTest extends AbstractNeedsScan {
+
+    @Autowired
+    private MenuItemDao menuItemDao;
+
+    @BeforeEach
+    public void setup() {
+        setSortAlphanum(true);
+        setSortStrict(true);
+        populateDatabaseOnlyOnce();
+    }
+
+    @Test
+    void testGetTopMenuItems() {
+        List<MenuItem> menuItems = menuItemDao.getTopMenuItems(ViewType.UPNP);
+        assertEquals(8, menuItems.size());
+        assertEquals(MenuItemId.FOLDER, menuItems.get(0).getId());
+        assertEquals(MenuItemId.ARTIST, menuItems.get(1).getId());
+        assertEquals(MenuItemId.ALBUM, menuItems.get(2).getId());
+        assertEquals(MenuItemId.GENRE, menuItems.get(3).getId());
+        assertEquals(MenuItemId.PODCAST, menuItems.get(4).getId());
+        assertEquals(MenuItemId.PLAYLISTS, menuItems.get(5).getId());
+        assertEquals(MenuItemId.RECENTLY, menuItems.get(6).getId());
+        assertEquals(MenuItemId.SHUFFLE, menuItems.get(7).getId());
+    }
+
+    @Test
+    void testGetChildlenOf() {
+        List<MenuItem> menuItems = menuItemDao.getChildlenOf(ViewType.UPNP, MenuItemId.FOLDER);
+        assertEquals(2, menuItems.size());
+        assertEquals(MenuItemId.INDEX, menuItems.get(0).getId());
+        assertTrue(menuItems.get(0).isEnabled());
+        assertEquals(MenuItemId.MEDIA_FILE, menuItems.get(1).getId());
+        assertFalse(menuItems.get(1).isEnabled());
+
+        menuItems = menuItemDao.getChildlenOf(ViewType.UPNP, MenuItemId.ARTIST);
+        assertEquals(3, menuItems.size());
+        assertEquals(MenuItemId.INDEX_ID3, menuItems.get(0).getId());
+        assertTrue(menuItems.get(0).isEnabled());
+        assertEquals(MenuItemId.ALBUM_ARTIST, menuItems.get(1).getId());
+        assertFalse(menuItems.get(1).isEnabled());
+        assertEquals(MenuItemId.ALBUM_ARTIST_BY_FOLDER, menuItems.get(2).getId());
+        assertFalse(menuItems.get(2).isEnabled());
+
+        menuItems = menuItemDao.getChildlenOf(ViewType.UPNP, MenuItemId.ALBUM);
+        assertEquals(1, menuItems.size());
+        assertEquals(MenuItemId.ALBUM_ID3, menuItems.get(0).getId());
+        assertTrue(menuItems.get(0).isEnabled());
+
+        menuItems = menuItemDao.getChildlenOf(ViewType.UPNP, MenuItemId.GENRE);
+        assertEquals(2, menuItems.size());
+        assertEquals(MenuItemId.ALBUM_BY_GENRE, menuItems.get(0).getId());
+        assertTrue(menuItems.get(0).isEnabled());
+        assertEquals(MenuItemId.SONG_BY_GENRE, menuItems.get(1).getId());
+        assertFalse(menuItems.get(1).isEnabled());
+
+        menuItems = menuItemDao.getChildlenOf(ViewType.UPNP, MenuItemId.PODCAST);
+        assertEquals(1, menuItems.size());
+        assertEquals(MenuItemId.PODCAST_DEFALT, menuItems.get(0).getId());
+        assertTrue(menuItems.get(0).isEnabled());
+
+        menuItems = menuItemDao.getChildlenOf(ViewType.UPNP, MenuItemId.PLAYLISTS);
+        assertEquals(1, menuItems.size());
+        assertEquals(MenuItemId.PLAYLISTS_DEFALT, menuItems.get(0).getId());
+        assertTrue(menuItems.get(0).isEnabled());
+
+        menuItems = menuItemDao.getChildlenOf(ViewType.UPNP, MenuItemId.RECENTLY);
+        assertEquals(2, menuItems.size());
+        assertEquals(MenuItemId.RECENTLY_ADDED_ALBUM, menuItems.get(0).getId());
+        assertTrue(menuItems.get(0).isEnabled());
+        assertEquals(MenuItemId.RECENTLY_TAGGED_ALBUM, menuItems.get(1).getId());
+        assertFalse(menuItems.get(1).isEnabled());
+
+        menuItems = menuItemDao.getChildlenOf(ViewType.UPNP, MenuItemId.SHUFFLE);
+        assertEquals(4, menuItems.size());
+        assertEquals(MenuItemId.RANDOM_ALBUM, menuItems.get(0).getId());
+        assertTrue(menuItems.get(0).isEnabled());
+        assertEquals(MenuItemId.RANDOM_SONG, menuItems.get(1).getId());
+        assertFalse(menuItems.get(1).isEnabled());
+        assertEquals(MenuItemId.RANDOM_SONG_BY_ARTIST, menuItems.get(2).getId());
+        assertFalse(menuItems.get(2).isEnabled());
+        assertEquals(MenuItemId.RANDOM_SONG_BY_FOLDER_ARTIST, menuItems.get(3).getId());
+        assertFalse(menuItems.get(3).isEnabled());
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MenuItemServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MenuItemServiceTest.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2023 tesshucom
+ */
+
+package com.tesshu.jpsonic.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Locale;
+
+import com.tesshu.jpsonic.NeedsHome;
+import com.tesshu.jpsonic.domain.MenuItem;
+import com.tesshu.jpsonic.domain.MenuItem.ViewType;
+import com.tesshu.jpsonic.domain.MenuItemId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@ExtendWith(NeedsHome.class)
+class MenuItemServiceTest {
+
+    @Autowired
+    private SettingsService settingsService;
+    @Autowired
+    private MenuItemService menuItemService;
+
+    @BeforeEach
+    public void setup() throws URISyntaxException {
+        Locale otherThanEnJp = settingsService.getAvailableLocales().get(5);
+        assertEquals("ca", otherThanEnJp.getLanguage());
+        settingsService.setLocale(otherThanEnJp);
+        settingsService.save();
+    }
+
+    @Test
+    void testGetTopMenuItems() {
+        List<MenuItem> menuItems = menuItemService.getTopMenuItems(ViewType.UPNP);
+        assertEquals(8, menuItems.size());
+        assertEquals("Folder", menuItems.get(0).getName());
+        assertEquals("Album Artist", menuItems.get(1).getName());
+        assertEquals("Album", menuItems.get(2).getName());
+        assertEquals("Genre", menuItems.get(3).getName());
+        assertEquals("Podcast", menuItems.get(4).getName());
+        assertEquals("Playlists", menuItems.get(5).getName());
+        assertEquals("Recently", menuItems.get(6).getName());
+        assertEquals("Shuffle", menuItems.get(7).getName());
+    }
+
+    @Test
+    void testGetChildlenOf() {
+        List<MenuItem> menuItems = menuItemService.getChildlenOf(ViewType.UPNP, MenuItemId.FOLDER);
+        assertEquals(2, menuItems.size());
+        assertEquals("Folder with Index", menuItems.get(0).getName());
+        assertEquals("File Structure", menuItems.get(1).getName());
+
+        menuItems = menuItemService.getChildlenOf(ViewType.UPNP, MenuItemId.ARTIST);
+        assertEquals(3, menuItems.size());
+        assertEquals("Album Artist with Index", menuItems.get(0).getName());
+        assertEquals("Album Artist All", menuItems.get(1).getName());
+        assertEquals("Album Artist All(by Folder)", menuItems.get(2).getName());
+
+        menuItems = menuItemService.getChildlenOf(ViewType.UPNP, MenuItemId.ALBUM);
+        assertEquals(1, menuItems.size());
+        assertEquals("Album All(ID3)", menuItems.get(0).getName());
+
+        menuItems = menuItemService.getChildlenOf(ViewType.UPNP, MenuItemId.GENRE);
+        assertEquals(2, menuItems.size());
+        assertEquals("Albums by Genre(File Structure)", menuItems.get(0).getName());
+        assertEquals("All Music by Genre", menuItems.get(1).getName());
+
+        menuItems = menuItemService.getChildlenOf(ViewType.UPNP, MenuItemId.PODCAST);
+        assertEquals(1, menuItems.size());
+        assertEquals("Podcast Channels All", menuItems.get(0).getName());
+
+        menuItems = menuItemService.getChildlenOf(ViewType.UPNP, MenuItemId.PLAYLISTS);
+        assertEquals(1, menuItems.size());
+        assertEquals("Playlists All", menuItems.get(0).getName());
+
+        menuItems = menuItemService.getChildlenOf(ViewType.UPNP, MenuItemId.RECENTLY);
+        assertEquals(2, menuItems.size());
+        assertEquals("Recently Added Albums", menuItems.get(0).getName());
+        assertEquals("Recently Tagged Albums", menuItems.get(1).getName());
+
+        menuItems = menuItemService.getChildlenOf(ViewType.UPNP, MenuItemId.SHUFFLE);
+        assertEquals(4, menuItems.size());
+        assertEquals("Random Album(ID3)", menuItems.get(0).getName());
+        assertEquals("Random Music", menuItems.get(1).getName());
+        assertEquals("Random Music by Artist(ID3)", menuItems.get(2).getName());
+        assertEquals("Random Music by Artist(by Folder/ID3)", menuItems.get(3).getName());
+    }
+}


### PR DESCRIPTION
Prerequisites: #2349

### Overview

A new table called menu_item will be added. This will be used to allow users to freely customize web pages and UPnP menus. However, implementation of this will involve gradual modifications. This is because some web pages may be used as they are, while others may be re-created.

Therefore, only database schema changes are performed at the time of major releases, and full-scale modifications are postponed until after that. This is a planned, gradual renovation. 😉

### Details

The new menu mechanism is expected to meet the following requirements:

 - Menu items can be enabled or disabled individually
 - Menu items can be sorted in any order you like
 - You can change the display name of menu items to whatever you like.
   - For example... To avoid ambiguity, "Artist" is redundantly written as "Album Artist" in Jpsonic. I'm sure some people want to rewrite it as Artist. In other words, you can rewrite it to Short name to make your mobile app view cleaner.
   - Avoiding i18n implementation. The default name supports English and Japanese. Users can rewrite it as needed if they want to use it in other native languages.
     - More menu items will be added in the future. In other words, the current state is not its final form. It is relatively difficult to provide each of these items with short names that correspond to the translations of each country. It is also doubtful whether such matters can be determined through discussion.
 - The display name of the rewritten menu item can be reset as desired. You can return to Default at any time. 
 - Web page menus and UPnP menus are not exactly the same and are managed independently.
   - UPnP will always be developed in advance, and there will be more wide variety of items to choose from.

### Contents of this commit

menu_item table records are added gradually with each release. Currently a schema, simple Dao and Service, and test code have been added. 

 - A default menu structure is registered in the table. Name is empty.
 - When retrieving a MenuItem via a Service, if the name is empty, the default name of the Property file will be used.
   - When Name-Change-Features is implemented and a user-defined name is registered, this Process will be skipped.
   - If the name is re-registered empty, the default name will be used again 
 
Cumulative updates will be made in the future.