### PR TITLE
Update Logback

### DIFF
--- a/install/docker/alpine/pom.xml
+++ b/install/docker/alpine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.12</version>
+    <version>112.2.13</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/alpine/pom.xml
+++ b/install/docker/alpine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.10</version>
+    <version>112.2.11</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/alpine/pom.xml
+++ b/install/docker/alpine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.11</version>
+    <version>112.2.12</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/jammy/pom.xml
+++ b/install/docker/jammy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.12</version>
+    <version>112.2.13</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/jammy/pom.xml
+++ b/install/docker/jammy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.10</version>
+    <version>112.2.11</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/jammy/pom.xml
+++ b/install/docker/jammy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.11</version>
+    <version>112.2.12</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.10</version>
+    <version>112.2.11</version>
     </parent>
 
     <properties>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.11</version>
+    <version>112.2.12</version>
     </parent>
 
     <properties>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.12</version>
+    <version>112.2.13</version>
     </parent>
 
     <properties>

--- a/jpsonic-upnp-template/pom.xml
+++ b/jpsonic-upnp-template/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.10</version>
+    <version>112.2.11</version>
     </parent>
 
     <dependencies>

--- a/jpsonic-upnp-template/pom.xml
+++ b/jpsonic-upnp-template/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.12</version>
+    <version>112.2.13</version>
     </parent>
 
     <dependencies>

--- a/jpsonic-upnp-template/pom.xml
+++ b/jpsonic-upnp-template/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.11</version>
+    <version>112.2.12</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>112.2.11</version>
+    <version>112.2.12</version>
     <name>Jpsonic</name>
     <packaging>pom</packaging>
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>112.2.12</version>
+    <version>112.2.13</version>
     <name>Jpsonic</name>
     <packaging>pom</packaging>
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>112.2.10</version>
+    <version>112.2.11</version>
     <name>Jpsonic</name>
     <packaging>pom</packaging>
     <organization>

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.10</version>
+    <version>112.2.11</version>
     </parent>
 
     <dependencies>

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.11</version>
+    <version>112.2.12</version>
     </parent>
 
     <dependencies>

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.12</version>
+    <version>112.2.13</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
This patch includes Bump of logback related to CVE-2023-6378.

Jpsonic does not use any code related to this vulnerability. However, this warning will prevent the automatic build, so the library will be updated to the latest version.
