### PR TITLE
Fix to avoid handling files or directories ending with a dot

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
@@ -66,6 +66,10 @@ public class SecurityService implements UserDetailsService {
 
     private static final Logger LOG = LoggerFactory.getLogger(SecurityService.class);
 
+    // https://kb.synology.com/en-in/DSM/help/FileStation/connect?version=7
+    private static final List<String> SYNOLOGY_RESERVED_WORDS = List.of("._", ".SYNOPPSDB", ".DS_Store", "@eaDir",
+            "@sharebin", "@tmp", ".SynologyWorkingDirectory");
+
     private final UserDao userDao;
     private final SettingsService settingsService;
     private final MusicFolderService musicFolderService;
@@ -525,28 +529,45 @@ public class SecurityService implements UserDetailsService {
         return true;
     }
 
+    private void info(String msg) {
+        if (LOG.isInfoEnabled()) {
+            LOG.info(msg);
+        }
+    }
+
+    @SuppressWarnings({ "PMD.GuardLogStatement", "PMD.NPathComplexity" })
+    // NPathComplexity : Redundantly coded for readability, but not difficult to understand
     public boolean isExcluded(Path path) {
         if (settingsService.isIgnoreSymLinks() && Files.isSymbolicLink(path)) {
-            if (LOG.isInfoEnabled()) {
-                LOG.info("excluding symbolic link " + path);
-            }
+            info("Excluding symbolic link %s".formatted(path));
             return true;
         }
+
         Path fileName = path.getFileName();
         if (fileName == null) {
             return true;
         }
+
+        // Exclude those that match a user-specified pattern
         String name = fileName.toString();
-        if (settingsService.getExcludePattern() != null && settingsService.getExcludePattern().matcher(name).find()) {
-            if (LOG.isInfoEnabled()) {
-                LOG.info("excluding file which matches exclude pattern " + settingsService.getExcludePatternString()
-                        + ": " + path);
-            }
+        if (settingsService.getExcludePattern() != null
+                && settingsService.getExcludePattern().matcher(name).matches()) {
+            info("Excluding file which matches exclude pattern %s : %s"
+                    .formatted(settingsService.getExcludePatternString(), path));
             return true;
         }
 
-        // Exclude all hidden files starting with a single "." or "@eaDir" (thumbnail dir created on Synology devices).
-        return !name.isEmpty() && name.charAt(0) == '.' && !name.startsWith("..") || name.startsWith("@eaDir")
-                || name.startsWith("@tmp") || "Thumbs.db".equals(name);
+        // Exclude all hidden files starting with a single "."
+        if (name.charAt(0) == '.' && !name.startsWith("..")) {
+            return true;
+        }
+
+        // Exclude Thumbnail on Windows
+        if ("Thumbs.db".equals(name)) {
+            return true;
+        }
+
+        // Exclude files or dir created on Synology devices
+        return SYNOLOGY_RESERVED_WORDS.stream().anyMatch(name::equals);
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
@@ -535,6 +535,12 @@ public class SecurityService implements UserDetailsService {
         }
     }
 
+    private void warn(String msg) {
+        if (LOG.isWarnEnabled()) {
+            LOG.warn(msg);
+        }
+    }
+
     @SuppressWarnings({ "PMD.GuardLogStatement", "PMD.NPathComplexity" })
     // NPathComplexity : Redundantly coded for readability, but not difficult to understand
     public boolean isExcluded(Path path) {
@@ -559,6 +565,16 @@ public class SecurityService implements UserDetailsService {
 
         // Exclude all hidden files starting with a single "."
         if (name.charAt(0) == '.' && !name.startsWith("..")) {
+            return true;
+        }
+
+        // Exclude files end with a dot (Windows prohibitions)
+        if (name.endsWith(".")) {
+            warn("""
+                    Excluding files ending with Dot. \
+                    Recommended to replace with a UNICODE String \
+                    like One dot leader or Horizontal Ellipsis. : %s\
+                    """.formatted(path));
             return true;
         }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/WritableMediaFileService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/WritableMediaFileService.java
@@ -159,7 +159,7 @@ public class WritableMediaFileService {
                 .collect(Collectors.toMap(mf -> mf.getPathString(), mf -> mf));
 
         LongAdder updateCount = new LongAdder();
-        CoverArtDetector coverArtDetector = new CoverArtDetector(mediaFileService);
+        CoverArtDetector coverArtDetector = new CoverArtDetector(securityService, mediaFileService);
         try (DirectoryStream<Path> ds = Files.newDirectoryStream(parent.toPath())) {
             for (Path childPath : ds) {
 
@@ -544,18 +544,21 @@ public class WritableMediaFileService {
 
     private static class CoverArtDetector {
 
+        private final SecurityService securityService;
         private final MediaFileService mediaFileService;
         private Path coverArtAvailable;
         private Path firstCoverArtEmbeddable;
 
-        public CoverArtDetector(MediaFileService mediaFileService) {
+        public CoverArtDetector(SecurityService securityService, MediaFileService mediaFileService) {
+            this.securityService = securityService;
             this.mediaFileService = mediaFileService;
         }
 
         void setChildFilePath(Path childPath) {
             try {
-                if (coverArtAvailable == null && mediaFileService.isAvailableCoverArtPath(childPath,
-                        Files.readAttributes(childPath, BasicFileAttributes.class))) {
+                if (coverArtAvailable == null && !securityService.isExcluded(childPath)
+                        && mediaFileService.isAvailableCoverArtPath(childPath,
+                                Files.readAttributes(childPath, BasicFileAttributes.class))) {
                     coverArtAvailable = childPath;
                 }
             } catch (IOException e) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/StringUtil.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/StringUtil.java
@@ -395,7 +395,7 @@ public final class StringUtil {
     public static String fileSystemSafe(final String filename) {
         String result = filename;
         for (String s : FILE_SYSTEM_UNSAFE) {
-            result = result.replace(s, "-");
+            result = result.replaceAll("\\.$", "").replace(s, "-");
         }
         return result;
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/SecurityServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/SecurityServiceTest.java
@@ -349,6 +349,11 @@ class SecurityServiceTest {
             assertTrue(service.isExcluded(Path.of("Thumbs.db")));
 
             assertTrue(service.isExcluded(Path.of(".foo.mp3")));
+            assertTrue(service.isExcluded(Path.of("foo.mp3.")));
+            assertFalse(service.isExcluded(Path.of("foo.mp3․"))); // The end is not dot (one dot leader)
+            assertTrue(service.isExcluded(Path.of("If...")));
+            assertFalse(service.isExcluded(Path.of("If․․․"))); // The end is not dot (one dot leader)
+            assertFalse(service.isExcluded(Path.of("If…"))); // The end is not dot (Horizontal Ellipsis)
             assertTrue(service.isExcluded(Path.of("._foo.mp3")));
             assertTrue(service.isExcluded(Path.of(".SYNOPPSDB")));
             assertTrue(service.isExcluded(Path.of(".DS_Store")));

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/SecurityServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/SecurityServiceTest.java
@@ -22,15 +22,20 @@
 package com.tesshu.jpsonic.service;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.concurrent.ExecutionException;
+import java.util.regex.Pattern;
 
 import com.tesshu.jpsonic.controller.WebFontUtils;
 import com.tesshu.jpsonic.dao.UserDao;
@@ -46,6 +51,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 /**
@@ -298,6 +304,51 @@ class SecurityServiceTest {
             assertFalse(service.isFileInFolder("C:\\music\\foo.mp3", "C:\\music2"));
             assertFalse(service.isFileInFolder("C:\\music2\\foo.mp3", "C:\\music"));
             assertTrue(service.isFileInFolder("C:\\music2\\foo.mp3", "C:\\music2"));
+        }
+    }
+
+    @Nested
+    class IsExcludedTest {
+
+        @Test
+        void testSymbolicLink(@TempDir Path tmpDir) throws IOException {
+            Path concrete = Files.createFile(Paths.get(tmpDir.toString(), "testSymbolic.txt"));
+            Path link = Files.createSymbolicLink(Paths.get(tmpDir.toString(), "testSymbolicLink.txt"), concrete);
+
+            assertFalse(settingsService.isIgnoreSymLinks());
+            assertFalse(service.isExcluded(concrete));
+            assertFalse(service.isExcluded(link));
+
+            Mockito.when(settingsService.isIgnoreSymLinks()).thenReturn(true);
+            assertFalse(service.isExcluded(concrete));
+            assertTrue(service.isExcluded(link));
+        }
+
+        @Test
+        void testNullName() {
+            assertTrue(service.isExcluded(Path.of("/", "")));
+        }
+
+        @Test
+        void testExcludePattern() throws IOException {
+            assertNull(settingsService.getExcludePattern());
+            Path song = Path.of("foo.mp3");
+            assertFalse(service.isExcluded(song));
+
+            Mockito.when(settingsService.getExcludePattern()).thenReturn(Pattern.compile("foo.flac"));
+            assertFalse(service.isExcluded(song));
+            Mockito.when(settingsService.getExcludePattern()).thenReturn(Pattern.compile("foo.mp3"));
+            assertTrue(service.isExcluded(song));
+        }
+
+        @Test
+        void testFixedExcludePattern() throws IOException {
+            assertFalse(service.isExcluded(Path.of("foo.mp3")));
+            assertTrue(service.isExcluded(Path.of(".foo.mp3")));
+            assertFalse(service.isExcluded(Path.of("..foo.mp3")));
+            assertTrue(service.isExcluded(Path.of("@eaDir")));
+            assertTrue(service.isExcluded(Path.of("@tmp")));
+            assertTrue(service.isExcluded(Path.of("Thumbs.db")));
         }
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/SecurityServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/SecurityServiceTest.java
@@ -344,11 +344,18 @@ class SecurityServiceTest {
         @Test
         void testFixedExcludePattern() throws IOException {
             assertFalse(service.isExcluded(Path.of("foo.mp3")));
-            assertTrue(service.isExcluded(Path.of(".foo.mp3")));
             assertFalse(service.isExcluded(Path.of("..foo.mp3")));
-            assertTrue(service.isExcluded(Path.of("@eaDir")));
-            assertTrue(service.isExcluded(Path.of("@tmp")));
+
             assertTrue(service.isExcluded(Path.of("Thumbs.db")));
+
+            assertTrue(service.isExcluded(Path.of(".foo.mp3")));
+            assertTrue(service.isExcluded(Path.of("._foo.mp3")));
+            assertTrue(service.isExcluded(Path.of(".SYNOPPSDB")));
+            assertTrue(service.isExcluded(Path.of(".DS_Store")));
+            assertTrue(service.isExcluded(Path.of("@eaDir")));
+            assertTrue(service.isExcluded(Path.of("@sharebin")));
+            assertTrue(service.isExcluded(Path.of("@tmp")));
+            assertTrue(service.isExcluded(Path.of(".SynologyWorkingDirectory")));
         }
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/PodcastServiceImplTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/PodcastServiceImplTest.java
@@ -57,8 +57,8 @@ class PodcastServiceImplTest {
         settingsService = mock(SettingsService.class);
         securityService = mock(SecurityService.class);
         MediaFileService mediaFlieService = new MediaFileService(settingsService, null, null, null, null, null);
-        podcastService = new PodcastServiceImpl(null, settingsService, securityService, mediaFlieService, null, null,
-                null, null, null, null);
+        podcastService = new PodcastServiceImpl(null, settingsService, securityService, mediaFlieService,
+                mock(WritableMediaFileService.class), null, null, null, null, null);
     }
 
     private ZonedDateTime toJST(String date) {
@@ -189,16 +189,16 @@ class PodcastServiceImplTest {
 
             PodcastEpisode episode = new PodcastEpisode(epId, null, episodeUrl, null, episodeTitle, null, publishDate,
                     null, null, null, null, null);
-            String fileName = "chTitleIf-." + " - " + pubDateStr + " - " + epId + " - " + "epTitleIf-." + ".mp3";
-            assertEquals(podcastFolder.toString() + File.separator + "chTitleIf-." + File.separator + fileName,
+            String fileName = "chTitleIf-." + " - " + pubDateStr + " - " + epId + " - " + "epTitleIf" + ".mp3";
+            assertEquals(podcastFolder.toString() + File.separator + "chTitleIf" + File.separator + fileName,
                     podcastService.getFile(channel, episode).toString());
 
             episodeUrl = "http://tesshu.com/chTitleIf.../epTitleIf....m4a";
 
             episode = new PodcastEpisode(epId, null, episodeUrl, null, episodeTitle, null, publishDate, null, null,
                     null, null, null);
-            fileName = "chTitleIf-." + " - " + pubDateStr + " - " + epId + " - " + "epTitleIf-." + ".m4a";
-            assertEquals(podcastFolder.toString() + File.separator + "chTitleIf-." + File.separator + fileName,
+            fileName = "chTitleIf-." + " - " + pubDateStr + " - " + epId + " - " + "epTitleIf" + ".m4a";
+            assertEquals(podcastFolder.toString() + File.separator + "chTitleIf" + File.separator + fileName,
                     podcastService.getFile(channel, episode).toString());
 
             episodeUrl = "http://tesshu.com/Star+Wars/Star+Wars+Ep.1.mp3";
@@ -207,7 +207,7 @@ class PodcastServiceImplTest {
             episode = new PodcastEpisode(epId, null, episodeUrl, null, episodeTitle, null, publishDate, null, null,
                     null, null, null);
             fileName = "chTitleIf-." + " - " + pubDateStr + " - " + epId + " - Star Wars Ep.1.mp3";
-            assertEquals(podcastFolder.toString() + File.separator + "chTitleIf-." + File.separator + fileName,
+            assertEquals(podcastFolder.toString() + File.separator + "chTitleIf" + File.separator + fileName,
                     podcastService.getFile(channel, episode).toString());
         }
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/PodcastServiceImplTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/PodcastServiceImplTest.java
@@ -168,6 +168,49 @@ class PodcastServiceImplTest {
                     podcastService.getFile(channel, episode).toString());
         }
 
+        // https://github.com/tesshucom/jpsonic/pull/2492
+        // If the title ends with Dot, it will be replaced with a hyphen when creating the filename.
+        @Test
+        void testDotAtTheEnd() throws URISyntaxException {
+
+            Path podcastFolder = Path.of(PodcastServiceImplTest.class.getResource("/MEDIAS/Podcast").toURI());
+            Mockito.when(settingsService.getPodcastFolder()).thenReturn(podcastFolder.toString());
+            Mockito.when(securityService.isWriteAllowed(Mockito.any(Path.class))).thenReturn(true);
+
+            final String channelTitle = "chTitleIf...";
+            final PodcastChannel channel = new PodcastChannel(null, null, channelTitle, null, null, null, null);
+            final int epId = 99;
+            final Instant publishDate = Instant.now();
+            final String pubDateStr = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault())
+                    .format(publishDate);
+
+            String episodeTitle = "epTitleIf...";
+            String episodeUrl = "http://tesshu.com/chTitle/epTitle.mp3";
+
+            PodcastEpisode episode = new PodcastEpisode(epId, null, episodeUrl, null, episodeTitle, null, publishDate,
+                    null, null, null, null, null);
+            String fileName = "chTitleIf-." + " - " + pubDateStr + " - " + epId + " - " + "epTitleIf-." + ".mp3";
+            assertEquals(podcastFolder.toString() + File.separator + "chTitleIf-." + File.separator + fileName,
+                    podcastService.getFile(channel, episode).toString());
+
+            episodeUrl = "http://tesshu.com/chTitleIf.../epTitleIf....m4a";
+
+            episode = new PodcastEpisode(epId, null, episodeUrl, null, episodeTitle, null, publishDate, null, null,
+                    null, null, null);
+            fileName = "chTitleIf-." + " - " + pubDateStr + " - " + epId + " - " + "epTitleIf-." + ".m4a";
+            assertEquals(podcastFolder.toString() + File.separator + "chTitleIf-." + File.separator + fileName,
+                    podcastService.getFile(channel, episode).toString());
+
+            episodeUrl = "http://tesshu.com/Star+Wars/Star+Wars+Ep.1.mp3";
+            episodeTitle = "Star Wars Ep.1";
+
+            episode = new PodcastEpisode(epId, null, episodeUrl, null, episodeTitle, null, publishDate, null, null,
+                    null, null, null);
+            fileName = "chTitleIf-." + " - " + pubDateStr + " - " + epId + " - Star Wars Ep.1.mp3";
+            assertEquals(podcastFolder.toString() + File.separator + "chTitleIf-." + File.separator + fileName,
+                    podcastService.getFile(channel, episode).toString());
+        }
+
         @Test
         void testEpisodeUrlWithQuery() throws URISyntaxException {
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/StringUtilTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/StringUtilTest.java
@@ -212,6 +212,7 @@ class StringUtilTest {
     void testFileSystemSafe() {
         assertEquals("foo", StringUtil.fileSystemSafe("foo"), "Error in fileSystemSafe().");
         assertEquals("foo.mp3", StringUtil.fileSystemSafe("foo.mp3"), "Error in fileSystemSafe().");
+        assertEquals("foo.mp3", StringUtil.fileSystemSafe("foo.mp3..."), "Error in fileSystemSafe().");
         assertEquals("foo-bar", StringUtil.fileSystemSafe("foo/bar"), "Error in fileSystemSafe().");
         assertEquals("foo-bar", StringUtil.fileSystemSafe("foo\\bar"), "Error in fileSystemSafe().");
         assertEquals("foo-bar", StringUtil.fileSystemSafe("foo:bar"), "Error in fileSystemSafe().");


### PR DESCRIPTION
## Overview

Add processing for cases where the file name or directory name ends with a dot.

 - Files or directories ending with a dot will be modified to not be scanned
 - When outputting a file locally using a title such as m3u or Podcast, the Dot at the end will be modified to be deleted.
 - Extra : Some reserved words used in the latest Synology DSM will be added

## Problem description

Jpsonic will immediately stop processing if an unexpected case is detected in the scan.

 - #2474

Currently, the scan will stop if you try to scan a file or directory that ends with a dot.

## Background

Files or directories ending with a dot are prohibited, especially on Windows Explorer. (It cannot be created from Explorer. Also, directories that end with Dot cannot be expanded. Both will result in an error.) However, they can be created from cmd or Program.

General Windows apps often take care not to create such files and directories. For example, when creating a directory from the Album name, change the dot to another string such as an underscore. One of historical classical trivialities that often require workarounds on Windows, such as "filenames with spaces". When transferring files created with ripping software without such specifications or Linux-specific software to Windows, cross-platform functionality may be hindered.

Conversely, it is a case that is not often encountered, so it may be said that it was not taken care of on the Sonic server.

## Policy on this issue

Subsonic/Airsonic originally has a definition of "file that cannot be read". This will be extended to exclude files or directories that end with Dot.

 https://github.com/airsonic/airsonic/blob/5ccca059d5cfe3dd19734c27861b434ea21b43d8/airsonic-main/src/main/java/org/airsonic/player/service/MediaFileService.java#L458-L471

 Also, the existing Synology reserved words will be updated. 

 > https://kb.synology.com/en-in/DSM/help/FileStation/connect?version=7

 >  - The system cannot display files/folders that adopt the following naming formats:
 >    - Beginning with ._ or .SYNOPPSDB
 >    - Including /
 >    - Named exactly as .    ..    '    "    .DS_Store    `@eaDir`    `@sharebin`    `@tmp`    .SynologyWorkingDirectory

### Specifications regarding warnings when excluded scanning

It is not always helpful to output information about all excluded files to the log. (If anything, verbose logs are often detrimental to the System!) Therefore, Jpsonic's policy is to suppress log output as much as possible for obvious problems. Jpsonic's default Log Level is WARN. Therefore, information about most excluded files will not be output to the log, as shown in the table below. (The log level can be changed using the startup argument.)

Prohibition rules | Log Level
-- | --
Thumbs.db (Tiny image created by Windows) | No warning
SYNOLOGY reserved word | No warning
SymbolicLink | INFO
ExcludePattern specified by the user on the settings page | INFO
Starts with double Dot | INFO
**Ends with Dot** | **WARN**

**Note that the spec added in this commit will be warned with WARN level.** The reason is as follows.

 - Basically, it is assumed that this is a rare case.
 - If situation to this case occur, there is a high possibility that the user was not aware of the problem.
   - The ripping software will properly create file and directory names from the title. Most of the time we take it for granted.
   - In case that wasn't the case. If Jpsonic uses it silently, the problem could be masked.
   - This kind of thinking would be called ``Fail Fast``

### Best Practice if you run into this problem

It's not necessarily a good idea for a program that loads a file to automatically rewrite its Path to read or display it. That's because it's a stopgap measure and not a fundamental solution. It must be fail-fast to work securely with many platforms and with many other software.

- Please note that there are platform-dependent restrictions on the strings that can be used within the file system.
- In such cases, workaround is to rename the target directory/files to UNICODE. This is not an unusual task in non-Latin-speaking countries. Unless you are using a very antique OS, it will probably work. 
  - `… (Horizontal Ellipsis)` `․ (one dot leader)`
  - Apostrophe...hmm. Maybe you should ask a French engineer.
    - [Which Unicode character should represent](https://tedclancy.wordpress.com/2015/06/03/which-unicode-character-should-represent-the-english-apostrophe-and-why-the-unicode-committee-is-very-wrong/)

How it looks depends on the font. Some fonts may even be visually indistinguishable.

![image](https://github.com/tesshucom/jpsonic/assets/27724847/138e43a0-3351-44ec-98f4-f94343dd695c)

### Todo

 - [x] 1. Fix file/dir exclusion rules when scanning
 - [x] 2. Check file/dir generation rules in Podcast/m3u
   - It had been be considered. StringUtil.fileSystemSafe is used to force change to hyphen. 
   - But it's a shame. A greedy transformation should be done here. The trailing dot will be fixed to be removed.
 - [x] 3. Check the Spec of Download/Zip Download 
   - There is no problem with zip files because the extension ".zip" is added.
   - There is no problem with processing within zip Stream (directory structure inside zip) as long as (1) is guaranteed.
 - [x] 4. Confirmation is required regarding the judgment of cover art.
   - Sonic servers support embedded cover art and local cover art. File validation for embedded cover art(=Mediafile) will be covered by (1). Other files will require Dot detection before determining whether they are image files. (Otherwise we will get a NIO Error)

