### PR TITLE
Bump lucene and Search Index version

### DIFF
--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <chameleon.version>1.2.1-RELEASE</chameleon.version>
         <tomcat.server.scope>provided</tomcat.server.scope>
-        <lucene.version>9.8.0</lucene.version>
+        <lucene.version>9.9.0</lucene.version>
     </properties>
 
     <dependencies>

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
@@ -94,7 +94,7 @@ public class IndexManager {
      * of AnalyzerFactory, DocumentFactory or the class that they use.
      *
      */
-    private static final int INDEX_VERSION = 26;
+    private static final int INDEX_VERSION = 27;
 
     /**
      * Literal name of index top directory.


### PR DESCRIPTION
### Overview

Lucene will be updated to the latest version. Historically, Lucene has had many updates without backward compatibility. Jpsonic frequently updates Lucene to avoid this risk. 

Beyond API and feature compatibility, special attention is paid to the codec versions used. That had been also done by Subsonic and Airsonic. This pull request contains the corresponding fixes.

### Details

Special processing is required when the Lucene search index codec generation changes. (This type of update doesn't happen very often.) Traditionally, many Sonic servers employing Lucene perform index rebuilds. 

 - Jpsonic requires a full scan. The directory "index-**" that exists in the data directory will be deleted and new data will be created. Generation change of the data directory will occur automatically at startup. 
 - It is possible to ensure backward compatibility without such a mechanism. However, in that case, it is necessary to continue installing additional legacy codecs. To avoid this, the current generation-update design has been maintained.　　

### Impact on users

A full scan will be required after startup. The search index data will be initialized, so search-deatures will not be available until a full scan done.


