### PR TITLE
Organize UPnP Executors

### DIFF
--- a/jpsonic-concurent17/src/main/java/com/tesshu/jpsonic/util/concurrent/ExecutorConfiguration.java
+++ b/jpsonic-concurent17/src/main/java/com/tesshu/jpsonic/util/concurrent/ExecutorConfiguration.java
@@ -29,13 +29,14 @@ import javax.naming.NamingException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.core.task.support.ExecutorServiceAdapter;
-import org.springframework.core.task.support.TaskExecutorAdapter;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.DefaultManagedAwareThreadFactory;
@@ -170,6 +171,7 @@ public class ExecutorConfiguration {
 
     /**
      * @see org.jupnp.DefaultUpnpServiceConfiguration.JUPnPExecutor
+     * @see com.tesshu.jpsonic.service.upnp.transport.UpnpServiceConfigurationAdapter
      */
     @Lazy
     @Bean
@@ -190,25 +192,27 @@ public class ExecutorConfiguration {
         return new ExecutorServiceAdapter(executor);
     }
 
-    @Lazy
-    @Bean
-    public ExecutorService asyncProtocolExecutorService() {
-        final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setWaitForTasksToCompleteOnShutdown(false);
-        executor.setAwaitTerminationMillis(SHORT_AWAIT_TERMINATION);
-        executor.setCorePoolSize(3);
-        executor.setMaxPoolSize(3);
-        executor.setThreadFactory(createThreadFactory(true, "upnp-discovery", Thread.MIN_PRIORITY));
-        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
-        executor.setDaemon(true);
-        executor.initialize();
-        return new ExecutorServiceAdapter(new TaskExecutorAdapter(executor));
+    @Configuration
+    public class VirtualExecutorServiceConfiguration {
+        @Lazy
+        @Bean("virtualExecutorService")
+        public ExecutorService createVirtualExecutorService(
+                @Autowired @Qualifier("shortExecutor") AsyncTaskExecutor shortExecutor) {
+            return new ExecutorServiceAdapter(shortExecutor);
+        }
+
+        @Lazy
+        @Bean("asyncProtocolExecutorService")
+        public ExecutorService asyncProtocolExecutorService(
+                @Autowired @Qualifier("virtualExecutorService") ExecutorService virtualExecutorService) {
+            return virtualExecutorService;
+        }
     }
 
     @Bean
     public Executor registryMaintainerExecutor() {
         return Executors
-                .newSingleThreadExecutor(createThreadFactory(true, "upnp-registry-maintainer", Thread.MIN_PRIORITY));
+                .newSingleThreadExecutor(createThreadFactory(false, "upnp-registry-maintainer", Thread.MIN_PRIORITY));
     }
 
     private ThreadFactory createThreadFactory(boolean isPool, String threadGroupName, int threadPriority) {

--- a/jpsonic-concurent17/src/main/java/com/tesshu/jpsonic/util/concurrent/ExecutorConfiguration.java
+++ b/jpsonic-concurent17/src/main/java/com/tesshu/jpsonic/util/concurrent/ExecutorConfiguration.java
@@ -19,7 +19,9 @@
 
 package com.tesshu.jpsonic.util.concurrent;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -159,7 +161,9 @@ public class ExecutorConfiguration {
     public TaskScheduler taskScheduler() {
         ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
         scheduler.setWaitForTasksToCompleteOnShutdown(false);
-        scheduler.setPoolSize(2); // scan and podcast. See *ScheduleConfiguration.
+        // scan, podcast. See *ScheduleConfiguration.
+        // upnp registry maintainer. See UpnpServiceConfigurationAdapter
+        scheduler.setPoolSize(3);
         scheduler.setThreadFactory(createThreadFactory(true, "task-scheduler", Thread.MIN_PRIORITY));
         return scheduler;
     }
@@ -199,6 +203,12 @@ public class ExecutorConfiguration {
         executor.setDaemon(true);
         executor.initialize();
         return new ExecutorServiceAdapter(new TaskExecutorAdapter(executor));
+    }
+
+    @Bean
+    public Executor registryMaintainerExecutor() {
+        return Executors
+                .newSingleThreadExecutor(createThreadFactory(true, "upnp-registry-maintainer", Thread.MIN_PRIORITY));
     }
 
     private ThreadFactory createThreadFactory(boolean isPool, String threadGroupName, int threadPriority) {

--- a/jpsonic-concurent21/src/main/java/com/tesshu/jpsonic/util/concurrent/ExecutorConfiguration.java
+++ b/jpsonic-concurent21/src/main/java/com/tesshu/jpsonic/util/concurrent/ExecutorConfiguration.java
@@ -75,6 +75,11 @@ public class ExecutorConfiguration {
     @Bean
     @DependsOn({ "legacyDaoHelper", "cacheDisposer" })
     public AsyncTaskExecutor shortExecutor() {
+        // @see TaskExecutorConfigurations
+        // shortExecutor(SimpleAsyncTaskExecutorBuilder builder)
+        // return builder.threadNamePrefix("jps-").build();
+
+        // ... Vanilla is enough for now.
         return new TaskExecutorAdapter(Executors.newVirtualThreadPerTaskExecutor());
     }
 
@@ -139,12 +144,14 @@ public class ExecutorConfiguration {
         return scheduler;
     }
 
-    @Lazy
-    @Bean
-    @DependsOn("legacyDaoHelper")
-    public ExecutorService virtualExecutorService() {
-        return new ExecutorServiceAdapter(
-                new TaskExecutorAdapter(Executors.newVirtualThreadPerTaskExecutor()));
+    @Configuration
+    public class VirtualExecutorServiceConfiguration {
+        @Lazy
+        @Bean(name = {"virtualExecutorService"})
+        public ExecutorService createVirtualExecutorService(
+                @Autowired @Qualifier("shortExecutor") AsyncTaskExecutor shortExecutor) {
+            return new ExecutorServiceAdapter(shortExecutor);
+        }
     }
 
     @Configuration

--- a/jpsonic-concurent21/src/main/java/com/tesshu/jpsonic/util/concurrent/ExecutorConfiguration.java
+++ b/jpsonic-concurent21/src/main/java/com/tesshu/jpsonic/util/concurrent/ExecutorConfiguration.java
@@ -19,6 +19,7 @@
 
 package com.tesshu.jpsonic.util.concurrent;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -161,6 +162,12 @@ public class ExecutorConfiguration {
                 @Autowired @Qualifier("virtualExecutorService") ExecutorService executorService) {
             return executorService;
         }
+    }
+
+    @Bean
+    public Executor registryMaintainerExecutor() {
+        return Executors.newSingleThreadExecutor(
+                createThreadFactory(false, "upnp-registry-maintainer", Thread.MIN_PRIORITY));
     }
 
     private ThreadFactory createThreadFactory(boolean isPool, String threadGroupName, int threadPriority) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/UpnpServiceFactory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/UpnpServiceFactory.java
@@ -37,6 +37,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -86,22 +87,25 @@ public class UpnpServiceFactory {
     private final CustomContentDirectory dispatchingContentDirectory;
     private final ExecutorService defaultExecutorService;
     private final ExecutorService asyncExecutorService;
+    private final Executor registryMaintainerExecutor;
 
     public UpnpServiceFactory(SettingsService settingsService, VersionService versionService,
             @Qualifier("dispatchingContentDirectory") CustomContentDirectory dispatchingContentDirectory,
             @Qualifier("upnpExecutorService") ExecutorService defaultExecutorService,
-            @Qualifier("asyncProtocolExecutorService") ExecutorService asyncExecutorService) {
+            @Qualifier("asyncProtocolExecutorService") ExecutorService asyncExecutorService,
+            @Qualifier("registryMaintainerExecutor") Executor registryMaintainerExecutor) {
         super();
         this.settingsService = settingsService;
         this.versionService = versionService;
         this.dispatchingContentDirectory = dispatchingContentDirectory;
         this.defaultExecutorService = defaultExecutorService;
         this.asyncExecutorService = asyncExecutorService;
+        this.registryMaintainerExecutor = registryMaintainerExecutor;
     }
 
     public UpnpService createUpnpService() {
         UpnpServiceConfiguration conf = new JpsonicUpnpServiceConf(defaultExecutorService, asyncExecutorService,
-                SettingsService.getBrand(), versionService.getLocalVersion());
+                registryMaintainerExecutor, SettingsService.getBrand(), versionService.getLocalVersion());
         return new UpnpServiceImpl(conf);
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/transport/JpsonicUpnpServiceConf.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/transport/JpsonicUpnpServiceConf.java
@@ -19,6 +19,7 @@
 
 package com.tesshu.jpsonic.service.upnp.transport;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 
 import com.tesshu.jpsonic.domain.Version;
@@ -35,9 +36,10 @@ public class JpsonicUpnpServiceConf extends UpnpServiceConfigurationAdapter {
 
     private final ServerClientTokens tokens;
 
-    public JpsonicUpnpServiceConf(ExecutorService defaultExecutorService, ExecutorService asyncExecutorService, String brand,
+    public JpsonicUpnpServiceConf(ExecutorService defaultExecutorService,
+            ExecutorService asyncExecutorService, Executor registryMaintainerExecutor, String brand,
             Version version) {
-        super(defaultExecutorService, asyncExecutorService);
+        super(defaultExecutorService, asyncExecutorService, registryMaintainerExecutor);
         tokens = new ServerClientTokens(brand, version.toString());
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/transport/UpnpServiceConfigurationAdapter.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/transport/UpnpServiceConfigurationAdapter.java
@@ -19,6 +19,7 @@
 
 package com.tesshu.jpsonic.service.upnp.transport;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 
 import org.jupnp.DefaultUpnpServiceConfiguration;
@@ -37,41 +38,52 @@ public class UpnpServiceConfigurationAdapter extends DefaultUpnpServiceConfigura
 
     private final ExecutorService defaultExecutorService;
     private final ExecutorService asyncExecutorService;
+    private final Executor registryMaintainerExecutor;
 
     public UpnpServiceConfigurationAdapter(ExecutorService defaultExecutorService,
-            ExecutorService asyncExecutorService) {
+            ExecutorService asyncExecutorService, Executor registryMaintainerExecutor) {
         super();
         this.defaultExecutorService = defaultExecutorService;
         this.asyncExecutorService = asyncExecutorService;
+        this.registryMaintainerExecutor = registryMaintainerExecutor;
     }
 
     public UpnpServiceConfigurationAdapter(ExecutorService executorService,
-            ExecutorService asyncExecutorService, int streamListenPort) {
+            ExecutorService asyncExecutorService, Executor registryMaintainerExecutor, int streamListenPort) {
         super(streamListenPort);
         this.defaultExecutorService = executorService;
         this.asyncExecutorService = asyncExecutorService;
+        this.registryMaintainerExecutor = registryMaintainerExecutor;
     }
 
     public UpnpServiceConfigurationAdapter(ExecutorService executorService,
-            ExecutorService asyncExecutorService, int streamListenPort, int multicastResponsePort) {
+            ExecutorService asyncExecutorService, Executor registryMaintainerExecutor, int streamListenPort, int multicastResponsePort) {
         super(streamListenPort, multicastResponsePort);
         this.defaultExecutorService = executorService;
         this.asyncExecutorService = asyncExecutorService;
+        this.registryMaintainerExecutor = registryMaintainerExecutor;
     }
 
     protected UpnpServiceConfigurationAdapter(ExecutorService executorService,
-            ExecutorService asyncExecutorService, boolean checkRuntime) {
+            ExecutorService asyncExecutorService, Executor registryMaintainerExecutor, boolean checkRuntime) {
         super(checkRuntime);
         this.defaultExecutorService = executorService;
         this.asyncExecutorService = asyncExecutorService;
+        this.registryMaintainerExecutor = registryMaintainerExecutor;
     }
 
     protected UpnpServiceConfigurationAdapter(ExecutorService executorService,
-            ExecutorService asyncExecutorService, int streamListenPort, int multicastResponsePort,
+            ExecutorService asyncExecutorService, Executor registryMaintainerExecutor, int streamListenPort, int multicastResponsePort,
             boolean checkRuntime) {
         super(streamListenPort, multicastResponsePort, checkRuntime);
         this.defaultExecutorService = executorService;
         this.asyncExecutorService = asyncExecutorService;
+        this.registryMaintainerExecutor = registryMaintainerExecutor;
+    }
+
+    @Override
+    public Executor getRegistryMaintainerExecutor() {
+        return registryMaintainerExecutor;
     }
 
     /**

--- a/jpsonic-main/src/main/resources/application.properties
+++ b/jpsonic-main/src/main/resources/application.properties
@@ -2,6 +2,7 @@
 spring.main.allow-circular-references: true
 #logging.level.org.springframework.security: TRACE
 
+#spring.threads.virtual.enabled: true
 server.error.includeStacktrace: ALWAYS
 server.max-http-request-header-size: 65536
 server.shutdown: graceful

--- a/jpsonic-main/src/test/resources/application.properties
+++ b/jpsonic-main/src/test/resources/application.properties
@@ -2,6 +2,7 @@
 spring.main.allow-circular-references: true
 #logging.level.org.springframework.security: TRACE
 
+#spring.threads.virtual.enabled: true
 server.error.includeStacktrace: ALWAYS
 server.max-http-request-header-size: 65536
 server.shutdown: graceful


### PR DESCRIPTION
Prerequisites: #2558

## Overview

UPnP thread implementation will be more detailed. UPnP thread desynchronization has already been done in #2558. This pull request will change the configuration to a threading strategy more in line with the design of Cling and Jupnp.

## Details

 - Jupnp has a class called [DefaultUpnpServiceConfiguration](https://github.com/jupnp/jupnp/blob/main/bundles/org.jupnp/src/main/java/org/jupnp/DefaultUpnpServiceConfiguration.java), which manages Executer and ExecuterService.
 - Jpsonic defines a class called [UpnpServiceConfigurationAdapter](https://github.com/tesshucom/jpsonic/blob/master/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/transport/UpnpServiceConfigurationAdapter.java)that inherits from it.
   - This class reverses dependencies and injects the Executor and ExecutorService, where Spring lifecycle is managed, into the Jupnp implementation. 
   - Jupnp includes shutting down ExecutorService as part of the shutdown process, but Jpsonic overrides this and prevents it. ExecutorService shutdown is done by Spring
 - The definitions of Jpsonic's thread pool and executor are placed in modules called jpsonic-concurent17 and jpsonic-concurent21. The Executor implementation is switched according to the version using JavaOption during compiling.
   - The Executor implementation does not change dynamically. It contains different definitions from the beginning. Java21 is based on the assumption that Virtual threads will be used regardless of Options.
   - Java17 compatibility will be maintained for the time being. Of course, if Java17Support ends, the jpsonic-concurent17 module will be destroyed.

If you carefully look at jupnp's DefaultUpnpServiceConfiguration, you will see that (1)asyncProtocolExecutor exists in ExecutorService. Everything else is a shadow of (2)defaultExecutorService. (Of course, you can assign a different ExecutorService to each if you want, but it may not be necessary.) The one you should be most careful with is (3)RegistryMaintainerExecutor. This assumes that you are running a classic monitoring thread with internal loop-sleep processing.

They can be roughly divided into three types.

 - (1) asyncProtocolExecutor  ≒ Daemon, and Multi thread.
 - (2) defaultExecutorService  ≒ Not daemon, and Multi thread.
 - (3) RegistryMaintainerExecutor ≒ Not daemon, and Single thread. Monitoring and Refresh (memory changes almost constantly)


## Why so much detail... 😫

There may be times when it is not a virtue to be too simple in everything... Even with the introduction of virtual threads, not everything can be replaced with them. Some systematic thread group and name management is still required. Especially when Thread or Memory profile.

![image](https://github.com/tesshucom/jpsonic/assets/27724847/75c28d6d-b6e3-4937-91a1-9d02dc8b9771)

UPnP processing is relatively detailed and complex. Maintenance without a Memory profile is a little difficult.

![image](https://github.com/tesshucom/jpsonic/assets/27724847/db6951d2-2eff-4c44-b2d7-3cadafb7669d)



