### PR TITLE
Add Java22 validation to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,13 +103,13 @@ jobs:
         if: contains(matrix.os, 'windows-latest')
         run: mvn -DfailIfNoTests=false -DtranscodePath="${{ steps.ffmpeg.outputs.path }}" clean verify -B -Ptomcat-embed -Punit-test
   ##########################################################################
-  verify-Java21:
+  verify-Java21-or-later:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     name: JDK${{ matrix.java }} on ubuntu-latest
     strategy:
       matrix:
-        java: [ 21 ]
+        java: [ 21, 22 ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -160,7 +160,7 @@ jobs:
   ##########################################################################
   ship-war:
     if: "(github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop') && github.event_name != 'schedule'"
-    needs: [ verify-Java17, verify-Java21 ]
+    needs: [ verify-Java17, verify-Java21-or-later ]
     name: Package with JDK ${{ matrix.java }} on ubuntu
     strategy:
       matrix:

--- a/pom.xml
+++ b/pom.xml
@@ -1087,6 +1087,14 @@
       </properties>
     </profile>
     <profile>
+      <id>release22</id>
+      <properties>
+        <java.version>22</java.version>
+        <jpsonic.concurent.module>jpsonic-concurent21</jpsonic.concurent.module>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
+      </properties>
+    </profile>
+    <profile>
       <id>unit-test</id>
       <modules>
         <module>subsonic-rest-api</module>


### PR DESCRIPTION

Validation for Java 22 will be added. There will be no release.

It looks like the maven-dependency-plugin now works with Java 22. (1edf44e96b092695db8ab3938dc0b6aa837144d8) This was a blocker.