### PR TITLE
Mark features scheduled for removal as Deprecated

### DIFF
--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/generalSettings.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/generalSettings.jsp
@@ -216,19 +216,19 @@ function resetExtension() {
         </c:if>
 
         <dl>
-            <dt></dt>
+            <dt><strong>Deprecated. Will be removed.</strong></dt>
             <dd>
                 <form:checkbox path="showServerLog" id="showServerLog"/>
                 <label for="showServerLog"><fmt:message key="generalsettings.showserverlog"/></label>
                 <c:import url="helpToolTip.jsp"><c:param name="topic" value="showserverlog"/></c:import>
             </dd>
-            <dt></dt>
+            <dt><strong>Deprecated. Will be removed.</strong></dt>
             <dd>
                 <form:checkbox path="showStatus" id="showStatus"/>
                 <label for="showStatus"><fmt:message key="generalsettings.showstatus"/></label>
                 <c:import url="helpToolTip.jsp"><c:param name="topic" value="showstatus"/></c:import>
             </dd>
-            <dt></dt>
+            <dt><strong>Deprecated. Will be removed.</strong></dt>
             <dd>
                 <form:checkbox path="othersPlayingEnabled" id="othersPlayingEnabled"/>
                 <label for="othersPlayingEnabled"><fmt:message key="generalsettings.othersplayingenabled"/></label>
@@ -240,7 +240,7 @@ function resetExtension() {
                 <label for="showRememberMe"><fmt:message key="generalsettings.showrememberme"/></label>
                 <c:import url="helpToolTip.jsp"><c:param name="topic" value="showrememberme"/></c:import>
             </dd>
-            <dt></dt>
+            <dt><strong>Deprecated. Will be removed.</strong></dt>
             <dd>
                 <form:checkbox path="publishPodcast" id="publishPodcast"/>
                 <label for="publishPodcast"><fmt:message key="generalsettings.publishpodcast"/></label>
@@ -252,13 +252,13 @@ function resetExtension() {
                 <label for="useRadio"><fmt:message key="generalsettings.useradio"/></label>
                 <c:import url="helpToolTip.jsp"><c:param name="topic" value="useradio"/></c:import>
             </dd>
-            <dt></dt>
+            <dt><strong>Deprecated. Will be removed.</strong></dt>
             <dd>
                 <form:checkbox path="useExternalPlayer" id="useExternalPlayer"/>
                 <label for="useExternalPlayer"><fmt:message key="generalsettings.useexternalplayer"/></label>
                 <c:import url="helpToolTip.jsp"><c:param name="topic" value="useexternalplayer"/></c:import>
             </dd>
-            <dt></dt>
+            <dt><strong>Deprecated. Will be removed.</strong></dt>
             <dd>
                 <form:checkbox path="useCopyOfAsciiUnprintable" id="useCopyOfAsciiUnprintable"/>
                 <label for="useCopyOfAsciiUnprintable"><fmt:message key="generalsettings.usecopyofasciiunprintable"/></label>
@@ -270,19 +270,19 @@ function resetExtension() {
                 <label for="useJsonp"><fmt:message key="generalsettings.usejsonp"/></label>
                 <c:import url="helpToolTip.jsp"><c:param name="topic" value="usejsonp"/></c:import>
             </dd>
-            <dt></dt>
+            <dt><strong>Deprecated. Will be removed.</strong></dt>
             <dd>
                 <form:checkbox path="useRemovingTrackFromId3Title" id="useRemovingTrackFromId3Title" disabled="${command.scanning}"/>
                 <label for="useRemovingTrackFromId3Title"><fmt:message key="generalsettings.useremovingtrackfromid3title"/></label>
                 <c:import url="helpToolTip.jsp"><c:param name="topic" value="useremovingtrackfromid3title"/></c:import>
             </dd>
-            <dt></dt>
+            <dt><strong>Deprecated. Will be removed.</strong></dt>
             <dd>
                 <form:checkbox path="useCleanUp" id="useCleanUp" disabled="${command.scanning}"/>
                 <label for="useCleanUp"><fmt:message key="generalsettings.usecleanup"/></label>
                 <c:import url="helpToolTip.jsp"><c:param name="topic" value="usecleanup"/></c:import>
             </dd>
-            <dt></dt>
+            <dt><strong>Deprecated. Will be removed.</strong></dt>
             <dd>
                 <form:checkbox path="redundantFolderCheck" id="redundantFolderCheck" disabled="${command.scanning}"/>
                 <label for="redundantFolderCheck"><fmt:message key="generalsettings.redundantfoldercheck"/></label>


### PR DESCRIPTION
## Overview

Some suppressed features will be removed completely. This corresponds to a de facto specification change. However, these do not affect the Subsonic API.

![image](https://github.com/tesshucom/jpsonic/assets/27724847/065898c6-aca4-470c-98cd-1d9a054773b5)

## Details

At Jpsonic, we carefully examine the implementation and suppress or delete functions that are not necessarily of sufficient quality, are less necessary, or are not good. (They will be summarized in the wiki in the future.)

This time, we are removing features that have already been suppressed but are likely to be completely unnecessary. These will be removed at some point in v114.x.

Some users seem to have a tendency to object to removing features from OSS Product. However, leaving unsuitable functions and not doing any maintenance is even worse. Not all implementations may be of perfect quality, and of course there may be misunderstandings or outdated ones. The implementations there were previously created by a limited number of people who were there. If it prevents better maintenance, it may be more appropriate to remove it.