### PR TITLE
Add JMX Options to production.synology.yml

### DIFF
--- a/install/docker/production.synology.yml
+++ b/install/docker/production.synology.yml
@@ -5,7 +5,7 @@
 # usage: 
 #   docker-compose -f production.synology.yml up -d
 #
-# @since v114.0.0
+# @since 114.0.0.alpha.2.1
 #
 
 services:
@@ -83,6 +83,8 @@ services:
      # Jpsonic context path.
      CONTEXT_PATH: '/'
 
+     # Advanced Options ###############################################
+
      # Whether to log the logo at startup. [OFF|CONSOLE|LOG]
      #
      #BANNER_MODE: 'OFF'
@@ -104,6 +106,24 @@ services:
      #
      #MIME_DSF: 'audio/x-dsd'
      #MIME_DFF: 'audio/x-dsd'
+
+     #　Option example when using JMX. The "ea" tag image is required to use JMX.
+     #　Note that port 3333 is free on "ea" !!
+     #　For VisualVM, you need to specify the port in File-Add JMX Connection.
+     #　e.g. localhost:3333
+     #
+     #JAVA_OPTS: >
+     #  -Xms512m
+     #  -Xmx512m
+     #  -XX:+UseG1GC
+     #  -XX:MaxGCPauseMillis=500
+     #  -Dcom.sun.management.jmxremote=true
+     #  -Dcom.sun.management.jmxremote.port=3333
+     #  -Dcom.sun.management.jmxremote.rmi.port=3333
+     #  -Dcom.sun.management.jmxremote.local.only=false
+     #  -Dcom.sun.management.jmxremote.ssl=false
+     #  -Dcom.sun.management.jmxremote.authenticate=false
+     #  -Djava.rmi.server.hostname=SynologyNAS
 
      # It is possible to override some of the UPnP server parameters.
      # https://docs.oracle.com/en/java/javase/21/docs/api/jdk.httpserver/module-summary.html


### PR DESCRIPTION
## Overview

A document will be added that explains how to connect JMX. Docker images with ea tags have free ports for JMX, so you can easily observe memory and CPU.

## TODO

 - [x] Add example connection options to production.synology.yml
   - It was previously listed, but was temporarily removed because it was too complicated.
   -  Some users may be interested in Profile since JVM functions have changed in various ways since Java 21.
 - [x] Add explanation page to Wiki
   - [About Docker Images](https://github.com/jpsonic/jpsonic/wiki/About-Docker-Images)