### PR TITLE
Migrate to ReentrantLock

### DIFF
--- a/airsonic-taglibs/src/main/java/com/tesshu/jpsonic/util/StringUtilBase.java
+++ b/airsonic-taglibs/src/main/java/com/tesshu/jpsonic/util/StringUtilBase.java
@@ -39,7 +39,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class StringUtilBase {
 
     private static final long BINARY_1KB = 1024L;
-    public static final Object FORMAT_LOCK = new Object();
 
     /**
      * Disallow external instantiation.
@@ -64,33 +63,31 @@ public final class StringUtilBase {
      * @return The formatted string.
      */
     public static String formatBytes(long byteCount, Locale locale) {
-        synchronized (FORMAT_LOCK) {
-            // More than 1 TB?
-            if (byteCount >= BINARY_1KB * 1024 * 1024 * 1024) {
-                NumberFormat teraByteFormat = new DecimalFormat("0.00 TB", new DecimalFormatSymbols(locale));
-                return teraByteFormat.format(byteCount / ((double) 1024 * 1024 * 1024 * 1024));
-            }
-
-            // More than 1 GB?
-            if (byteCount >= BINARY_1KB * 1024 * 1024) {
-                NumberFormat gigaByteFormat = new DecimalFormat("0.00 GB", new DecimalFormatSymbols(locale));
-                return gigaByteFormat.format(byteCount / ((double) 1024 * 1024 * 1024));
-            }
-
-            // More than 1 MB?
-            if (byteCount >= BINARY_1KB * 1024) {
-                NumberFormat megaByteFormat = new DecimalFormat("0.0 MB", new DecimalFormatSymbols(locale));
-                return megaByteFormat.format(byteCount / ((double) 1024 * 1024));
-            }
-
-            // More than 1 KB?
-            if (byteCount >= BINARY_1KB) {
-                NumberFormat kiloByteFormat = new DecimalFormat("0 KB", new DecimalFormatSymbols(locale));
-                return kiloByteFormat.format((double) byteCount / 1024);
-            }
-
-            return byteCount + " B";
+        // More than 1 TB?
+        if (byteCount >= BINARY_1KB * 1024 * 1024 * 1024) {
+            NumberFormat teraByteFormat = new DecimalFormat("0.00 TB", new DecimalFormatSymbols(locale));
+            return teraByteFormat.format(byteCount / ((double) 1024 * 1024 * 1024 * 1024));
         }
+
+        // More than 1 GB?
+        if (byteCount >= BINARY_1KB * 1024 * 1024) {
+            NumberFormat gigaByteFormat = new DecimalFormat("0.00 GB", new DecimalFormatSymbols(locale));
+            return gigaByteFormat.format(byteCount / ((double) 1024 * 1024 * 1024));
+        }
+
+        // More than 1 MB?
+        if (byteCount >= BINARY_1KB * 1024) {
+            NumberFormat megaByteFormat = new DecimalFormat("0.0 MB", new DecimalFormatSymbols(locale));
+            return megaByteFormat.format(byteCount / ((double) 1024 * 1024));
+        }
+
+        // More than 1 KB?
+        if (byteCount >= BINARY_1KB) {
+            NumberFormat kiloByteFormat = new DecimalFormat("0 KB", new DecimalFormatSymbols(locale));
+            return kiloByteFormat.format((double) byteCount / 1024);
+        }
+
+        return byteCount + " B";
     }
 
     /**

--- a/jpsonic-main/ruleset.xml
+++ b/jpsonic-main/ruleset.xml
@@ -65,9 +65,12 @@
 
         <!-- Rather recommended. -->
         <exclude name="OnlyOneReturn" />
-        
+
         <!-- Degrade pmd/pmd#4785 -->
         <exclude name="UnnecessaryImport" />
+
+        <!-- allowCommentedBlocks will be ignored. (And duplicate with Checkstyle) -->
+        <exclude name="EmptyControlStatement" />
     </rule>
 
     <!-- Java Rules:Design -->

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/CoverArtController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/CoverArtController.java
@@ -104,7 +104,6 @@ public class CoverArtController implements CoverArtPresentation {
     private final ArtistDao artistDao;
     private final AlbumDao albumDao;
     private final FontLoader fontLoader;
-    private final Object dirLock = new Object();
 
     private Semaphore semaphore;
 
@@ -361,15 +360,10 @@ public class CoverArtController implements CoverArtPresentation {
         return ffmpeg.createImage(mediaFile.toPath(), width, height, offset);
     }
 
-    private Path getImageCacheDirectory(int size) {
+    @Nullable
+    Path getImageCacheDirectory(int size) {
         Path dir = Path.of(SettingsService.getJpsonicHome().toString(), "thumbs", String.valueOf(size));
-        if (!Files.exists(dir)) {
-            synchronized (dirLock) {
-                if (FileUtil.createDirectories(dir) == null && LOG.isErrorEnabled()) {
-                    LOG.error("Failed to create thumbnail cache " + dir);
-                }
-            }
-        }
+        FileUtil.createDirectories(dir);
         return dir;
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/M3UController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/M3UController.java
@@ -89,10 +89,7 @@ public class M3UController {
             out.print("\ufeff");
         }
         out.println("#EXTM3U");
-        List<MediaFile> result;
-        synchronized (player.getPlayQueue()) {
-            result = player.getPlayQueue().getFiles();
-        }
+        List<MediaFile> result = player.getPlayQueue().getFiles();
         for (MediaFile mediaFile : result) {
             Integer duration = mediaFile.getDurationSeconds();
             if (duration == null) {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StatusChartController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/StatusChartController.java
@@ -49,6 +49,8 @@ import org.jfree.data.time.MovingAverage;
 import org.jfree.data.time.TimeSeries;
 import org.jfree.data.time.TimeSeriesCollection;
 import org.jfree.data.time.TimeSeriesDataItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -64,9 +66,10 @@ import org.springframework.web.servlet.ModelAndView;
 @RequestMapping("/statusChart.view")
 public class StatusChartController extends AbstractChartController {
 
+    private static final Logger LOG = LoggerFactory.getLogger(StatusChartController.class);
+
     public static final int IMAGE_WIDTH = 240;
     public static final int IMAGE_HEIGHT = 150;
-    public static final Object LOCK = new Object();
 
     private final StatusService statusService;
     private final FontLoader fontLoader;
@@ -77,13 +80,7 @@ public class StatusChartController extends AbstractChartController {
         this.fontLoader = fontLoader;
     }
 
-    @SuppressWarnings({ "PMD.AvoidInstantiatingObjectsInLoops", "PMD.UselessParentheses" })
-    @Override
-    @GetMapping
-    public ModelAndView handleRequest(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        String type = request.getParameter(Attributes.Request.TYPE.value());
-        int index = ServletRequestUtils.getIntParameter(request, Attributes.Request.INDEX.value(), 0);
-
+    private List<TransferStatus> getStatuses(String type) {
         List<TransferStatus> statuses = Collections.emptyList();
         if ("stream".equals(type)) {
             statuses = statusService.getAllStreamStatuses();
@@ -92,7 +89,17 @@ public class StatusChartController extends AbstractChartController {
         } else if ("upload".equals(type)) {
             statuses = statusService.getAllUploadStatuses();
         }
+        return statuses;
+    }
 
+    @SuppressWarnings({ "PMD.AvoidInstantiatingObjectsInLoops", "PMD.UselessParentheses" })
+    @Override
+    @GetMapping
+    public ModelAndView handleRequest(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String type = request.getParameter(Attributes.Request.TYPE.value());
+        List<TransferStatus> statuses = getStatuses(type);
+
+        int index = ServletRequestUtils.getIntParameter(request, Attributes.Request.INDEX.value(), 0);
         if (index < 0 || index >= statuses.size()) {
             return null;
         }
@@ -184,8 +191,12 @@ public class StatusChartController extends AbstractChartController {
         rangeAxis.setTickMarkPaint(fgColor);
         rangeAxis.setAxisLinePaint(fgColor);
 
-        synchronized (LOCK) {
+        try {
             ChartUtils.writeChartAsPNG(response.getOutputStream(), chart, IMAGE_WIDTH, IMAGE_HEIGHT);
+        } catch (IOException e) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Client may have closed the Stream.", e);
+            }
         }
 
         return null;

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/UserChartController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/UserChartController.java
@@ -49,6 +49,8 @@ import org.jfree.chart.renderer.category.BarRenderer;
 import org.jfree.chart.ui.RectangleEdge;
 import org.jfree.data.category.CategoryDataset;
 import org.jfree.data.category.DefaultCategoryDataset;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -62,6 +64,8 @@ import org.springframework.web.servlet.ModelAndView;
 @Controller
 @RequestMapping("/userChart.view")
 public class UserChartController extends AbstractChartController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UserChartController.class);
 
     public static final int IMAGE_WIDTH = 400;
     public static final int IMAGE_MIN_HEIGHT = 200;
@@ -85,7 +89,14 @@ public class UserChartController extends AbstractChartController {
 
         int imageHeight = Math.max(IMAGE_MIN_HEIGHT, 15 * dataset.getColumnCount());
 
-        ChartUtils.writeChartAsPNG(response.getOutputStream(), chart, IMAGE_WIDTH, imageHeight);
+        try {
+            ChartUtils.writeChartAsPNG(response.getOutputStream(), chart, IMAGE_WIDTH, imageHeight);
+        } catch (IOException e) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Client may have closed the Stream.", e);
+            }
+        }
+
         return null;
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/PlayQueue.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/domain/PlayQueue.java
@@ -28,8 +28,10 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import com.tesshu.jpsonic.ThreadSafe;
+import com.tesshu.jpsonic.util.concurrent.ReadWriteLockSupport;
 
 /**
  * A play queue is a list of music files that are associated to a remote player.
@@ -37,10 +39,9 @@ import com.tesshu.jpsonic.ThreadSafe;
  * @author Sindre Mehus
  */
 @ThreadSafe(enableChecks = false)
-public class PlayQueue {
+public class PlayQueue implements ReadWriteLockSupport {
 
-    private final Object statusLock = new Object();
-    private final Object sequenceLock = new Object();
+    private final ReentrantReadWriteLock sequenceLock = new ReentrantReadWriteLock();
     private final AtomicBoolean repeatEnabled;
 
     private List<MediaFile> files;
@@ -94,24 +95,25 @@ public class PlayQueue {
      * @return The current song in the playlist, or <code>null</code> if no current song exists.
      */
     public MediaFile getCurrentFile() {
-        synchronized (statusLock) {
-            synchronized (sequenceLock) {
-                if (index == -1 || index == 0 && size() == 0) {
+        writeLock(sequenceLock);
+        try {
+            if (index == -1 || index == 0 && size() == 0) {
+                if (getStatus() != Status.STOPPED) {
                     setStatus(Status.STOPPED);
-                    return null;
-                } else {
-                    MediaFile file = files.get(index);
-
-                    // Remove file from playlist if it doesn't exist.
-                    if (!file.exists()) {
-                        files.remove(index);
-                        index = Math.max(0, Math.min(index, size() - 1));
-                        return getCurrentFile();
-                    }
-
-                    return file;
                 }
+                return null;
+            } else {
+                MediaFile file = files.get(index);
+                // Remove file from playlist if it doesn't exist.
+                if (!file.exists()) {
+                    files.remove(index);
+                    index = Math.max(0, Math.min(index, size() - 1));
+                    return getCurrentFile();
+                }
+                return file;
             }
+        } finally {
+            writeUnlock(sequenceLock);
         }
     }
 
@@ -121,8 +123,11 @@ public class PlayQueue {
      * @return All music files in the playlist.
      */
     public List<MediaFile> getFiles() {
-        synchronized (sequenceLock) {
+        readLock(sequenceLock);
+        try {
             return files;
+        } finally {
+            readUnlock(sequenceLock);
         }
     }
 
@@ -138,8 +143,11 @@ public class PlayQueue {
      *             If the index is out of range.
      */
     public MediaFile getFile(int index) {
-        synchronized (sequenceLock) {
+        readLock(sequenceLock);
+        try {
             return files.get(index);
+        } finally {
+            readUnlock(sequenceLock);
         }
     }
 
@@ -147,13 +155,14 @@ public class PlayQueue {
      * Skip to the next song in the playlist.
      */
     public void next() {
-        synchronized (sequenceLock) {
+        writeLock(sequenceLock);
+        try {
             index++;
-
-            // Reached the end?
             if (index >= size()) {
                 index = isRepeatEnabled() ? 0 : -1;
             }
+        } finally {
+            writeUnlock(sequenceLock);
         }
     }
 
@@ -163,8 +172,11 @@ public class PlayQueue {
      * @return The number of songs in the playlists.
      */
     public int size() {
-        synchronized (sequenceLock) {
+        readLock(sequenceLock);
+        try {
             return files.size();
+        } finally {
+            readUnlock(sequenceLock);
         }
     }
 
@@ -174,8 +186,11 @@ public class PlayQueue {
      * @return Whether the playlist is empty.
      */
     public boolean isEmpty() {
-        synchronized (sequenceLock) {
+        readLock(sequenceLock);
+        try {
             return files.isEmpty();
+        } finally {
+            readUnlock(sequenceLock);
         }
     }
 
@@ -185,8 +200,11 @@ public class PlayQueue {
      * @return The index of the current song, or -1 if the end of the playlist is reached.
      */
     public int getIndex() {
-        synchronized (sequenceLock) {
+        readLock(sequenceLock);
+        try {
             return index;
+        } finally {
+            readUnlock(sequenceLock);
         }
     }
 
@@ -197,12 +215,13 @@ public class PlayQueue {
      *            The index of the current song.
      */
     public void setIndex(int index) {
-        synchronized (statusLock) {
-            synchronized (sequenceLock) {
-                makeBackup();
-                this.index = Math.max(0, Math.min(index, size() - 1));
-                setStatus(Status.PLAYING);
-            }
+        writeLock(sequenceLock);
+        try {
+            makeBackup();
+            this.index = Math.max(0, Math.min(index, size() - 1));
+            setStatus(Status.PLAYING);
+        } finally {
+            writeUnlock(sequenceLock);
         }
     }
 
@@ -215,13 +234,14 @@ public class PlayQueue {
      *            Where to add them.
      */
     public void addFilesAt(Iterable<MediaFile> mediaFiles, final int index) {
-        synchronized (statusLock) {
-            synchronized (sequenceLock) {
-                makeBackup();
-                AtomicInteger i = new AtomicInteger(index);
-                mediaFiles.forEach(m -> files.add(i.getAndIncrement(), m));
-                setStatus(Status.PLAYING);
-            }
+        writeLock(sequenceLock);
+        try {
+            makeBackup();
+            AtomicInteger i = new AtomicInteger(index);
+            mediaFiles.forEach(m -> files.add(i.getAndIncrement(), m));
+            setStatus(Status.PLAYING);
+        } finally {
+            writeUnlock(sequenceLock);
         }
     }
 
@@ -234,16 +254,17 @@ public class PlayQueue {
      *            The music files to add.
      */
     public void addFiles(boolean append, Iterable<MediaFile> mediaFiles) {
-        synchronized (statusLock) {
-            synchronized (sequenceLock) {
-                makeBackup();
-                if (!append) {
-                    index = 0;
-                    files.clear();
-                }
-                mediaFiles.forEach(m -> files.add(m));
-                setStatus(Status.PLAYING);
+        writeLock(sequenceLock);
+        try {
+            makeBackup();
+            if (!append) {
+                index = 0;
+                files.clear();
             }
+            mediaFiles.forEach(m -> files.add(m));
+            setStatus(Status.PLAYING);
+        } finally {
+            writeUnlock(sequenceLock);
         }
     }
 
@@ -251,10 +272,11 @@ public class PlayQueue {
      * Convenience method, equivalent to {@link #addFiles(boolean, Iterable)}.
      */
     public void addFiles(boolean append, MediaFile... mediaFiles) {
-        synchronized (statusLock) {
-            synchronized (sequenceLock) {
-                addFiles(append, Arrays.asList(mediaFiles));
-            }
+        writeLock(sequenceLock);
+        try {
+            addFiles(append, Arrays.asList(mediaFiles));
+        } finally {
+            writeUnlock(sequenceLock);
         }
     }
 
@@ -265,7 +287,8 @@ public class PlayQueue {
      *            The playlist index.
      */
     public void removeFileAt(final int index) {
-        synchronized (sequenceLock) {
+        writeLock(sequenceLock);
+        try {
             makeBackup();
             int i = index;
             i = Math.max(0, Math.min(i, size() - 1));
@@ -275,6 +298,8 @@ public class PlayQueue {
             files.remove(i);
 
             this.index = Math.max(0, Math.min(this.index, size() - 1));
+        } finally {
+            writeUnlock(sequenceLock);
         }
     }
 
@@ -282,12 +307,15 @@ public class PlayQueue {
      * Clears the playlist.
      */
     public void clear() {
-        synchronized (sequenceLock) {
+        writeLock(sequenceLock);
+        try {
             makeBackup();
             files.clear();
             setRandomSearchCriteria(null);
             setInternetRadio(null);
             index = 0;
+        } finally {
+            writeUnlock(sequenceLock);
         }
     }
 
@@ -295,16 +323,17 @@ public class PlayQueue {
      * Shuffles the playlist.
      */
     public void shuffle() {
-        synchronized (statusLock) {
-            synchronized (sequenceLock) {
-                makeBackup();
-                MediaFile currentFile = getCurrentFile();
-                Collections.shuffle(files);
-                if (currentFile != null) {
-                    Collections.swap(files, files.indexOf(currentFile), 0);
-                    index = 0;
-                }
+        writeLock(sequenceLock);
+        try {
+            makeBackup();
+            MediaFile currentFile = getCurrentFile();
+            Collections.shuffle(files);
+            if (currentFile != null) {
+                Collections.swap(files, files.indexOf(currentFile), 0);
+                index = 0;
             }
+        } finally {
+            writeUnlock(sequenceLock);
         }
     }
 
@@ -312,15 +341,16 @@ public class PlayQueue {
      * Sorts the playlist according to the given sort order.
      */
     public void sort(Comparator<MediaFile> comparator) {
-        synchronized (statusLock) {
-            synchronized (sequenceLock) {
-                makeBackup();
-                MediaFile currentFile = getCurrentFile();
-                files.sort(comparator);
-                if (currentFile != null) {
-                    index = files.indexOf(currentFile);
-                }
+        writeLock(sequenceLock);
+        try {
+            makeBackup();
+            MediaFile currentFile = getCurrentFile();
+            files.sort(comparator);
+            if (currentFile != null) {
+                index = files.indexOf(currentFile);
             }
+        } finally {
+            writeUnlock(sequenceLock);
         }
     }
 
@@ -328,7 +358,8 @@ public class PlayQueue {
      * Rearranges the playlist using the provided indexes.
      */
     public void rearrange(int... indexes) {
-        synchronized (sequenceLock) {
+        writeLock(sequenceLock);
+        try {
             makeBackup();
             if (indexes == null || indexes.length != size()) {
                 return;
@@ -346,6 +377,8 @@ public class PlayQueue {
 
             files.clear();
             files.addAll(Arrays.asList(newFiles));
+        } finally {
+            writeUnlock(sequenceLock);
         }
     }
 
@@ -366,7 +399,8 @@ public class PlayQueue {
      *            The playlist index.
      */
     public void moveDown(int index) {
-        synchronized (sequenceLock) {
+        writeLock(sequenceLock);
+        try {
             makeBackup();
             if (index < 0 || index >= size() - 1) {
                 return;
@@ -378,6 +412,8 @@ public class PlayQueue {
             } else if (this.index == index + 1) {
                 this.index--;
             }
+        } finally {
+            writeUnlock(sequenceLock);
         }
     }
 
@@ -422,14 +458,15 @@ public class PlayQueue {
      * Revert the last operation.
      */
     public void undo() {
-        synchronized (sequenceLock) {
+        writeLock(sequenceLock);
+        try {
             int indexTmp = index;
-
             index = indexBackup;
             files = filesBackup;
             indexBackup = indexTmp;
-
             filesBackup = new ArrayList<>(files);
+        } finally {
+            writeUnlock(sequenceLock);
         }
     }
 
@@ -439,8 +476,11 @@ public class PlayQueue {
      * @return The playlist status.
      */
     public Status getStatus() {
-        synchronized (statusLock) {
+        readLock(sequenceLock);
+        try {
             return status;
+        } finally {
+            readUnlock(sequenceLock);
         }
     }
 
@@ -451,13 +491,14 @@ public class PlayQueue {
      *            The playlist status.
      */
     public void setStatus(Status status) {
-        synchronized (statusLock) {
-            synchronized (sequenceLock) {
-                this.status = status;
-                if (index == -1) {
-                    index = Math.max(0, Math.min(index, size() - 1));
-                }
+        writeLock(sequenceLock);
+        try {
+            this.status = status;
+            if (index == -1) {
+                index = Math.max(0, Math.min(index, size() - 1));
             }
+        } finally {
+            writeUnlock(sequenceLock);
         }
     }
 
@@ -506,8 +547,11 @@ public class PlayQueue {
      */
     public long length() {
         long length;
-        synchronized (sequenceLock) {
+        writeLock(sequenceLock);
+        try {
             length = files.stream().mapToLong(MediaFile::getFileSize).sum();
+        } finally {
+            writeUnlock(sequenceLock);
         }
         return length;
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/AudioScrobblerService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/AudioScrobblerService.java
@@ -41,8 +41,6 @@ public class AudioScrobblerService {
 
     private final SecurityService securityService;
     private final Executor shortExecutor;
-    private final Object fmLock = new Object();
-    private final Object brainzLock = new Object();
 
     private LastFMScrobbler lastFMScrobbler;
     private ListenBrainzScrobbler listenBrainzScrobbler;
@@ -73,23 +71,19 @@ public class AudioScrobblerService {
         UserSettings userSettings = securityService.getUserSettings(username);
         if (userSettings.isLastFmEnabled() && userSettings.getLastFmUsername() != null
                 && userSettings.getLastFmPassword() != null) {
-            synchronized (fmLock) {
-                if (lastFMScrobbler == null) {
-                    lastFMScrobbler = new LastFMScrobbler();
-                }
-                lastFMScrobbler.register(mediaFile, userSettings.getLastFmUsername(), userSettings.getLastFmPassword(),
-                        submission, time, shortExecutor);
+            if (lastFMScrobbler == null) {
+                lastFMScrobbler = new LastFMScrobbler();
             }
+            lastFMScrobbler.register(mediaFile, userSettings.getLastFmUsername(), userSettings.getLastFmPassword(),
+                    submission, time, shortExecutor);
         }
 
         if (userSettings.isListenBrainzEnabled() && userSettings.getListenBrainzToken() != null) {
-            synchronized (brainzLock) {
-                if (listenBrainzScrobbler == null) {
-                    listenBrainzScrobbler = new ListenBrainzScrobbler();
-                }
-                listenBrainzScrobbler.register(mediaFile, userSettings.getListenBrainzToken(), submission, time,
-                        shortExecutor);
+            if (listenBrainzScrobbler == null) {
+                listenBrainzScrobbler = new ListenBrainzScrobbler();
             }
+            listenBrainzScrobbler.register(mediaFile, userSettings.getListenBrainzToken(), submission, time,
+                    shortExecutor);
         }
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/LastFmCache.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/LastFmCache.java
@@ -51,7 +51,6 @@ public final class LastFmCache extends Cache {
 
     private final Path cacheDir;
     private final long ttl;
-    private final Object lock = new Object();
 
     public LastFmCache(Path cacheDir, final long ttl) {
         super();
@@ -82,8 +81,7 @@ public final class LastFmCache extends Cache {
 
     @Override
     public void store(String cacheEntryName, InputStream inputStream, long expirationDate) {
-        createCache();
-
+        FileUtil.createDirectories(cacheDir);
         Path xmlFile = getXmlFile(cacheEntryName);
         try (OutputStream xmlOut = Files.newOutputStream(xmlFile)) {
 
@@ -108,17 +106,6 @@ public final class LastFmCache extends Cache {
 
     private long getExpirationDate() {
         return Instant.now().toEpochMilli() + ttl;
-    }
-
-    private void createCache() {
-        if (!Files.exists(cacheDir)) {
-            synchronized (lock) {
-                if (FileUtil.createDirectories(cacheDir) == null && LOG.isWarnEnabled()) {
-                    LOG.warn("The directory '{}' could not be created.", cacheDir);
-                }
-
-            }
-        }
     }
 
     @Override

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/AnalyzerFactory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/AnalyzerFactory.java
@@ -29,6 +29,7 @@ import java.io.Reader;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.tesshu.jpsonic.domain.IndexScheme;
 import com.tesshu.jpsonic.service.SettingsService;
@@ -82,7 +83,7 @@ public final class AnalyzerFactory {
     private static final String FILTER_ATTR_ALL = "all";
 
     private final SettingsService settingsService;
-    private final Object analyzerLock = new Object();
+    private final ReentrantLock analyzerLock = new ReentrantLock();
     private Analyzer analyzer;
 
     public AnalyzerFactory(SettingsService settingsService) {
@@ -263,7 +264,8 @@ public final class AnalyzerFactory {
      */
     @SuppressWarnings("PMD.CloseResource") // False positive. Stream is reused by ReuseStrategy.
     public Analyzer getAnalyzer() {
-        synchronized (analyzerLock) {
+        analyzerLock.lock();
+        try {
             if (isEmpty(analyzer)) {
                 try {
 
@@ -293,6 +295,8 @@ public final class AnalyzerFactory {
                 }
             }
             return analyzer;
+        } finally {
+            analyzerLock.unlock();
         }
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/UpnpDIDLFactory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/UpnpDIDLFactory.java
@@ -353,9 +353,7 @@ public class UpnpDIDLFactory implements CoverArtPresentation {
             musicTrack.addProperty(toPodcastArt(channel));
         }
         if (!isEmpty(episode.getPublishDate())) {
-            synchronized (DATE_FORMAT) {
-                musicTrack.setDate(DATE_FORMAT.get().format(episode.getPublishDate()));
-            }
+            musicTrack.setDate(DATE_FORMAT.get().format(episode.getPublishDate()));
         }
         if (episode.getStatus() == PodcastStatus.COMPLETED && !isEmpty(episode.getMediaFileId())) {
             MediaFile song = mediaFileService.getMediaFileStrict(episode.getMediaFileId());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/theme/CustomThemeResolver.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/theme/CustomThemeResolver.java
@@ -43,7 +43,6 @@ public class CustomThemeResolver implements ThemeResolver {
 
     private final SecurityService securityService;
     private final SettingsService settingsService;
-    private final Object lock = new Object();
 
     private Set<String> themeIds;
 
@@ -105,10 +104,8 @@ public class CustomThemeResolver implements ThemeResolver {
      * @return Whether the theme with the given ID exists.
      */
     private boolean themeExists(String themeId) {
-        synchronized (lock) {
-            if (themeIds == null) {
-                themeIds = SettingsService.getAvailableThemes().stream().map(Theme::getId).collect(Collectors.toSet());
-            }
+        if (themeIds == null) {
+            themeIds = SettingsService.getAvailableThemes().stream().map(Theme::getId).collect(Collectors.toSet());
         }
         return themeIds.contains(themeId);
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/concurrent/ReadWriteLockSupport.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/util/concurrent/ReadWriteLockSupport.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.concurrent;
+
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.IntStream;
+
+/**
+ * ReadWriteLock privilege switching is supported.
+ */
+public interface ReadWriteLockSupport {
+
+    default void readLock(ReentrantReadWriteLock lock) {
+        lock.readLock().lock();
+    }
+
+    /**
+     * Completely release readLock
+     */
+    default void readUnlock(ReentrantReadWriteLock lock) {
+        IntStream.range(0, lock.getReadHoldCount()).forEach(i -> lock.readLock().unlock());
+    }
+
+    /**
+     * Promotion of readLock to writeLock. Interrupts on readLock#unlock and writeLock#lock are allowed.
+     */
+    default void writeLock(ReentrantReadWriteLock lock) {
+        readUnlock(lock);
+        lock.writeLock().lock();
+    }
+
+    default void writeUnlock(ReentrantReadWriteLock lock) {
+        lock.writeLock().unlock();
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/CoverArtControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/CoverArtControllerTest.java
@@ -36,10 +36,19 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
+import com.codahale.metrics.ConsoleReporter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 import com.tesshu.jpsonic.NeedsHome;
 import com.tesshu.jpsonic.controller.CoverArtController.AlbumCoverArtRequest;
 import com.tesshu.jpsonic.controller.CoverArtController.ArtistCoverArtRequest;
@@ -61,13 +70,16 @@ import com.tesshu.jpsonic.service.PodcastService;
 import com.tesshu.jpsonic.service.TranscodingService;
 import com.tesshu.jpsonic.service.metadata.FFmpeg;
 import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.exception.UncheckedException;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -490,4 +502,84 @@ class CoverArtControllerTest {
             assertEquals(changed.toEpochMilli(), request.lastModified());
         }
     }
+
+    @Nested
+    class GetImageCacheDirectoryTest {
+
+        private final CoverArtController controller = new CoverArtController(mediaFileService, null, null, null, null,
+                null, null);
+
+        @Test
+        void testGetImageCacheDirectory(@TempDir Path tmp) {
+            final String home = System.getProperty("jpsonic.home");
+            System.setProperty("jpsonic.home", tmp.toString());
+
+            Path path = controller.getImageCacheDirectory(150);
+            assertNotNull(path);
+
+            System.setProperty("jpsonic.home", home);
+        }
+
+        abstract class IntRunnable implements Callable<Path> {
+            int i;
+
+            public IntRunnable(int i) {
+                this.i = i;
+            }
+        }
+
+        @Test
+        @SuppressWarnings("PMD.UnusedLocalVariable")
+        void testLock() throws Exception {
+
+            int threadsCount = 1_000;
+
+            final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+            executor.setWaitForTasksToCompleteOnShutdown(true); // To handle Stream
+            executor.setAwaitTerminationMillis(1_000);
+            executor.setQueueCapacity(threadsCount);
+            executor.setCorePoolSize(threadsCount);
+            executor.setMaxPoolSize(threadsCount);
+            executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+            executor.setDaemon(true);
+            executor.initialize();
+
+            MetricRegistry metrics = new MetricRegistry();
+            List<Future<Path>> futures = new ArrayList<>();
+            Timer globalTimer = metrics
+                    .timer(MetricRegistry.name(FontLoaderTest.class, "SpeedOfGetImageCacheDirectory"));
+
+            for (int i = 0; i < threadsCount; i++) {
+                futures.add(executor.submit(new IntRunnable(i) {
+                    @Override
+                    public Path call() {
+                        Path path;
+                        try (Timer.Context globalTimerContext = globalTimer.time()) {
+                            path = controller.getImageCacheDirectory(i % 10);
+                        } catch (IllegalArgumentException e) {
+                            throw new UncheckedException(e);
+                        }
+                        return path;
+                    }
+                }));
+            }
+
+            assertEquals(threadsCount, futures.stream().mapToInt(future -> {
+                try {
+                    assertNotNull(future.get());
+                } catch (InterruptedException | ExecutionException e) {
+                    throw new UncheckedException(e);
+                }
+                return 1;
+            }).sum());
+            executor.shutdown();
+
+            ConsoleReporter.Builder builder = ConsoleReporter.forRegistry(metrics).convertRatesTo(TimeUnit.SECONDS)
+                    .convertDurationsTo(TimeUnit.MILLISECONDS);
+            try (ConsoleReporter reporter = builder.build()) {
+                // to be none
+            }
+        }
+    }
+
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/FontLoaderTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/FontLoaderTest.java
@@ -1,0 +1,128 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.controller;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.awt.Font;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import com.codahale.metrics.ConsoleReporter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import net.sf.ehcache.CacheManager;
+import org.apache.commons.lang3.exception.UncheckedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+class FontLoaderTest {
+
+    private CacheManager manager;
+    private FontLoader fontLoader;
+
+    @BeforeEach
+    public void setup() throws URISyntaxException {
+        Path path = Path.of(FontLoaderTest.class.getResource("/ehcache.xml").toURI());
+        manager = CacheManager.newInstance(path.toString());
+        fontLoader = new FontLoader(manager.getCache("fontCache"));
+    }
+
+    @AfterEach
+    public void tearDown() {
+        manager.shutdown();
+        System.clearProperty("jpsonic.embeddedfont");
+    }
+
+    @Test
+    void testGetDefaultFont() throws Exception {
+        assertNotNull(fontLoader.getFont(10));
+    }
+
+    @Test
+    void testGetDefaultFontFromCache() throws Exception {
+        assertNotNull(fontLoader.getFont(10));
+        assertNotNull(fontLoader.getFont(10));
+    }
+
+    @Test
+    void testGetEmbed() throws Exception {
+        System.setProperty("jpsonic.embeddedfont", "true");
+        assertNotNull(fontLoader.getFont(10));
+    }
+
+    @Test
+    @SuppressWarnings("PMD.UnusedLocalVariable")
+    void testLock() throws Exception {
+
+        int threadsCount = 1_000;
+
+        final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setWaitForTasksToCompleteOnShutdown(true); // To handle Stream
+        executor.setAwaitTerminationMillis(1_000);
+        executor.setQueueCapacity(threadsCount);
+        executor.setCorePoolSize(threadsCount);
+        executor.setMaxPoolSize(threadsCount);
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.setDaemon(true);
+        executor.initialize();
+
+        MetricRegistry metrics = new MetricRegistry();
+        List<Future<Font>> futures = new ArrayList<>();
+        Timer globalTimer = metrics.timer(MetricRegistry.name(FontLoaderTest.class, "SpeedOfFontRetrieval"));
+
+        for (int i = 0; i < threadsCount; i++) {
+            futures.add(executor.submit(() -> {
+                Font font;
+                try (Timer.Context globalTimerContext = globalTimer.time()) {
+                    font = fontLoader.getFont(10);
+                } catch (IllegalArgumentException e) {
+                    throw new UncheckedException(e);
+                }
+                return font;
+            }));
+        }
+
+        assertEquals(threadsCount, futures.stream().mapToInt(future -> {
+            try {
+                assertNotNull(future.get());
+            } catch (InterruptedException | ExecutionException e) {
+                throw new UncheckedException(e);
+            }
+            return 1;
+        }).sum());
+        executor.shutdown();
+
+        ConsoleReporter.Builder builder = ConsoleReporter.forRegistry(metrics).convertRatesTo(TimeUnit.SECONDS)
+                .convertDurationsTo(TimeUnit.MILLISECONDS);
+        try (ConsoleReporter reporter = builder.build()) {
+            // to be none
+        }
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
@@ -47,8 +47,10 @@ import com.tesshu.jpsonic.service.MediaScannerService;
 import com.tesshu.jpsonic.service.SearchService;
 import com.tesshu.jpsonic.service.SettingsService;
 import com.tesshu.jpsonic.util.FileUtil;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
@@ -60,9 +62,19 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.ObjectUtils;
 
-@SuppressWarnings({ "PMD.TooManyStaticImports", "PMD.AvoidDuplicateLiterals" })
+@SuppressWarnings({ "PMD.TooManyStaticImports", "PMD.AvoidDuplicateLiterals", "PMD.UseUtilityClass" })
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class IndexManagerTest {
+
+    @BeforeAll
+    public static void setUpOnce() throws InterruptedException {
+        SettingsService.setDevelopmentMode(true);
+    }
+
+    @AfterAll
+    public static void tearDownOnce() throws InterruptedException {
+        SettingsService.setDevelopmentMode(false);
+    }
 
     @Nested
     class UnitTest {

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/LegacyHsqlUtilTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/LegacyHsqlUtilTest.java
@@ -24,12 +24,25 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import ch.qos.logback.classic.Level;
 import com.tesshu.jpsonic.TestCaseUtils;
+import com.tesshu.jpsonic.service.SettingsService;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class LegacyHsqlUtilTest {
+
+    @BeforeAll
+    public static void setUpOnce() throws InterruptedException {
+        SettingsService.setDevelopmentMode(true);
+    }
+
+    @AfterAll
+    public static void tearDownOnce() throws InterruptedException {
+        SettingsService.setDevelopmentMode(false);
+    }
 
     @BeforeEach
     public void setup() {

--- a/jpsonic-main/src/test/resources/ehcache.xml
+++ b/jpsonic-main/src/test/resources/ehcache.xml
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+CacheManager Configuration
+==========================
+An ehcache.xml corresponds to a single CacheManager.
+
+See instructions below or the ehcache schema (ehcache.xsd) on how to configure.
+
+System property tokens can be specified in this file which are replaced when the configuration
+is loaded. For example multicastGroupPort=${multicastGroupPort} can be replaced with the
+System property either from an environment variable or a system property specified with a
+command line switch such as -DmulticastGroupPort=4446. Another example, useful for Terracotta
+server based deployments is <terracottaConfig url="${serverAndPort}"/ and specify a command line
+switch of -Dserver36:9510
+
+The attributes of <ehcache> are:
+* name - an optional name for the CacheManager.  The name is optional and primarily used
+for documentation or to distinguish Terracotta clustered cache state.  With Terracotta
+clustered caches, a combination of CacheManager name and cache name uniquely identify a
+particular cache store in the Terracotta clustered memory.
+* updateCheck - an optional boolean flag specifying whether this CacheManager should check
+for new versions of Ehcache over the Internet.  If not specified, updateCheck="true".
+* dynamicConfig - an optional setting that can be used to disable dynamic configuration of caches
+associated with this CacheManager.  By default this is set to true - i.e. dynamic configuration
+is enabled.  Dynamically configurable caches can have their TTI, TTL and maximum disk and
+in-memory capacity changed at runtime through the cache's configuration object.
+* monitoring - an optional setting that determines whether the CacheManager should
+automatically register the SampledCacheMBean with the system MBean server.
+
+Currently, this monitoring is only useful when using Terracotta clustering and using the
+Terracotta Developer Console. With the "autodetect" value, the presence of Terracotta clustering
+will be detected and monitoring, via the Developer Console, will be enabled. Other allowed values
+are "on" and "off".  The default is "autodetect". This setting does not perform any function when
+used with JMX monitors.
+-->
+<ehcache xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://ehcache.sourceforge.net/ehcache.xsd"
+         updateCheck="false"
+         monitoring="off"
+         dynamicConfig="true">
+
+    <!--
+    DiskStore configuration
+    =======================
+
+    The diskStore element is optional. To turn off disk store path creation, comment out the diskStore
+    element below.
+
+    Configure it if you have overflowToDisk or diskPersistent enabled for any cache.
+
+    If it is not configured, and a cache is created which requires a disk store, a warning will be
+     issued and java.io.tmpdir will automatically be used.
+
+    diskStore has only one attribute - "path". It is the path to the directory where
+    .data and .index files will be created.
+
+    If the path is one of the following Java System Property it is replaced by its value in the
+    running VM. For backward compatibility these should be specified without being enclosed in the ${token}
+    replacement syntax.
+
+    The following properties are translated:
+    * user.home - User's home directory
+    * user.dir - User's current working directory
+    * java.io.tmpdir - Default temp file path
+    * ehcache.disk.store.dir - A system property you would normally specify on the command line
+      e.g. java -Dehcache.disk.store.dir=/u01/myapp/diskdir ...
+
+    Subdirectories can be specified below the property e.g. java.io.tmpdir/one
+
+    -->
+    <!-- NOTE: The path is overridden in CacheFactory -->
+    <diskStore path="java.io.tmpdir"/>
+
+
+    <!-- Uncomment this to enable cache monitoring. -->
+    <!--<cacheManagerPeerListenerFactory-->
+            <!--class="org.terracotta.ehcachedx.monitor.probe.ProbePeerListenerFactory"-->
+            <!--properties="monitorAddress=localhost, monitorPort=9889, memoryMeasurement=true" />-->
+    <!---->
+
+    <!--
+    Cache configuration
+    ===================
+
+    The following attributes are required.
+
+    name:
+    Sets the name of the cache. This is used to identify the cache. It must be unique.
+
+    maxElementsInMemory:
+    Sets the maximum number of objects that will be created in memory.  0 = no limit.
+    In practice no limit means Integer.MAX_SIZE (2147483647) unless the cache is distributed
+    with a Terracotta server in which case it is limited by resources.
+
+    maxElementsOnDisk:
+    Sets the maximum number of objects that will be maintained in the DiskStore
+    The default value is zero, meaning unlimited.
+
+    eternal:
+    Sets whether elements are eternal. If eternal,  timeouts are ignored and the
+    element is never expired.
+
+    overflowToDisk:
+    Sets whether elements can overflow to disk when the memory store
+    has reached the maxInMemory limit.
+
+    The following attributes and elements are optional.
+
+    overflowToOffHeap:
+    (boolean) This feature is available only in enterprise versions of Ehcache.
+    When set to true, enables the cache to utilize off-heap memory
+    storage to improve performance. Off-heap memory is not subject to Java
+    GC. The default value is false.
+
+    maxMemoryOffHeap:
+    (string) This feature is available only in enterprise versions of Ehcache.
+    Sets the amount of off-heap memory available to the cache.
+    This attribute's values are given as <number>k|K|m|M|g|G|t|T for
+    kilobytes (k|K), megabytes (m|M), gigabytes (g|G), or terabytes
+    (t|T). For example, maxMemoryOffHeap="2g" allots 2 gigabytes to
+    off-heap memory.
+
+    This setting is in effect only if overflowToOffHeap is true.
+
+    Note that it is recommended to set maxElementsInMemory to at least 100 elements
+    when using an off-heap store, otherwise performance will be seriously degraded,
+    and a warning will be logged.
+
+    The minimum amount that can be allocated is 128MB. There is no maximum.
+
+    timeToIdleSeconds:
+    Sets the time to idle for an element before it expires.
+    i.e. The maximum amount of time between accesses before an element expires
+    Is only used if the element is not eternal.
+    Optional attribute. A value of 0 means that an Element can idle for infinity.
+    The default value is 0.
+
+    timeToLiveSeconds:
+    Sets the time to live for an element before it expires.
+    i.e. The maximum time between creation time and when an element expires.
+    Is only used if the element is not eternal.
+    Optional attribute. A value of 0 means that and Element can live for infinity.
+    The default value is 0.
+
+    diskPersistent:
+    Whether the disk store persists between restarts of the Virtual Machine.
+    The default value is false.
+
+    diskExpiryThreadIntervalSeconds:
+    The number of seconds between runs of the disk expiry thread. The default value
+    is 120 seconds.
+
+    diskSpoolBufferSizeMB:
+    This is the size to allocate the DiskStore for a spool buffer. Writes are made
+    to this area and then asynchronously written to disk. The default size is 30MB.
+    Each spool buffer is used only by its cache. If you get OutOfMemory errors consider
+    lowering this value. To improve DiskStore performance consider increasing it. Trace level
+    logging in the DiskStore will show if put back ups are occurring.
+
+    clearOnFlush:
+    whether the MemoryStore should be cleared when flush() is called on the cache.
+    By default, this is true i.e. the MemoryStore is cleared.
+
+    statistics:
+    Whether to collect statistics. Note that this should be turned on if you are using
+    the Ehcache Monitor. By default statistics is turned off to favour raw performance.
+    To enable set statistics="true"
+
+    memoryStoreEvictionPolicy:
+    Policy would be enforced upon reaching the maxElementsInMemory limit. Default
+    policy is Least Recently Used (specified as LRU). Other policies available -
+    First In First Out (specified as FIFO) and Less Frequently Used
+    (specified as LFU)
+
+    copyOnRead:
+    Whether an Element is copied when being read from a cache.
+    By default this is false.
+
+    copyOnWrite:
+    Whether an Element is copied when being added to the cache.
+    By default this is false.
+    -->
+
+
+    <!--
+    Default Cache configuration. These settings will be applied to caches
+    created programmatically using CacheManager.add(String cacheName).
+    This element is optional, and using CacheManager.add(String cacheName) when
+    its not present will throw CacheException
+
+    The defaultCache has an implicit name "default" which is a reserved cache name.
+
+    <defaultCache
+            maxElementsInMemory="10000"
+            eternal="false"
+            timeToIdleSeconds="120"
+            timeToLiveSeconds="120"
+            overflowToDisk="true"
+            diskSpoolBufferSizeMB="10"
+            maxElementsOnDisk="10000000"
+            diskPersistent="false"
+            diskExpiryThreadIntervalSeconds="120"
+            memoryStoreEvictionPolicy="LRU"
+            statistics="true"
+            />
+    -->
+
+    <cache name="mediaFileMemoryCache"
+           maxElementsInMemory="1000"
+           eternal="false"
+           timeToIdleSeconds="0"
+           timeToLiveSeconds="10"
+           overflowToDisk="false"
+           statistics="true"/>
+
+    <cache name="searchCache"
+           maxElementsInMemory="30"
+           eternal="false"
+           timeToLiveSeconds="10"
+           overflowToDisk="false"
+           statistics="false"/>
+
+    <cache name="randomCache"
+           maxElementsInMemory="2"
+           eternal="false"
+           timeToLiveSeconds="2"
+           overflowToDisk="false"
+           statistics="false"/>
+
+    <cache name="fontCache"
+           maxElementsInMemory="10"
+           eternal="false"
+           timeToIdleSeconds="60"
+           timeToLiveSeconds="60"
+           overflowToDisk="false"
+           statistics="false"/>
+
+    <!--
+    Sample caches. Following are some example caches. Remove these before use.
+    -->
+
+    <!--
+    Sample cache named sampleCache1
+    This cache contains a maximum in memory of 10000 elements, and will expire
+    an element if it is idle for more than 5 minutes and lives for more than
+    10 minutes.
+
+    If there are more than 10000 elements it will overflow to the
+    disk cache, which in this configuration will go to wherever java.io.tmp is
+    defined on your system. On a standard Linux system this will be /tmp"
+
+    <cache name="sampleCache1"
+           maxElementsInMemory="10000"
+           maxElementsOnDisk="1000"
+           eternal="false"
+           overflowToDisk="true"
+           diskSpoolBufferSizeMB="20"
+           timeToIdleSeconds="300"
+           timeToLiveSeconds="600"
+           memoryStoreEvictionPolicy="LFU"
+           transactionalMode="off"
+            />
+    -->
+
+
+    <!--
+    Sample cache named sampleCache2
+    This cache has a maximum of 1000 elements in memory. There is no overflow to disk, so 1000
+    is also the maximum cache size. Note that when a cache is eternal, timeToLive and
+    timeToIdle are not used and do not need to be specified.
+
+    <cache name="sampleCache2"
+           maxElementsInMemory="1000"
+           eternal="true"
+           overflowToDisk="false"
+           memoryStoreEvictionPolicy="FIFO"
+            />
+    -->
+
+
+    <!--
+    Sample cache named sampleCache3. This cache overflows to disk. The disk store is
+    persistent between cache and VM restarts. The disk expiry thread interval is set to 10
+    minutes, overriding the default of 2 minutes.
+
+    <cache name="sampleCache3"
+           maxElementsInMemory="500"
+           eternal="false"
+           overflowToDisk="true"
+           timeToIdleSeconds="300"
+           timeToLiveSeconds="600"
+           diskPersistent="true"
+           diskExpiryThreadIntervalSeconds="1"
+           memoryStoreEvictionPolicy="LFU"
+            />
+    -->
+
+</ehcache>


### PR DESCRIPTION
Prerequisites: #2558

## Overview

The synchronized codings will be removed and replaced with concurrent Lock classes. 

This is part of complying with [Practical Advice for Virtual Threads](https://docs.oracle.com/en/java/javase/20/core/virtual-threads.html#GUID-9065C2D5-9006-4F1A-93E0-D5153BB40475). 

## Goal

synchronize will be replaced by ReentrantLock or ReentrantReadWriteLock. 

## Non-Goal

 - In particular, it does not include thread modifications.
 - Only changes to CoverArtController are not included in this pull request. CoverArtController has Semaphores intentionally killed. This is because there was a problem with the synchronization process. Currently, Jpsonic should be free from glitches such as black images, incorrect images, and updates not being reflected, in exchange for image processing being single-threaded. CoverArtController will be refactored in a subsequent pull request.

## Details

It will be mainly divided into three groups. These will be "squash" after review

- Remove unnecessary synchronized
- Migrate to ReentrantLock
- Migrate to ReentrantReadWriteLock

Jpsonic's synchronized code has the following history.

- Eliminating synchronized methods
  - They have been replaced by synchronized blocks using object locks. There was a lot of misuse of synchronized methods, and some of them didn't make sense.
- Scrutiny by Facebook Infer
  - A tool called RacerD is excellent. Since I set these to no errors once, I think that many fatal problems have been avoided.

However, the points pointed out by the tool were corrected very mechanically. (Unnecessary synchronized or misunderstood codes cannot be detected, and new ones are sometimes created.) This time, unnecessary synchronized files are deleted manually.




