### PR TITLE
Fix unlock bug

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SettingsService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SettingsService.java
@@ -721,7 +721,7 @@ public class SettingsService implements ReadWriteLockSupport {
         try {
             return getString(SettingsConstants.General.Extension.VIDEO_FILE_TYPES);
         } finally {
-            readUnlock(musicFileTypesLock);
+            readUnlock(videoFileTypesLock);
         }
     }
 


### PR DESCRIPTION

## Problem description

 - Cannot save on the General Settings page.
   - This only affects this settings page.
   - Browsing is possible.
 - After trying Save and clicking, we may not be able to view it.
   - Can't recover without restarting


### Steps to reproduce

1. Click the Save button on the General Settings page

## System information

 * **Jpsonic version**: v114.0.0

## Additional notes

The cause of the flaw is in SettingsService#getVideoFileTypes(). Lock not released correctly.


