### PR TITLE
Suppress AsyncRequestNotUsableException

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/spring/LoggingExceptionResolver.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/spring/LoggingExceptionResolver.java
@@ -43,8 +43,9 @@ public class LoggingExceptionResolver implements HandlerExceptionResolver, Order
      * A list of frequently exceptions that occur outside the control of the server. It is managed by a string to store
      * vendor-specific exceptions. (Depending on packaging, these classes may not exist in the classpath)
      */
-    private static final List<String> TO_BE_SUPPRESSED_CLASS_NAME = Arrays
-            .asList("org.apache.catalina.connector.ClientAbortException", "org.eclipse.jetty.io.EofException");
+    private static final List<String> TO_BE_SUPPRESSED_CLASS_NAME = Arrays.asList(
+            "org.apache.catalina.connector.ClientAbortException", "org.eclipse.jetty.io.EofException",
+            "org.springframework.web.context.request.async.AsyncRequestNotUsableException");
 
     private static boolean isInstanceOfClassName(Object o, String className) {
         try {


### PR DESCRIPTION

## Overview

In CoverArtController and StreamController, AsyncRequestNotUsableException will be changed to be output to TRACE.

If you've ever used Subsonic or Airsonic, you've probably seen log files that look like that spell. In Jpsonic, the contents output to the log file are organized to some extent. What I have seen relatively often on legacy servers is errors related to Close from the client while outputting a response. (When viewed from the server, it is expressed as ``I tried to write, but I can't write!''.) This will probably happen relatively often when streaming music. Usually these are suppressed.

In Jpsonic, these exceptions that often occur during image or streaming are logged at the TRACE level. However, the exception design especially related to communication has been frequently changed in Apps Servers or Frame Work. The issues covered in this issue are to follow changes in Spring's exception specifications.


## Goal




## Non-Goal




