### PR TITLE
Add UBI9 Base Docker Image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
           retention-days: 90
   ##########################################################################
   ship-docker-image:
-    name: Docker(alpine-amd)
+    name: Docker(alpine-amd, arm)
     needs: ship-war
     runs-on: ubuntu-latest
     steps:
@@ -434,9 +434,86 @@ jobs:
             docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-jammy-v7 .
           fi
   ##########################################################################
+  ship-docker-image-ubi9:
+    name: Docker(ubi9-amd)
+    needs: ship-war
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 21
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+      - name: Get current date
+        id: date
+        run: echo "current=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+      - name: Download package
+        uses: actions/download-artifact@v4
+        with:
+          name: jpsonic-jetty-embedded-for-jdk21-${{ steps.date.outputs.current }}
+      - name: Create Tag
+        run: |
+          echo "DOCKER_TAG=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
+      - name: Copy artifact
+        run: |
+          mkdir -p install/docker/ubi9/target/dependency
+          mv jpsonic.war install/docker/ubi9/target/dependency
+      - name: Release with Version Tag
+        if: "(github.ref == 'refs/heads/master')"
+        run: |
+          if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            cd install/docker/ubi9
+            sed -i -e "s/21-jdk-ubi9-minimal/21-jre-ubi9-minimal/g" Dockerfile
+            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
+            mvn -DdockerTag=${{ env.DOCKER_TAG }}-ubi9 package
+            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+            docker buildx build --push --platform linux/amd64 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-ubi9 .
+            mvn -DdockerTag=${DOCKER_TAG%.*}-ubi9 package
+            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+            docker buildx build --push --platform linux/amd64 -t jpsonic/jpsonic:${DOCKER_TAG%.*}-ubi9 .
+            mvn -DdockerTag=${DOCKER_TAG%.*.*}-ubi9 package
+            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+            docker buildx build --push --platform linux/amd64 -t jpsonic/jpsonic:${DOCKER_TAG%.*.*}-ubi9 .
+          fi
+      - name: Release with Latest Tag
+        if: github.ref == 'refs/heads/master'
+        run: |
+          if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            cd install/docker/ubi9
+            sed -i -e "s/21-jdk-ubi9-minimal/21-jre-ubi9-minimal/g" Dockerfile
+            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
+            mvn -DdockerTag=latest-ubi9 package
+            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+            docker buildx build --push --platform linux/amd64 -t jpsonic/jpsonic:latest-ubi9 .
+          fi
+      - name: Release with Alpha/Beta Tag
+        if: github.ref == 'refs/heads/master'
+        run: |
+          if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.(alpha|beta)\.[0-9]+\.[0-9]+$ ]]; then
+            cd install/docker/ubi9
+            sed -i -e "s/21-jdk-ubi9-minimal/21-jre-ubi9-minimal/g" Dockerfile
+            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
+            mvn -DdockerTag=latest-ubi9 package
+            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+            docker buildx build --push --platform linux/amd64 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-ubi9 .
+          fi
+      - name: Release with Early-Access Tag
+        if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/feature/docker'
+        run: |
+          cd install/docker/ubi9
+          mvn -DdockerTag=ea-ubi9 package
+          docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+          docker buildx build --push --platform linux/amd64 -t jpsonic/jpsonic:ea-ubi9 .
+  ##########################################################################
   run-docker4latest:
     name: Run ${{ matrix.tag }}
-    needs: [ ship-docker-image, ship-docker-image-jammy, ship-docker-image-jammy-v7 ]
+    needs: [ ship-docker-image, ship-docker-image-jammy, ship-docker-image-jammy-v7, ship-docker-image-ubi9 ]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     strategy:
@@ -466,7 +543,7 @@ jobs:
   ##########################################################################
   run-docker4ea:
     name: Run ${{ matrix.tag }}
-    needs: [ ship-docker-image, ship-docker-image-jammy, ship-docker-image-jammy-v7 ]
+    needs: [ ship-docker-image, ship-docker-image-jammy, ship-docker-image-jammy-v7, ship-docker-image-ubi9 ]
     if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/feature/docker'
     runs-on: ubuntu-latest
     strategy:

--- a/install/docker/ubi9/.dockerignore
+++ b/install/docker/ubi9/.dockerignore
@@ -1,0 +1,5 @@
+.gitignore
+pom.xml
+production.yml
+target/
+!target/dependency/*

--- a/install/docker/ubi9/Dockerfile
+++ b/install/docker/ubi9/Dockerfile
@@ -1,0 +1,63 @@
+FROM eclipse-temurin:21-jdk-ubi9-minimal
+
+LABEL description="Jpsonic is a free, web-based media streamer, providing ubiquitious access to your music." \
+      url="https://github.com/jpsonic/jpsonic"
+
+ENV JPSONIC_DIR=/jpsonic \
+    CONTEXT_PATH=/ \
+    JPSONIC_PORT=4040 \
+    UPNP_PORT=4041 \
+    UPNP_IDLE_INTERVAL=30 \
+    UPNP_MAX_CONNECTIONS=50 \
+    UPNP_MAX_IDLE_CONNECTIONS=30 \
+    UPNP_DRAIN_AMOUNT=65536 \
+    UPNP_MAX_REQ_HEADERS=200 \
+    UPNP_MAX_REQ_TIME=500 \
+    UPNP_MAX_RSP_TIME=500 \
+    UPNP_NODELAY=true \
+    SHOW_DATA_DIR=true \
+    USER_ID=1000 \
+    GROUP_ID=1000 \
+    TIME_ZONE=GB \
+    BANNER_MODE=OFF \
+    LOG_LEVEL=WARN \
+    SCAN_ON_BOOT=false \
+    EMBEDDED_FONT=false \
+    MIME_DSF=audio/x-dsd \
+    MIME_DFF=audio/x-dsd \
+    JAVA_OPTS="-Xms512m -Xmx512m -XX:+UseG1GC -XX:MaxGCPauseMillis=500"
+
+WORKDIR $JPSONIC_DIR
+
+RUN microdnf install --disableplugin=subscription-manager --setopt=install_weak_deps=0 -y \
+    xz \
+    unzip \
+    findutils \
+    && microdnf clean all \
+    && rm -rf /var/lib/dnf
+
+COPY local.conf /etc/fonts
+
+COPY install-tools.sh "${JPSONIC_DIR}/install-tools.sh"
+RUN chmod +x "${JPSONIC_DIR}/install-tools.sh"
+RUN ["/bin/bash", "-c", "${JPSONIC_DIR}/install-tools.sh amd64"]
+RUN rm "${JPSONIC_DIR}/install-tools.sh"
+
+EXPOSE $JPSONIC_PORT
+EXPOSE $UPNP_PORT
+EXPOSE 1900/udp
+EXPOSE 3333
+
+VOLUME \
+    $JPSONIC_DIR/data \
+    $JPSONIC_DIR/music \
+    $JPSONIC_DIR/playlists \
+    $JPSONIC_DIR/podcasts
+
+HEALTHCHECK --interval=30s --timeout=2s CMD export HEALTHCHECK_QUERY=$(echo localhost:"$JPSONIC_PORT""$CONTEXT_PATH"/rest/ping | tr -s /);wget -q http://"$HEALTHCHECK_QUERY" -O /dev/null || exit 1
+
+COPY entry-point.sh /usr/local/bin/entry-point.sh
+RUN chmod +x /usr/local/bin/entry-point.sh
+COPY target/dependency/jpsonic.war jpsonic.war
+
+ENTRYPOINT ["tini", "-e", "143", "--", "entry-point.sh"]

--- a/install/docker/ubi9/entry-point.sh
+++ b/install/docker/ubi9/entry-point.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+groupname=$(getent group "$GROUP_ID" | cut -d":" -f1)
+if [ -z "$groupname" ]; then
+    groupname=jpsonic
+    groupadd -g "$GROUP_ID" $groupname
+fi
+
+username=$(getent passwd "$USER_ID" | cut -d":" -f1)
+if [ -z "$username" ]; then
+    username=jpsonic
+	adduser \
+	    -u "$USER_ID" \
+	    -s /bin/false \
+	    --comment "" \
+	    --no-create-home \
+	    --home-dir "$JPSONIC_DIR" \
+	    --gid "$groupname" \
+	    jpsonic
+fi
+
+usermod -aG "$groupname" "$username"
+
+su "$username" -
+mkdir -p "$JPSONIC_DIR"/data/transcode
+rm -f "$JPSONIC_DIR"/data/transcode/ffmpeg
+ln -fs /usr/bin/ffmpeg "$JPSONIC_DIR"/data/transcode/ffmpeg
+rm -f "$JPSONIC_DIR"/data/transcode/ffprobe
+ln -fs /usr/bin/ffprobe "$JPSONIC_DIR"/data/transcode/ffprobe
+
+if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
+
+    java_opts_array=()
+    while IFS= read -r -d '' item; do
+        java_opts_array+=( "$item" )
+    done < <([[ $JAVA_OPTS ]] && xargs printf '%s\0' <<<"$JAVA_OPTS")
+
+    set -- java \
+     -Dserver.host=0.0.0.0 \
+     -Dserver.port="$JPSONIC_PORT" \
+     -Dserver.servlet.context-path="$CONTEXT_PATH" \
+     -Djpsonic.home="$JPSONIC_DIR"/data \
+     -Djpsonic.defaultMusicFolder="$JPSONIC_DIR"/music \
+     -Djpsonic.defaultPodcastFolder="$JPSONIC_DIR"/podcasts \
+     -Djpsonic.defaultPlaylistFolder="$JPSONIC_DIR"/playlists \
+     -Djpsonic.scan.onboot="$SCAN_ON_BOOT" \
+     -Djpsonic.embeddedfont="$EMBEDDED_FONT" \
+     -Djpsonic.mime.dsf="$MIME_DSF" \
+     -Djpsonic.mime.dff="$MIME_DFF" \
+     -DUPNP_PORT="$UPNP_PORT" \
+     -Dsun.net.httpserver.idleInterval="$UPNP_IDLE_INTERVAL" \
+     -Djdk.httpserver.maxConnections="$UPNP_MAX_CONNECTIONS" \
+     -Dsun.net.httpserver.maxIdleConnections="$UPNP_MAX_IDLE_CONNECTIONS" \
+     -Dsun.net.httpserver.drainAmount="$UPNP_DRAIN_AMOUNT" \
+     -Dsun.net.httpserver.maxReqHeaders="$UPNP_MAX_REQ_HEADERS" \
+     -Dsun.net.httpserver.maxReqTime="$UPNP_MAX_REQ_TIME" \
+     -Dsun.net.httpserver.maxRspTime="$UPNP_MAX_RSP_TIME" \
+     -Dsun.net.httpserver.nodelay="$UPNP_NODELAY" \
+     -Dspring.main.banner-mode="$BANNER_MODE" \
+     -Dlogging.level.com.tesshu.jpsonic="$LOG_LEVEL" \
+     -Djava.awt.headless=true \
+     -Duser.timezone="$TIME_ZONE" \
+     "${java_opts_array[@]}" \
+     -jar jpsonic.war "$@"
+fi
+
+exec "$@"
+exit

--- a/install/docker/ubi9/install-tools.sh
+++ b/install/docker/ubi9/install-tools.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# @param TARGET_ARCH amd64 or arm64
+
+TARGET_ARCH="$@"
+
+# Install noto-cjk
+mkdir -p /opt/noto
+cd /opt/noto
+
+wget https://github.com/googlefonts/noto-cjk/releases/download/Sans2.004/03_NotoSansCJK-OTC.zip
+unzip 03_NotoSansCJK-OTC.zip
+rm NotoSansCJK-Black.ttc
+rm NotoSansCJK-Bold.ttc
+rm NotoSansCJK-DemiLight.ttc
+rm NotoSansCJK-Light.ttc
+rm NotoSansCJK-Medium.ttc
+mkdir -p /usr/share/fonts/noto
+ln -sf "${PWD}/NotoSansCJK-Regular.ttc" /usr/share/fonts/noto/NotoSansCJK-Regular.ttc
+rm NotoSansCJK-Thin.ttc
+rm 03_NotoSansCJK-OTC.zip
+fc-cache -vf
+
+# Install tini
+mkdir -p /opt/tini
+cd /opt/tini
+
+wget "https://github.com/krallin/tini/releases/download/v0.19.0/tini-${TARGET_ARCH}"
+wget "https://github.com/krallin/tini/releases/download/v0.19.0/tini-${TARGET_ARCH}.sha1sum"
+wget https://raw.githubusercontent.com/krallin/tini/master/LICENSE
+sha1sum --check tini-${TARGET_ARCH}.sha1sum
+chmod +x tini-${TARGET_ARCH}
+ln -sf "${PWD}/tini-${TARGET_ARCH}" /sbin/tini
+rm -f tini-${TARGET_ARCH}.sha1sum
+
+# Install ffmpeg
+mkdir -p /opt/ffmpeg
+cd /opt/ffmpeg
+
+wget "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-${TARGET_ARCH}-static.tar.xz"
+wget "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-${TARGET_ARCH}-static.tar.xz.md5"
+md5sum -c "ffmpeg-release-${TARGET_ARCH}-static.tar.xz.md5"
+tar xvf "ffmpeg-release-${TARGET_ARCH}-static.tar.xz"
+cd ffmpeg-*-static
+ln -sf "${PWD}/ffmpeg" /usr/bin/ffmpeg
+ln -sf "${PWD}/ffprobe" /usr/bin/ffprobe
+cd ../
+rm -f ffmpeg-release-${TARGET_ARCH}-static.tar.xz ffmpeg-release-${TARGET_ARCH}-static.tar.xz.md5

--- a/install/docker/ubi9/local.conf
+++ b/install/docker/ubi9/local.conf
@@ -1,0 +1,12 @@
+<?xml version='1.0'?>
+<!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
+<fontconfig>
+    <match target="pattern">
+        <test qual="any" name="family">
+            <string>sans-serif</string>
+        </test>
+        <edit name="family" mode="prepend" binding="same">
+            <string>Noto Sans CJK JP</string>
+        </edit>
+    </match>
+</fontconfig>

--- a/install/docker/ubi9/pom.xml
+++ b/install/docker/ubi9/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <relativePath>../../../pom.xml</relativePath>
+        <artifactId>jpsonic</artifactId>
+        <version>114.1.0</version>
+        <groupId>com.tesshu.jpsonic.player</groupId>
+    </parent>
+    <packaging>pom</packaging>
+    <artifactId>jpsonic-docker-ubi9</artifactId>
+    <name>Jpsonic Docker Image</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.40.1</version>
+                <executions>
+                    <execution>
+                        <id>build-image</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <name>${docker.container.repo}</name>
+                                    <build>
+                                        <dockerFile>${project.basedir}/Dockerfile</dockerFile>
+                                        <tags>${dockerTag}</tags>
+                                    </build>
+                                </image>
+                            </images>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <configuration>
+                    <stripClassifier>true</stripClassifier>
+                    <stripVersion>true</stripVersion>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
## Overview

A Docker image that uses Red Hat Universal Base Image 9 will be added.

![image](https://github.com/tesshucom/jpsonic/assets/27724847/95b4d3ff-1398-44db-8e14-a82cc5ee0191)

## Details

There's nothing particularly noteworthy though...

 - Jpsonic latest is based on the small Alpine, which uses musl. Ubuntu was created as a libc-based platform for the purpose of comparing with Alpine.
   - I don't think the end result will be much different 🙄
 - These two were maintained as they were so that comparison verification could be performed if there was a problem on the platform side. Or, if the user notices something unusual, the other one can be used as a replacement 😉
 - RHEL + Oracle dominates Java projects in Japan. For this reason, RHEL-based distributions are relatively popular among engineers and students.
   - Users may want to use the distribution they are familiar with ..?
   - I think some people will start learning Linux as a result of self-hosting. Therefore, I had wanted to have a RHEL series distribution as one of my options.

