### PR TITLE
Fix that coverArt cache creation can be processed in parallel

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/CoverArtController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/CoverArtController.java
@@ -35,14 +35,15 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.imageio.ImageIO;
 
@@ -66,7 +67,6 @@ import com.tesshu.jpsonic.spring.LoggingExceptionResolver;
 import com.tesshu.jpsonic.util.FileUtil;
 import com.tesshu.jpsonic.util.StringUtil;
 import com.tesshu.jpsonic.util.concurrent.ConcurrentUtils;
-import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -94,8 +94,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class CoverArtController implements CoverArtPresentation {
 
     private static final Logger LOG = LoggerFactory.getLogger(CoverArtController.class);
-    private static final int COVER_ART_CONCURRENCY = 4;
-    private static final Map<String, Object> IMG_LOCKS = new ConcurrentHashMap<>();
 
     private final MediaFileService mediaFileService;
     private final FFmpeg ffmpeg;
@@ -105,7 +103,10 @@ public class CoverArtController implements CoverArtPresentation {
     private final AlbumDao albumDao;
     private final FontLoader fontLoader;
 
-    private Semaphore semaphore;
+    private static final int COVER_ART_CONCURRENCY = 4;
+    private final Semaphore semaphore = new Semaphore(COVER_ART_CONCURRENCY);
+    private final List<Path> writingCache = Collections.synchronizedList(new ArrayList<>());
+    private final ReentrantLock writingCacheLock = new ReentrantLock();
 
     public CoverArtController(MediaFileService mediaFileService, FFmpeg ffmpeg, PlaylistService playlistService,
             PodcastService podcastService, ArtistDao artistDao, AlbumDao albumDao, FontLoader fontLoader) {
@@ -117,11 +118,6 @@ public class CoverArtController implements CoverArtPresentation {
         this.artistDao = artistDao;
         this.albumDao = albumDao;
         this.fontLoader = fontLoader;
-    }
-
-    @PostConstruct
-    public void init() {
-        semaphore = new Semaphore(COVER_ART_CONCURRENCY);
     }
 
     private static void warnLog(String msg, Throwable t) {
@@ -278,36 +274,90 @@ public class CoverArtController implements CoverArtPresentation {
         }
     }
 
+    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops") // false positive
+    private void waitWriting(Path path) throws ExecutionException {
+        int waitingTime = 0;
+        while (writingCache.contains(path)) {
+            try {
+                TimeUnit.MILLISECONDS.sleep(200);
+            } catch (InterruptedException e) {
+                throw new ExecutionException(e);
+            }
+            waitingTime += 200;
+            if (waitingTime > 5_000) {
+                throw new ExecutionException(new InterruptedException("Coverart cache write wait exceeded 5 seconds"));
+            }
+        }
+    }
+
+    private boolean isCacheExist(Path cache, long lastModified) {
+        try {
+            if (Files.exists(cache) && lastModified <= Files.getLastModifiedTime(cache).toMillis()) {
+                return true;
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return false;
+    }
+
+    private boolean tryCacheWriting(Path cache) {
+        writingCacheLock.lock();
+        try {
+            if (writingCache.contains(cache)) {
+                return true;
+            }
+            writingCache.add(cache);
+            return false;
+        } finally {
+            writingCacheLock.unlock();
+        }
+    }
+
+    private void releaseCacheWriting(Path cache) {
+        writingCacheLock.lock();
+        try {
+            writingCache.remove(cache);
+        } finally {
+            writingCacheLock.unlock();
+        }
+    }
+
     @SuppressFBWarnings(value = "WEAK_MESSAGE_DIGEST_MD5", justification = "It has nothing to do with security. The chances of a collision are also low enough")
     private Path getCachedImage(CoverArtRequest request, int size) throws ExecutionException {
         String encoding = request.getCoverArt() == null ? "png" : "jpeg";
-        Path cachedImage = Path.of(getImageCacheDirectory(size).toString(),
+        Path cache = Path.of(getImageCacheDirectory(size).toString(),
                 DigestUtils.md5Hex(request.getKey()) + "." + encoding);
-        String lockKey = cachedImage.toString();
 
-        Object lock = new Object();
-        IMG_LOCKS.putIfAbsent(lockKey, lock);
-
-        synchronized (IMG_LOCKS.get(lockKey)) {
-            try {
-                if (IMG_LOCKS.get(lockKey) != null && IMG_LOCKS.get(lockKey).equals(lock) && (!Files.exists(cachedImage)
-                        || request.lastModified() > Files.getLastModifiedTime(cachedImage).toMillis())) {
-                    try (OutputStream out = Files.newOutputStream(cachedImage)) {
-                        semaphore.acquire();
-                        BufferedImage image = request.createImage(size);
-                        ImageIO.write(image, encoding, out);
-                    } catch (InterruptedException | IOException e) {
-                        FileUtil.deleteIfExists(cachedImage);
-                    } finally {
-                        semaphore.release();
-                        IMG_LOCKS.remove(lockKey, lock);
-                    }
-                }
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-            return cachedImage;
+        // Use cache if enabled
+        if (isCacheExist(cache, request.lastModified())) {
+            return cache;
         }
+
+        // Wait if writing is already in progress
+        if (tryCacheWriting(cache)) {
+            waitWriting(cache);
+            // Use cache if enabled (It was created while I was waiting.)
+            if (isCacheExist(cache, request.lastModified())) {
+                return cache;
+            }
+        }
+
+        // Create cache if it does not exist
+        try {
+            // However, the number of simultaneous writes will be limited.
+            semaphore.acquire();
+            try (OutputStream out = Files.newOutputStream(cache)) {
+                BufferedImage image = request.createImage(size);
+                ImageIO.write(image, encoding, out);
+            }
+        } catch (InterruptedException | IOException e) {
+            FileUtil.deleteIfExists(cache);
+        } finally {
+            semaphore.release();
+            releaseCacheWriting(cache);
+        }
+        return cache;
     }
 
     /**

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/CoverArtControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/CoverArtControllerTest.java
@@ -110,7 +110,6 @@ class CoverArtControllerTest {
         fontLoader = mock(FontLoader.class);
         controller = new CoverArtController(mediaFileService, ffmpeg, playlistService, mock(PodcastService.class),
                 mock(ArtistDao.class), mock(AlbumDao.class), fontLoader);
-        controller.init();
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
     }
 


### PR DESCRIPTION
Prerequisites: #2558, #2564 (Separated from #2564 due to code fix)

## Overview

Cover art caching will be fixed to allow parallel processing. And, this pull request will wipe out `synchronized` keyword from Jpsonic.

## Details

Initially, Airsonic allowed up to four cover art caches to be created simultaneously. However, the only guarantee is that four simultaneous operations are possible. There is no guarantee that they are the same or different images. If an error occurs as a result of concentrated cashe create process to the same image, there is a case where the image falls back to a dummy image (assuming error handling can be done correctly). This is a problem with low reproducibility and is very difficult to understand, but in order to avoid this, Jpsonic avoided creating cache at the same time.

I think there are some requests on cover art... but this bug was effectively a blocker. 

## Goal

 - If you delete the "thumbs" directory that exists directly under the data directory and retrieve it again using Ctrl+F5 in your browser, it will display very smoothly, then that is a success example.
 - When displaying a view that displays the same images all at once (like a view that displays image icons for each song in an album) with Subsonic Apps or DLNA Apps...
   - It will be successful if the image can be displayed correctly and quickly from a state where the cache has not yet been created.

