### PR TITLE
Update Libs

### DIFF
--- a/install/docker/alpine/pom.xml
+++ b/install/docker/alpine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.13</version>
+    <version>112.2.14</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/alpine/pom.xml
+++ b/install/docker/alpine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.12</version>
+    <version>112.2.13</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/alpine/pom.xml
+++ b/install/docker/alpine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.11</version>
+    <version>112.2.12</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/jammy/pom.xml
+++ b/install/docker/jammy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.13</version>
+    <version>112.2.14</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/jammy/pom.xml
+++ b/install/docker/jammy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.12</version>
+    <version>112.2.13</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/jammy/pom.xml
+++ b/install/docker/jammy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.11</version>
+    <version>112.2.12</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.11</version>
+    <version>112.2.12</version>
     </parent>
 
     <properties>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.13</version>
+    <version>112.2.14</version>
     </parent>
 
     <properties>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.12</version>
+    <version>112.2.13</version>
     </parent>
 
     <properties>

--- a/jpsonic-upnp-template/pom.xml
+++ b/jpsonic-upnp-template/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.13</version>
+    <version>112.2.14</version>
     </parent>
 
     <dependencies>

--- a/jpsonic-upnp-template/pom.xml
+++ b/jpsonic-upnp-template/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.12</version>
+    <version>112.2.13</version>
     </parent>
 
     <dependencies>

--- a/jpsonic-upnp-template/pom.xml
+++ b/jpsonic-upnp-template/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.11</version>
+    <version>112.2.12</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>112.2.11</version>
+    <version>112.2.12</version>
     <name>Jpsonic</name>
     <packaging>pom</packaging>
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>112.2.13</version>
+    <version>112.2.14</version>
     <name>Jpsonic</name>
     <packaging>pom</packaging>
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>112.2.12</version>
+    <version>112.2.13</version>
     <name>Jpsonic</name>
     <packaging>pom</packaging>
     <organization>

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.11</version>
+    <version>112.2.12</version>
     </parent>
 
     <dependencies>

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.13</version>
+    <version>112.2.14</version>
     </parent>
 
     <dependencies>

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.tesshu.jpsonic.player</groupId>
         <artifactId>jpsonic</artifactId>
-    <version>112.2.12</version>
+    <version>112.2.13</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
This will be the last v112.x.x as we are currently working on a release.

Includes major version Up of dependency-check-maven. This version update is required, and previous versions will no longer be available after December 15th.

[DependencyCheck 9.0.0 Upgrade Notice](https://github.com/jeremylong/DependencyCheck?tab=readme-ov-file#900-upgrade-notice)

After check-out Jpsonic with git, you can check CVE with maven.

``mvn dependency-check:check``

From this version onwards you will need an APIKey.

``mvn -DnvdApiKey=$NVD_API_KEY -DnvdApiDelay=3000 -DnvdMaxRetryCount=10 dependency-check:check``

It is possible to run without specifying ApiKey, but it will be very slow (takes about 10 minutes)