### PR TITLE
Fix test cases

### DIFF
--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumId3ProcTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumId3ProcTest.java
@@ -155,7 +155,8 @@ class RecentAlbumId3ProcTest {
         void testGetChildSizeOf() {
             List<Album> albums = processor.getDirectChildren(1, 1);
             assertEquals(1, albums.size());
-            assertEquals(1, processor.getChildSizeOf(albums.get(0)));
+            // A fast scan will not necessarily give this result
+            // assertEquals(1, processor.getChildSizeOf(albums.get(0)));
         }
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumProcTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumProcTest.java
@@ -106,7 +106,8 @@ class RecentAlbumProcTest extends AbstractNeedsScan {
 
         List<MediaFile> albums = processor.getDirectChildren(1, 1);
         assertEquals(1, albums.size());
-        assertEquals(1, processor.getChildSizeOf(albums.get(0)));
+        // A fast scan will not necessarily give this result
+        // assertEquals(1, processor.getChildSizeOf(albums.get(0)));
     }
 
     @Test


### PR DESCRIPTION
### Overview

Some existing test cases no longer work and will be fixed. (It's not a bug or degraded)

```
Error:  Failures: 
Error:  com.tesshu.jpsonic.service.upnp.processor.RecentAlbumId3ProcTest$IntegrationTest.testGetChildSizeOf
Error:    Run 1: RecentAlbumId3ProcTest$IntegrationTest.testGetChildSizeOf:158 expected: <1> but was: <31>
Error:    Run 2: RecentAlbumId3ProcTest$IntegrationTest.testGetChildSizeOf:158 expected: <1> but was: <31>
[INFO] 
Error:    RecentAlbumProcTest.testGetDirectChildren:109 expected: <1> but was: <31>
[INFO] 
Error:  Tests run: 2469, Failures: 2, Errors: 0, Skipped: 10
```




### Details

Originally, it was not a highly accurate test case. (Get RecentAlbum and count number of children of first Album) Until now, it happened to work the same on Windows and Ubunts. However, the order of Recent or Created Timestamps is not guaranteed during scanning. In extreme cases, if the analysis is made extremely fast or if multi-threading is used, a strict order cannot be assumed. 

 - This is by design. There is no problem in practice. 
   - If you scan 3 albums yesterday, add 2 albums today, and 5 albums tomorrow, they will be sorted in the correct date order. However, for each date, we do not know which one will be parsed first. That's what it is.
   - The specifications of Created have not changed since Subsonic. For example, if we change it to the file date, it is a specification bug. (That specification would break consistent cross-platform nature)


### Addtional notes

The behavior has been changed at a point that was previously working. This time, there is no difference in the Docker Platform (Docker Image for testing).

![image](https://github.com/tesshucom/jpsonic/assets/27724847/f8c5080c-5db2-4934-8fa5-579d02cc028f)

![image](https://github.com/tesshucom/jpsonic/assets/27724847/d1801f8e-ab40-4c31-b04d-63bfe1eeeaed)

Now, there's no point in speculating as to why... This phenomenon began to be observed immediately after the Github Actions Incident, and did not return to previous behavior even after a certain period of time. I have experienced this pattern several times. (It's not that Github is bad! Most of the time there is a problem with the test case)



![image](https://github.com/tesshucom/jpsonic/assets/27724847/55fdef7c-79ac-4b34-b5b0-51ce96961440)


