### PR TITLE
Fix the scope of jstl

### DIFF
--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -188,12 +188,10 @@
     <dependency>
       <groupId>jakarta.servlet.jsp.jstl</groupId>
       <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.web</groupId>
       <artifactId>jakarta.servlet.jsp.jstl</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
#### Overview

jstl scope will be modified from `provided` to `compile`. This will allow you to deploy war files on Tomcat running as App Sever.

#### Details

This is due to the convenience of Servlet6.0 library deployment.

Jpsonic is deployed using Jetty as an App Server, and the created war files are distributed and Docker images are created. However, the standalone embedded server used supports Tomcat as well as Jetty.

e.g. [packaging](https://github.com/jpsonic/jpsonic/wiki/Package)

Also, the created war file can be deployed to Jetty/Tomcat. If anything, this may be a mechanism that makes it difficult for users to understand the benefits. There will be advantages such as:

 - Being able to operate on two servers means that no implementation depends on features specific to either App Server. In other words, it is proof that it is more versatile.
 - Development convenience. Tomcat is easy to set up an environment, so it is easy to use during development. For example, when developing on Windows. On the other hand, during production, Jetty is a more advantageous configuration because it often operates at high speed.
   - Airsonic used Tomcat, but to compensate for its slow speed, a precompiler was used. The true nature of this pre-compiler is a reused part of Jetty's Lib. The problem is that precompiler updates are slow. There was a case where a security patch applied to the original Jetty was introduced more than half a year later.
 - Currently Jetty is the main choice, but of course you can try a better server in the future if it comes out. Alternatively, although unlikely, if either Jetty or Tomcat were to end development, the damage would be minimal. That's the benefit of avoiding vendor lock-in. Proprietary software may also include such requirements in the OS/application server/DB.

