### PR TITLE
Fix search-schema version update feature

### DIFF
--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
@@ -21,10 +21,11 @@
 
 package com.tesshu.jpsonic.service.search;
 
+import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
 import static com.tesshu.jpsonic.util.PlayerUtils.now;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -34,6 +35,8 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import com.tesshu.jpsonic.AbstractNeedsScan;
+import com.tesshu.jpsonic.dao.AlbumDao;
+import com.tesshu.jpsonic.dao.ArtistDao;
 import com.tesshu.jpsonic.dao.MediaFileDao;
 import com.tesshu.jpsonic.dao.RatingDao;
 import com.tesshu.jpsonic.dao.base.TemplateWrapper;
@@ -44,219 +47,267 @@ import com.tesshu.jpsonic.service.MediaScannerService;
 import com.tesshu.jpsonic.service.SearchService;
 import com.tesshu.jpsonic.service.SettingsService;
 import com.tesshu.jpsonic.util.FileUtil;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.ObjectUtils;
 
-@SuppressWarnings("PMD.AvoidDuplicateLiterals") // In the testing class, it may be less readable.
+@SuppressWarnings({ "PMD.TooManyStaticImports", "PMD.AvoidDuplicateLiterals" })
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class IndexManagerTest extends AbstractNeedsScan {
+class IndexManagerTest {
 
-    private List<MusicFolder> musicFolders;
+    @Nested
+    class UnitTest {
 
-    @Autowired
-    private SearchService searchService;
+        private SettingsService settingsService;
+        private ArtistDao artistDao;
+        private AlbumDao albumDao;
+        private IndexManager indexManager;
 
-    @Autowired
-    private IndexManager indexManager;
-
-    @Autowired
-    private SearchCriteriaDirector director;
-
-    @Autowired
-    private MediaScannerService mediaScannerService;
-
-    @Autowired
-    private TemplateWrapper template;
-
-    @Autowired
-    private MediaFileDao mediaFileDao;
-
-    @Autowired
-    private RatingDao ratingDao;
-
-    private static final String USER_NAME = "admin";
-
-    @Override
-    public List<MusicFolder> getMusicFolders() {
-        if (ObjectUtils.isEmpty(musicFolders)) {
-            musicFolders = Arrays
-                    .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1, false));
+        @BeforeEach
+        public void setup() {
+            settingsService = Mockito.mock(SettingsService.class);
+            artistDao = mock(ArtistDao.class);
+            albumDao = mock(AlbumDao.class);
+            indexManager = new IndexManager(null, null, null, null, null, settingsService, null, artistDao, albumDao);
         }
-        return musicFolders;
+
+        @AfterEach
+        public void trarDown() {
+            System.clearProperty("jpsonic.home");
+        }
+
+        @Test
+        void testIndexDirectoryAlreadyExists(@TempDir Path tempDir) throws IOException {
+            System.setProperty("jpsonic.home", tempDir.toString());
+            Files.createDirectories(indexManager.getRootIndexDirectory());
+            indexManager.initializeIndexDirectory();
+            Mockito.verify(artistDao, Mockito.never()).deleteAll();
+            Mockito.verify(albumDao, Mockito.never()).deleteAll();
+        }
+
+        @Test
+        void testIndexDirectoryNotExists(@TempDir Path tempDir) {
+            System.setProperty("jpsonic.home", tempDir.toString());
+            indexManager.initializeIndexDirectory();
+            Mockito.verify(artistDao, Mockito.times(1)).deleteAll();
+            Mockito.verify(albumDao, Mockito.times(1)).deleteAll();
+        }
     }
 
-    @BeforeEach
-    public void setup() {
-        populateDatabaseOnlyOnce(() -> {
-            return true;
-        }, () -> {
+    @Nested
+    class IntegrationTest extends AbstractNeedsScan {
 
-            // #1842 Airsonic does not implement Rating expunge
+        private List<MusicFolder> musicFolders;
 
-            List<MediaFile> albums = mediaFileDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, true, musicFolders);
-            assertEquals(4, albums.size());
+        @Autowired
+        private SearchService searchService;
 
-            albums.forEach(m -> ratingDao.setRatingForUser(USER_NAME, m, 1));
-            assertEquals(4, ratingDao.getRatedAlbumCount(USER_NAME, musicFolders));
+        @Autowired
+        private IndexManager indexManager;
+
+        @Autowired
+        private SearchCriteriaDirector director;
+
+        @Autowired
+        private MediaScannerService mediaScannerService;
+
+        @Autowired
+        private TemplateWrapper template;
+
+        @Autowired
+        private MediaFileDao mediaFileDao;
+
+        @Autowired
+        private RatingDao ratingDao;
+
+        private static final String USER_NAME = "admin";
+
+        @Override
+        public List<MusicFolder> getMusicFolders() {
+            if (ObjectUtils.isEmpty(musicFolders)) {
+                musicFolders = Arrays
+                        .asList(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1, false));
+            }
+            return musicFolders;
+        }
+
+        @BeforeEach
+        public void setup() {
+            populateDatabaseOnlyOnce(() -> {
+                return true;
+            }, () -> {
+
+                // #1842 Airsonic does not implement Rating expunge
+
+                List<MediaFile> albums = mediaFileDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, true, musicFolders);
+                assertEquals(4, albums.size());
+
+                albums.forEach(m -> ratingDao.setRatingForUser(USER_NAME, m, 1));
+                assertEquals(4, ratingDao.getRatedAlbumCount(USER_NAME, musicFolders));
+                int ratingsCount = template.getJdbcTemplate().queryForObject(
+                        "select count(*) from user_rating where user_rating.username = ?", Integer.class, USER_NAME);
+                assertEquals(4, ratingsCount, "Because explicitly registered 4 Ratings.");
+
+                // Register a dummy rate (reproduce old path data by moving files)
+                MediaFile dummyMediaFile = new MediaFile();
+                dummyMediaFile.setPathString("oldPath");
+                ratingDao.setRatingForUser(USER_NAME, dummyMediaFile, 1);
+
+                assertEquals(4, ratingDao.getRatedAlbumCount(USER_NAME, musicFolders),
+                        "Because the SELECT condition only references real paths.");
+                ratingsCount = template.getJdbcTemplate().queryForObject(
+                        "select count(*) from user_rating where user_rating.username = ?", Integer.class, USER_NAME);
+                assertEquals(5, ratingsCount, "Because counted directly, including non-existent paths.");
+
+                return true;
+            });
+
+        }
+
+        @Test
+        @Order(1)
+        void testExpunge() throws IOException {
+
+            int offset = 0;
+            int count = Integer.MAX_VALUE;
+
+            final SearchCriteria criteriaArtist = director.construct("_DIR_ Ravel", offset, count, false, musicFolders,
+                    IndexType.ARTIST);
+            final SearchCriteria criteriaAlbum = director.construct("Complete Piano Works", offset, count, false,
+                    musicFolders, IndexType.ALBUM);
+            final SearchCriteria criteriaSong = director.construct("Gaspard", offset, count, false, musicFolders,
+                    IndexType.SONG);
+            final SearchCriteria criteriaArtistId3 = director.construct("_DIR_ Ravel", offset, count, false,
+                    musicFolders, IndexType.ARTIST_ID3);
+            final SearchCriteria criteriaAlbumId3 = director.construct("Complete Piano Works", offset, count, false,
+                    musicFolders, IndexType.ALBUM_ID3);
+
+            /* Delete DB record. */
+
+            // artist
+            SearchResult result = searchService.search(criteriaArtist);
+            assertEquals(1, result.getMediaFiles().size());
+            assertEquals("_DIR_ Ravel", result.getMediaFiles().get(0).getName());
+
+            List<Integer> candidates = mediaFileDao.getArtistExpungeCandidates();
+            assertEquals(0, candidates.size());
+
+            result.getMediaFiles().forEach(a -> mediaFileDao.deleteMediaFile(a.getId()));
+
+            candidates = mediaFileDao.getArtistExpungeCandidates();
+            assertEquals(1, candidates.size());
+
+            // album
+            result = searchService.search(criteriaAlbum);
+            assertEquals(1, result.getMediaFiles().size());
+            assertEquals("_DIR_ Ravel - Complete Piano Works", result.getMediaFiles().get(0).getName());
+
+            candidates = mediaFileDao.getAlbumExpungeCandidates();
+            assertEquals(0, candidates.size());
+
+            result.getMediaFiles().forEach(a -> mediaFileDao.deleteMediaFile(a.getId()));
+
+            candidates = mediaFileDao.getAlbumExpungeCandidates();
+            assertEquals(1, candidates.size());
+
+            // song
+            result = searchService.search(criteriaSong);
+            assertEquals(2, result.getMediaFiles().size());
+            if ("01 - Gaspard de la Nuit - i. Ondine".equals(result.getMediaFiles().get(0).getName())) {
+                assertEquals("02 - Gaspard de la Nuit - ii. Le Gibet", result.getMediaFiles().get(1).getName());
+            } else if ("02 - Gaspard de la Nuit - ii. Le Gibet".equals(result.getMediaFiles().get(0).getName())) {
+                assertEquals("01 - Gaspard de la Nuit - i. Ondine", result.getMediaFiles().get(1).getName());
+            } else {
+                Assertions.fail("Search results are not correct.");
+            }
+
+            candidates = mediaFileDao.getSongExpungeCandidates();
+            assertEquals(0, candidates.size());
+
+            result.getMediaFiles().forEach(a -> mediaFileDao.deleteMediaFile(a.getId()));
+
+            candidates = mediaFileDao.getSongExpungeCandidates();
+            assertEquals(2, candidates.size());
+
+            // artistid3
+            result = searchService.search(criteriaArtistId3);
+            assertEquals(1, result.getArtists().size());
+            assertEquals("_DIR_ Ravel", result.getArtists().get(0).getName());
+
+            // albumId3
+            result = searchService.search(criteriaAlbumId3);
+            assertEquals(1, result.getAlbums().size());
+            assertEquals("Complete Piano Works", result.getAlbums().get(0).getName());
+
+            /* Does not scan, only expunges the index. */
+            mediaScannerService.expunge();
+
+            /*
+             * Subsequent search results. Results can also be confirmed with Luke.
+             */
+
+            result = searchService.search(criteriaArtist);
+            assertEquals(0, result.getMediaFiles().size());
+
+            result = searchService.search(criteriaAlbum);
+            assertEquals(0, result.getMediaFiles().size());
+
+            result = searchService.search(criteriaSong);
+            assertEquals(0, result.getMediaFiles().size());
+
+            result = searchService.search(criteriaArtistId3);
+            assertEquals(0, result.getArtists().size());
+
+            result = searchService.search(criteriaAlbumId3);
+            assertEquals(0, result.getAlbums().size());
+
+            // See this#setup
+            assertEquals(3, ratingDao.getRatedAlbumCount(USER_NAME, musicFolders),
+                    "Because one album has been deleted.");
             int ratingsCount = template.getJdbcTemplate().queryForObject(
                     "select count(*) from user_rating where user_rating.username = ?", Integer.class, USER_NAME);
-            assertEquals(4, ratingsCount, "Because explicitly registered 4 Ratings.");
-
-            // Register a dummy rate (reproduce old path data by moving files)
-            MediaFile dummyMediaFile = new MediaFile();
-            dummyMediaFile.setPathString("oldPath");
-            ratingDao.setRatingForUser(USER_NAME, dummyMediaFile, 1);
-
-            assertEquals(4, ratingDao.getRatedAlbumCount(USER_NAME, musicFolders),
-                    "Because the SELECT condition only references real paths.");
-            ratingsCount = template.getJdbcTemplate().queryForObject(
-                    "select count(*) from user_rating where user_rating.username = ?", Integer.class, USER_NAME);
-            assertEquals(5, ratingsCount, "Because counted directly, including non-existent paths.");
-
-            return true;
-        });
-
-    }
-
-    @Test
-    @Order(1)
-    void testExpunge() throws IOException {
-
-        int offset = 0;
-        int count = Integer.MAX_VALUE;
-
-        final SearchCriteria criteriaArtist = director.construct("_DIR_ Ravel", offset, count, false, musicFolders,
-                IndexType.ARTIST);
-        final SearchCriteria criteriaAlbum = director.construct("Complete Piano Works", offset, count, false,
-                musicFolders, IndexType.ALBUM);
-        final SearchCriteria criteriaSong = director.construct("Gaspard", offset, count, false, musicFolders,
-                IndexType.SONG);
-        final SearchCriteria criteriaArtistId3 = director.construct("_DIR_ Ravel", offset, count, false, musicFolders,
-                IndexType.ARTIST_ID3);
-        final SearchCriteria criteriaAlbumId3 = director.construct("Complete Piano Works", offset, count, false,
-                musicFolders, IndexType.ALBUM_ID3);
-
-        /* Delete DB record. */
-
-        // artist
-        SearchResult result = searchService.search(criteriaArtist);
-        assertEquals(1, result.getMediaFiles().size());
-        assertEquals("_DIR_ Ravel", result.getMediaFiles().get(0).getName());
-
-        List<Integer> candidates = mediaFileDao.getArtistExpungeCandidates();
-        assertEquals(0, candidates.size());
-
-        result.getMediaFiles().forEach(a -> mediaFileDao.deleteMediaFile(a.getId()));
-
-        candidates = mediaFileDao.getArtistExpungeCandidates();
-        assertEquals(1, candidates.size());
-
-        // album
-        result = searchService.search(criteriaAlbum);
-        assertEquals(1, result.getMediaFiles().size());
-        assertEquals("_DIR_ Ravel - Complete Piano Works", result.getMediaFiles().get(0).getName());
-
-        candidates = mediaFileDao.getAlbumExpungeCandidates();
-        assertEquals(0, candidates.size());
-
-        result.getMediaFiles().forEach(a -> mediaFileDao.deleteMediaFile(a.getId()));
-
-        candidates = mediaFileDao.getAlbumExpungeCandidates();
-        assertEquals(1, candidates.size());
-
-        // song
-        result = searchService.search(criteriaSong);
-        assertEquals(2, result.getMediaFiles().size());
-        if ("01 - Gaspard de la Nuit - i. Ondine".equals(result.getMediaFiles().get(0).getName())) {
-            assertEquals("02 - Gaspard de la Nuit - ii. Le Gibet", result.getMediaFiles().get(1).getName());
-        } else if ("02 - Gaspard de la Nuit - ii. Le Gibet".equals(result.getMediaFiles().get(0).getName())) {
-            assertEquals("01 - Gaspard de la Nuit - i. Ondine", result.getMediaFiles().get(1).getName());
-        } else {
-            Assertions.fail("Search results are not correct.");
+            assertEquals(3, ratingsCount, "Will be removed, including oldPath");
         }
 
-        candidates = mediaFileDao.getSongExpungeCandidates();
-        assertEquals(0, candidates.size());
+        @Test
+        @Order(2)
+        void testDeleteLegacyFiles() throws ExecutionException, IOException {
+            // Remove the index used in the early days of Airsonic(Close to Subsonic)
+            Path legacyFile = Path.of(SettingsService.getJpsonicHome().toString(), "lucene2");
+            if (Files.createFile(legacyFile) != null) {
+                assertTrue(Files.exists(legacyFile));
+            } else {
+                Assertions.fail();
+            }
+            Path legacyDir = Path.of(SettingsService.getJpsonicHome().toString(), "lucene3");
+            FileUtil.createDirectories(legacyDir);
 
-        result.getMediaFiles().forEach(a -> mediaFileDao.deleteMediaFile(a.getId()));
-
-        candidates = mediaFileDao.getSongExpungeCandidates();
-        assertEquals(2, candidates.size());
-
-        // artistid3
-        result = searchService.search(criteriaArtistId3);
-        assertEquals(1, result.getArtists().size());
-        assertEquals("_DIR_ Ravel", result.getArtists().get(0).getName());
-
-        // albumId3
-        result = searchService.search(criteriaAlbumId3);
-        assertEquals(1, result.getAlbums().size());
-        assertEquals("Complete Piano Works", result.getAlbums().get(0).getName());
-
-        /* Does not scan, only expunges the index. */
-        mediaScannerService.expunge();
-
-        /*
-         * Subsequent search results. Results can also be confirmed with Luke.
-         */
-
-        result = searchService.search(criteriaArtist);
-        assertEquals(0, result.getMediaFiles().size());
-
-        result = searchService.search(criteriaAlbum);
-        assertEquals(0, result.getMediaFiles().size());
-
-        result = searchService.search(criteriaSong);
-        assertEquals(0, result.getMediaFiles().size());
-
-        result = searchService.search(criteriaArtistId3);
-        assertEquals(0, result.getArtists().size());
-
-        result = searchService.search(criteriaAlbumId3);
-        assertEquals(0, result.getAlbums().size());
-
-        // See this#setup
-        assertEquals(3, ratingDao.getRatedAlbumCount(USER_NAME, musicFolders), "Because one album has been deleted.");
-        int ratingsCount = template.getJdbcTemplate().queryForObject(
-                "select count(*) from user_rating where user_rating.username = ?", Integer.class, USER_NAME);
-        assertEquals(3, ratingsCount, "Will be removed, including oldPath");
-    }
-
-    @Test
-    @Order(2)
-    void testDeleteLegacyFiles() throws ExecutionException, IOException {
-        // Remove the index used in the early days of Airsonic(Close to Subsonic)
-        Path legacyFile = Path.of(SettingsService.getJpsonicHome().toString(), "lucene2");
-        if (Files.createFile(legacyFile) != null) {
-            assertTrue(Files.exists(legacyFile));
-        } else {
-            Assertions.fail();
+            indexManager.deleteLegacyFiles();
+            assertFalse(Files.exists(legacyFile));
+            assertFalse(Files.exists(legacyDir));
         }
-        Path legacyDir = Path.of(SettingsService.getJpsonicHome().toString(), "lucene3");
-        FileUtil.createDirectories(legacyDir);
 
-        indexManager.deleteLegacyFiles();
-        assertFalse(Files.exists(legacyFile));
-        assertFalse(Files.exists(legacyDir));
-    }
-
-    @Test
-    @Order(3)
-    void testDeleteOldFiles() throws ExecutionException, IOException {
-        // If the index version does not match, delete it
-        Path oldDir = Path.of(SettingsService.getJpsonicHome().toString(), "index-JP22");
-        if (FileUtil.createDirectories(oldDir) != null) {
-            assertTrue(Files.exists(oldDir));
-        } else {
-            Assertions.fail();
+        @Test
+        @Order(3)
+        void testDeleteOldFiles() throws ExecutionException, IOException {
+            // If the index version does not match, delete it
+            Path oldDir = Path.of(SettingsService.getJpsonicHome().toString(), "index-JP22");
+            if (FileUtil.createDirectories(oldDir) != null) {
+                assertTrue(Files.exists(oldDir));
+            } else {
+                Assertions.fail();
+            }
+            indexManager.deleteOldFiles();
+            assertFalse(Files.exists(oldDir));
         }
-        indexManager.deleteOldFiles();
-        assertFalse(Files.exists(oldDir));
     }
 }


### PR DESCRIPTION
## Problem description

When automatically migrating to v113, ID3 index data is not created and searches cannot be performed. 

 - Web page searches are not affected. You may not be able to search from Mobile Apps.
 - Can be avoided by enabling IgnoreTimestamp

### Steps to reproduce

 - 1. Update to v113 after running a regular scan on v112.x.x
 - 2. Run a scan

Searching web pages works fine. (Because, It's File Structure search) However, ID3 search cannot be used.

## System information

 * **Jpsonic version**: v113.0.0

## Details

Related #2478. Due to the codec change, the data directory search index will be replaced. This happens regularly, but not often. Most Sonic servers have a mechanism for data generation change. 
However, Jpsonic's scanning mechanism has changed, so the previous generation update method is insufficient.


 - Database ID3 tables are typically updated differentially. (Only necessary items are compared)
 - Lucene index will be updated when DB record update occurs.
 - Neither the ID3 database record nor the Lucene index is updated because there is no difference in the contents of the Database between index generations.

Difference comparisons are performed extremely accurately 😩

## Fixes

Force Delete/Insert. It's the fastest and surest. Same processing as when IgnoreTimestamp=true.

 
