### PR TITLE
Fix initialization of AuthenticationManager

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/Application.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/Application.java
@@ -62,8 +62,7 @@ import org.springframework.util.ReflectionUtils;
 
 @SpringBootApplication(exclude = { JmxAutoConfiguration.class, JdbcTemplateAutoConfiguration.class,
         DataSourceAutoConfiguration.class, DataSourceTransactionManagerAutoConfiguration.class,
-        MultipartAutoConfiguration.class,
-        LiquibaseAutoConfiguration.class }, scanBasePackages = { "com.tesshu.jpsonic", "com.tesshu.jpsonic" })
+        MultipartAutoConfiguration.class, LiquibaseAutoConfiguration.class }, scanBasePackages = "com.tesshu.jpsonic")
 @EnableScheduling
 public class Application extends SpringBootServletInitializer
         implements WebServerFactoryCustomizer<ConfigurableServletWebServerFactory> {

--- a/jpsonic-main/src/main/resources/application.properties
+++ b/jpsonic-main/src/main/resources/application.properties
@@ -1,8 +1,4 @@
 
-spring.main.allow-circular-references: true
-#logging.level.org.springframework.security: TRACE
-
-#spring.threads.virtual.enabled: true
 server.error.includeStacktrace: ALWAYS
 server.max-http-request-header-size: 65536
 server.shutdown: graceful

--- a/jpsonic-main/src/test/resources/application.properties
+++ b/jpsonic-main/src/test/resources/application.properties
@@ -1,8 +1,4 @@
 
-spring.main.allow-circular-references: true
-#logging.level.org.springframework.security: TRACE
-
-#spring.threads.virtual.enabled: true
 server.error.includeStacktrace: ALWAYS
 server.max-http-request-header-size: 65536
 server.shutdown: graceful


### PR DESCRIPTION
## Overview

Security settings will be rewritten. All circular references in Spring beans that have existed since Airsonic are resolved at this point.


## Probrems

Currently, `org.springframework.security.config.annotation.web.builders.HttpSecurity#getSharedObject` is used to obtain an instance of authenticationManager in SecurityFilterChain. This is a temporary measure. This Commit will solve this problem.

Since the SpringSecurity configuration has undergone a major change, it has been migrated little by little in order to avoid large differences as much as possible. What has a relatively large impact is the elimination of inheritance for WebSecurityConfigurerAdapter. We can easily disguise this with sharedObject. However, in that case a circular reference would occur. (Well, Spring doesn't specifically claim that the previous configuration doesn't have any bad dependencies. Circular reference checking was enabled by default in Spring Boot in late 2.7.x, when there was a major update to Spring Security. In Jpsonic, their checks had been suppressed due to circular-reference issue.)

## Goal

 - AuthenticationManager initialization will be tidied up, and HttpSecurity#getSharedObject will be fixed from being used
 - spring.main.allow-circular-references will be removed from environment variables (properties).
 - It will be confirmed that the test case using Spring Security works in JUnit.
   - With current Spring Boot, it is possible to have a configuration that compiles and executes but does not work with JUnit 😨

## Non-Goal

 - It has been rewritten to roughly follow the processing order, but there are no configuration changes other than AuthenticationManager and getSharedObject.
 - For example, there are currently no plans to introduce AuthenticationManagerProvider. So far, the security configuration related to functionality has hardly changed since Subsonic. (Although everything else has been strengthened)

