### PR TITLE
Use virtual threads with IndexSearcher

### DIFF
--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
@@ -76,7 +76,8 @@ class IndexManagerTest {
             SettingsService settingsService = Mockito.mock(SettingsService.class);
             artistDao = mock(ArtistDao.class);
             albumDao = mock(AlbumDao.class);
-            indexManager = new IndexManager(null, null, null, null, null, settingsService, null, artistDao, albumDao);
+            indexManager = new IndexManager(null, null, null, null, null, settingsService, null, artistDao, albumDao,
+                    null);
         }
 
         @AfterEach


### PR DESCRIPTION
Prerequisites: #2558

IndexSearcher will be fixed to use virtual threads. The effect is. . . Originally Search was fast. It might be a little hard to understand if there are only a few songs 🤨
It may be fixed again when SliceExecutor is released.

`ttps://github.com/apache/lucene/issues/12347`