### PR TITLE
Revert Jetty to 12.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,9 @@
     <versions.java-jwt>4.4.0</versions.java-jwt>
     <versions.jaxb-runtime>4.0.5</versions.jaxb-runtime>
     <versions.jdom2>2.0.6.1</versions.jdom2>
-    <versions.jetty-ee10-apache-jsp>12.0.9</versions.jetty-ee10-apache-jsp>
+
+    <!-- jetty-ee10-apache-jsp is currently fixed. See #2638 -->
+    <versions.jetty>12.0.6</versions.jetty>
     <versions.jfreechart>1.5.4</versions.jfreechart>
     <versions.junit-jupiter-api>5.10.2</versions.junit-jupiter-api>
     <versions.junit-jupiter-engine>5.7.1</versions.junit-jupiter-engine>
@@ -317,7 +319,57 @@
       <dependency>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-apache-jsp</artifactId>
-        <version>${versions.jetty-ee10-apache-jsp}</version>
+        <version>${versions.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-servlet</artifactId>
+        <version>${versions.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-servlets</artifactId>
+        <version>${versions.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-webapp</artifactId>
+        <version>${versions.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-http</artifactId>
+        <version>${versions.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-io</artifactId>
+        <version>${versions.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-security</artifactId>
+        <version>${versions.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-server</artifactId>
+        <version>${versions.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-session</artifactId>
+        <version>${versions.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-util</artifactId>
+        <version>${versions.jetty}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-xml</artifactId>
+        <version>${versions.jetty}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Overview

In v114.1, two log specification issues related to Jetty were confirmed. Jetty will be reverted to v12.0.6, which is currently confirmed for stable use.

## Problem description

 -  #2632
     - When starting Jpsonic, a warning due to false positive detection may be output.
       - SPIRING : the URL produced by your classloader lookup has nested references.
       - JETTY: Internal security/safety mechanism that attempts to determine if the requested path is an alias of the actual path causes false positives.
         - Triggered by AliasCheckers specification change `ttps://github.com/jetty/jetty.project/pull/11279`
         - It is possible to suppress it but it is cluttered. Measures are currently being considered　`ttps://github.com/jetty/jetty.project/issues/11492`
 -  #2638
     - Meaningless warnings may be output during streaming. Similar issues have been reported with Jetty. Under observation. 



