### PR TITLE
Fix to suppress redundant logs at startup

### DIFF
--- a/jpsonic-main/src/main/resources/application.properties
+++ b/jpsonic-main/src/main/resources/application.properties
@@ -27,6 +27,8 @@ logging.level.liquibase.executor.jvm.JdbcExecutor: ERROR
 logging.level.org.eclipse.jetty.io.AbstractConnection: ERROR
 logging.level.org.jupnp.protocol.RetrieveRemoteDescriptors: ERROR
 logging.level.org.jupnp.util.SpecificationViolationReporter: ERROR
+logging.level.org.eclipse.jetty.server.handler.ContextHandler: ERROR
+logging.level.org.springframework.security.config.annotation.authentication.configuration.InitializeUserDetailsBeanManagerConfigurer: ERROR
 
 # See ExecutorConfiguration
 short-task-pool.corePoolSize: 4

--- a/jpsonic-main/src/test/resources/application.properties
+++ b/jpsonic-main/src/test/resources/application.properties
@@ -25,6 +25,8 @@ logging.level.com.tesshu.jpsonic.spring.AirsonicHsqlDatabase: WARN
 logging.level.liquibase: WARN
 logging.level.liquibase.executor.jvm.JdbcExecutor: ERROR
 logging.level.org.eclipse.jetty.io.AbstractConnection: ERROR
+logging.level.org.eclipse.jetty.server.handler.ContextHandler: ERROR
+logging.level.org.springframework.security.config.annotation.authentication.configuration.InitializeUserDetailsBeanManagerConfigurer: ERROR
 
 
 # See ExecutorConfiguration


### PR DESCRIPTION
## Ovewview

As part of the migration to Spring 3.3.0, two redundant warning logs will be recorded when Jpsonic starts. These will be temporarily suppressed as they do not affect operation.

 - [Linux] Alias ​​Checker False Positives
 - [Win/Linux] Spring Configuration Warning

These will be tracked and will likely be fixed in later versions. At that time, log suppression will also be removed.