### PR TITLE
Fix the problem of not being able to connect with wmp12

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/transport/StreamServerImpl.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/transport/StreamServerImpl.java
@@ -112,8 +112,8 @@ public final class StreamServerImpl implements StreamServer<DefaultStreamServerC
 
     private static boolean isAcceptable(RequestInfo requestInfo) {
         return switch (requestInfo.method) {
-            case GET, POST -> true;
-            case MSEARCH, NOTIFY, SUBSCRIBE, UNKNOWN, UNSUBSCRIBE -> false;
+            case GET, POST, SUBSCRIBE, UNSUBSCRIBE -> true;
+            case MSEARCH, NOTIFY, UNKNOWN  -> false;
         };
     }
 


### PR DESCRIPTION
Related: #2544

## Problem description

After UPnP Migration of v114.0.0.alpha.1, connection with WMP12 is not possible.

### Steps to reproduce

Using WMP12 with v114.0.0.alpha.1. It is possible to connect with other major UPnP clients, but only WMP12 cannot.

## System information

 * **Jpsonic version**: v114.0.0.alpha.1
 * **Operating system**: Windows 10
 * **Java version**: All
 * **Client**: WMP12
 * **Language**: ja

## Additional notes

 - Most UPnP players only use GET, or at most POST like Foobar2k. WMP12 is unique and uses SUBSCRIBE.
 - Only GET, POST were allowed, now fixed to accept SUBSCRIBE and UNSUBSCRIBE 
