### PR TITLE
Fix Docker health checks

### DIFF
--- a/install/docker/alpine/Dockerfile
+++ b/install/docker/alpine/Dockerfile
@@ -56,7 +56,7 @@ VOLUME \
     $JPSONIC_DIR/playlists \
     $JPSONIC_DIR/podcasts
 
-HEALTHCHECK --interval=30s --timeout=2s CMD wget -q http://localhost:"$JPSONIC_PORT""$CONTEXT_PATH"rest/ping -O /dev/null || exit 1
+HEALTHCHECK --interval=30s --timeout=2s CMD export HEALTHCHECK_QUERY=$(echo localhost:"$JPSONIC_PORT""$CONTEXT_PATH"/rest/ping | tr -s /);wget -q http://"$HEALTHCHECK_QUERY" -O /dev/null || exit 1
 
 COPY entry-point.sh /usr/local/bin/entry-point.sh
 RUN chmod +x /usr/local/bin/entry-point.sh

--- a/install/docker/jammy/Dockerfile
+++ b/install/docker/jammy/Dockerfile
@@ -55,7 +55,7 @@ VOLUME \
     $JPSONIC_DIR/playlists \
     $JPSONIC_DIR/podcasts
 
-HEALTHCHECK --interval=30s --timeout=2s CMD wget -q http://localhost:"$JPSONIC_PORT""$CONTEXT_PATH"rest/ping -O /dev/null || exit 1
+HEALTHCHECK --interval=30s --timeout=2s CMD export HEALTHCHECK_QUERY=$(echo localhost:"$JPSONIC_PORT""$CONTEXT_PATH"/rest/ping | tr -s /);wget -q http://"$HEALTHCHECK_QUERY" -O /dev/null || exit 1
 
 COPY entry-point.sh /usr/local/bin/entry-point.sh
 RUN chmod +x /usr/local/bin/entry-point.sh


### PR DESCRIPTION
## Problem description

If we specify a context path other than a slash in Docker, Health Chack will always be false.


Although it does not affect operation at all, the status of Health Check will always be displayed as Warning in UI such as Contaner Manager.

![image](https://github.com/tesshucom/jpsonic/assets/27724847/c5771cf6-c899-4153-a33a-d5c3a51af45d)



### Steps to reproduce

Specify a context path other than a slash in Docker.

## System information

I think it has been like that since the initial introduction of production.yml.

 * **Jpsonic version**: Maybe 112.1.0. 

## Additional notes

`JPSONIC_PORT=8080`
`CONTEXT_PATH=/`
`http://localhost:"$JPSONIC_PORT""$CONTEXT_PATH"rest/ping`

In this case it would look like this:
`http://localhost:8080/rest/ping`

CONTEXT_PATH=/jpsonic
`http://localhost:8080/jpsonicrest/ping`

Therefore, it should be as follows

`http://localhost:"$JPSONIC_PORT""$CONTEXT_PATH"/rest/ping`

Also, double slashes must be removed from the query part. At least in Spring Boot 3.x it will return a 400 code.

I couldn't find a way to do this elegantly... It seems that this is often done with shell or js. I haven't found any functionality in Docker that solves this kind of problem.
