### PR TITLE
[Docker/Alpine] Fix bug that ffmpeg did not work

### DIFF
--- a/install/docker/alpine/Dockerfile
+++ b/install/docker/alpine/Dockerfile
@@ -43,8 +43,7 @@ RUN apk --no-cache add \
     && rm /usr/share/fonts/noto/NotoSansCJK-Bold.ttc \
     && rm /usr/share/fonts/noto/NotoSerifCJK-Bold.ttc \
     && rm /usr/share/fonts/noto/NotoSerifCJK-Regular.ttc \
-    && fc-cache -vf \
-    && rm -f /usr/lib/librav1e.so.0.6.6
+    && fc-cache -vf
 
 EXPOSE $JPSONIC_PORT
 EXPOSE $UPNP_PORT


### PR DESCRIPTION
## Problem description

Since 114.0.6, ffpmeg is not available in Alpine Image. This pull request will resolve it.

### Steps to reproduce

Play the song under conditions that allow MP3 transcoding. Enabling [mp3 audio] and playing FLAC songs in BPS320, etc.

## System information

 * **Jpsonic version**: 

Playable | Jpsonic | ffmpeg
-- | -- | --
Y | 114.0.0 | ffmpeg-6.1.1-r0
Y | 114.0.5 | ffmpeg-6.1.1-r0
N | 114.0.6 | ffmpeg-6.1.1-r0
N | 114.0.7 | ffmpeg-6.1.1-r0
N | 114.1.0 | ffmpeg-6.1.1-r0
N | 114.1.2 | ffmpeg-6.1.1-r0

 * **Operating system**: Docker Alpine image only. Cannot be reproduced in jammy.

## Details

In 114.0.6, a somewhat drastic measure was taken to remove librav1e.so.0.6.6. This was to avoid GHSA-c827-hfw6-qwvm⁠(rustix 0.37.19), but the method was not appropriate. This Pull Request will roll it back. It is assumed that there is probably no problem, but progress is being monitored.

 - [FFmpeg Security](https://ffmpeg.org/security.html)


