### PR TITLE
Fix bug that the random maximum value of UPnP could not be set

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/DLNASettingsCommand.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/DLNASettingsCommand.java
@@ -53,7 +53,7 @@ public class DLNASettingsCommand extends SettingsPageCommons {
 
     // Display options / Access control
     private boolean dlnaGenreCountVisible;
-    private int dlnaRandomMax;
+    private Integer dlnaRandomMax;
     private boolean dlnaGuestPublish;
 
     public boolean isDlnaEnabled() {
@@ -180,11 +180,11 @@ public class DLNASettingsCommand extends SettingsPageCommons {
         this.dlnaGenreCountVisible = dlnaGenreCountVisible;
     }
 
-    public int getDlnaRandomMax() {
+    public Integer getDlnaRandomMax() {
         return dlnaRandomMax;
     }
 
-    public void setDlnaRandomMax(int dlnaRandomMax) {
+    public void setDlnaRandomMax(Integer dlnaRandomMax) {
         this.dlnaRandomMax = dlnaRandomMax;
     }
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DLNASettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DLNASettingsController.java
@@ -27,6 +27,7 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -72,6 +73,9 @@ import org.springframework.web.servlet.view.RedirectView;
 @Controller
 @RequestMapping({ "/dlnaSettings", "/dlnaSettings.view" })
 public class DLNASettingsController {
+
+    private static final int DLNA_RANDOM_DEFAULT = 50;
+    private static final int DLNA_RANDOM_LIMIT = 1999;
 
     private final SettingsService settingsService;
     private final MusicFolderService musicFolderService;
@@ -193,6 +197,9 @@ public class DLNASettingsController {
                 .collect(Collectors.toList());
         settingsService.setDlnaGenreCountVisible(command.isDlnaGenreCountVisible() && allIds.equals(allowedIds));
         settingsService.setDlnaGuestPublish(command.isDlnaGuestPublish());
+        int randomMax = Objects.isNull(command.getDlnaRandomMax()) || command.getDlnaRandomMax() == 0
+                ? DLNA_RANDOM_DEFAULT : command.getDlnaRandomMax();
+        settingsService.setDlnaRandomMax(Math.min(randomMax, DLNA_RANDOM_LIMIT));
 
         settingsService.save();
 

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/dlnaSettings.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/dlnaSettings.jsp
@@ -301,7 +301,7 @@
                                 <c:when test="${subMenuItem.parent eq MenuItemId.SHUFFLE}">
                                     <td rowspan="${rowInfo.count()}" class="${ifDisabled}">
                                         <label for="dlnaRandomMax"><fmt:message key="dlnasettings.randommax"/></label>
-                                        <form:input path="dlnaRandomMax" id="dlnaRandomMax" maxlength="4"/>
+                                        <form:input type="text" inputmode="numeric" path="dlnaRandomMax" id="dlnaRandomMax" maxlength="4"/>
                                     </td>
                                 </c:when>
                                 <c:when test="${subMenuItem.parent eq MenuItemId.PLAYLISTS}">

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DLNASettingsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DLNASettingsControllerTest.java
@@ -275,6 +275,103 @@ class DLNASettingsControllerTest {
     }
 
     @Nested
+    class RandomMaxTest {
+
+        private DLNASettingsCommand command;
+
+        @BeforeEach
+        public void setup() {
+            settingsService = mock(SettingsService.class);
+            controller = new DLNASettingsController(settingsService, mock(MusicFolderService.class),
+                    mock(SecurityService.class), mock(PlayerService.class), mock(TranscodingService.class),
+                    mock(UPnPService.class), mock(ShareService.class), mock(MenuItemService.class),
+                    mock(OutlineHelpSelector.class));
+            command = new DLNASettingsCommand();
+            command.setTopMenuItems(Collections.emptyList());
+            command.setSubMenuItems(Collections.emptyList());
+        }
+
+        @Test
+        void testNull() {
+            ArgumentCaptor<Integer> captor = ArgumentCaptor.forClass(int.class);
+            Mockito.doNothing().when(settingsService).setDlnaRandomMax(captor.capture());
+            controller.post(command, Mockito.mock(RedirectAttributes.class));
+            Mockito.verify(settingsService, Mockito.times(1)).setDlnaRandomMax(Mockito.any(int.class));
+            assertEquals(50, captor.getValue());
+        }
+
+        @Test
+        void test0() {
+            command.setDlnaRandomMax(0);
+            ArgumentCaptor<Integer> captor = ArgumentCaptor.forClass(int.class);
+            Mockito.doNothing().when(settingsService).setDlnaRandomMax(captor.capture());
+            controller.post(command, Mockito.mock(RedirectAttributes.class));
+            Mockito.verify(settingsService, Mockito.times(1)).setDlnaRandomMax(Mockito.any(int.class));
+            assertEquals(50, captor.getValue());
+        }
+
+        @Test
+        void test1() {
+            command.setDlnaRandomMax(1);
+            ArgumentCaptor<Integer> captor = ArgumentCaptor.forClass(int.class);
+            Mockito.doNothing().when(settingsService).setDlnaRandomMax(captor.capture());
+            controller.post(command, Mockito.mock(RedirectAttributes.class));
+            Mockito.verify(settingsService, Mockito.times(1)).setDlnaRandomMax(Mockito.any(int.class));
+            assertEquals(1, captor.getValue());
+        }
+
+        @Test
+        void test49() {
+            command.setDlnaRandomMax(49);
+            ArgumentCaptor<Integer> captor = ArgumentCaptor.forClass(int.class);
+            Mockito.doNothing().when(settingsService).setDlnaRandomMax(captor.capture());
+            controller.post(command, Mockito.mock(RedirectAttributes.class));
+            Mockito.verify(settingsService, Mockito.times(1)).setDlnaRandomMax(Mockito.any(int.class));
+            assertEquals(49, captor.getValue());
+        }
+
+        @Test
+        void test50() {
+            command.setDlnaRandomMax(50);
+            ArgumentCaptor<Integer> captor = ArgumentCaptor.forClass(int.class);
+            Mockito.doNothing().when(settingsService).setDlnaRandomMax(captor.capture());
+            controller.post(command, Mockito.mock(RedirectAttributes.class));
+            Mockito.verify(settingsService, Mockito.times(1)).setDlnaRandomMax(Mockito.any(int.class));
+            assertEquals(50, captor.getValue());
+        }
+
+        @Test
+        void test51() {
+            command.setDlnaRandomMax(51);
+            ArgumentCaptor<Integer> captor = ArgumentCaptor.forClass(int.class);
+            Mockito.doNothing().when(settingsService).setDlnaRandomMax(captor.capture());
+            controller.post(command, Mockito.mock(RedirectAttributes.class));
+            Mockito.verify(settingsService, Mockito.times(1)).setDlnaRandomMax(Mockito.any(int.class));
+            assertEquals(51, captor.getValue());
+        }
+
+        @Test
+        void test1999() {
+            command.setDlnaRandomMax(1999);
+            ArgumentCaptor<Integer> captor = ArgumentCaptor.forClass(int.class);
+            Mockito.doNothing().when(settingsService).setDlnaRandomMax(captor.capture());
+            controller.post(command, Mockito.mock(RedirectAttributes.class));
+            Mockito.verify(settingsService, Mockito.times(1)).setDlnaRandomMax(Mockito.any(int.class));
+            assertEquals(1999, captor.getValue());
+        }
+
+        @Test
+        void test2000() {
+            command.setDlnaRandomMax(2000);
+            ArgumentCaptor<Integer> captor = ArgumentCaptor.forClass(int.class);
+            Mockito.doNothing().when(settingsService).setDlnaRandomMax(captor.capture());
+            controller.post(command, Mockito.mock(RedirectAttributes.class));
+            Mockito.verify(settingsService, Mockito.times(1)).setDlnaRandomMax(Mockito.any(int.class));
+            assertEquals(1999, captor.getValue());
+        }
+    }
+
+    @Nested
     class UpdateSubMenuItemsTest {
 
         @Test


### PR DESCRIPTION
## Problem description

Unable to set the maximum value used for UPnP shuffle list.

![image](https://github.com/tesshucom/jpsonic/assets/27724847/8e44b29a-079e-40ce-bd22-b77bb04f9bee)

### Steps to reproduce

Set any value and click Save. The value does not change.

## System information

 * **Jpsonic version**: About 2 years and 7 months ago 😁

I didn't notice it because I don't touch it much...

## Additional notes

There is no particular problem with shuffling, it seems like it is only a problem with the web page. It has been corrected as follows.

 - If null or 0 is specified from the web page, register the default value. Default value is 50. 
 - The maximum value that can be specified is 1999. If a higher value is specified, 1999 will be set.
 - Boundary value test added.

