### PR TITLE
Fix to filter unknown menus

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MenuItemDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MenuItemDao.java
@@ -42,6 +42,7 @@ public class MenuItemDao {
     private final TemplateWrapper template;
     private final RowMapper<MenuItem> rowMapper = (ResultSet rs, int num) -> new MenuItem(ViewType.of(rs.getInt(1)),
             MenuItemId.of(rs.getInt(2)), MenuItemId.of(rs.getInt(3)), rs.getString(4), rs.getBoolean(5), rs.getInt(6));
+    private final RowMapper<MenuItemId> idRowMapper = (ResultSet rs, int num) -> MenuItemId.of(rs.getInt(1));
 
     public MenuItemDao(TemplateWrapper templateWrapper) {
         template = templateWrapper;
@@ -54,11 +55,11 @@ public class MenuItemDao {
                 """, rowMapper, id);
     }
 
-    public int getTopMenuItemCount(ViewType viewType) {
-        return template.queryForInt("""
-                select count(id) from menu_item
+    public List<MenuItemId> getTopMenuIds(ViewType viewType) {
+        return template.query("""
+                select id from menu_item
                 where view_type=? and parent=? and enabled=?
-                """, 0, viewType.value(), MenuItemId.ROOT.value(), true);
+                """, idRowMapper, viewType.value(), MenuItemId.ROOT.value(), true);
     }
 
     public List<MenuItem> getTopMenuItems(ViewType viewType, boolean enabledOnly, long offset, long count) {
@@ -72,11 +73,11 @@ public class MenuItemDao {
                 """.formatted(enabledOnly ? "and enabled=:enabledOnly" : ""), rowMapper, args);
     }
 
-    public int getChildSizeOf(ViewType viewType, MenuItemId id) {
-        return template.queryForInt("""
-                select count(id) from menu_item
+    public List<MenuItemId> getChildIds(ViewType viewType, MenuItemId id) {
+        return template.query("""
+                select id from menu_item
                 where view_type=? and parent=? and enabled=?
-                """, 0, viewType.value(), id.value(), true);
+                """, idRowMapper, viewType.value(), id.value(), true);
     }
 
     public List<MenuItem> getChildlenOf(ViewType viewType, MenuItemId id, boolean enabledOnly, long offset,


### PR DESCRIPTION
## Problem description

This has no effect on currently released versions. However, after updating to the next version v114.2.0 (after the menu has been added), there may be cases where problems occur when reverting the main version to v114.1.x. This is a so-called latent bug, but this Pull Request will fix it.



### Details

In v114.x, UPnP views will be gradually enhanced. To achieve this, the settings page already allows users to customize the menu. For example, v114.2.0 will add several new items, including Genre.

![image](https://github.com/user-attachments/assets/3a9a7a43-ec56-4d57-a5dc-177b262f3fd6)

This is achieved by managing the menu structure in a database. As new menu data is added, more items will be displayed. However, in the current version, if you revert Jpsonic to a previous version, "unknown menu items" will exist. (In fact, an error occurs and you cannot view the UPnP setting page.)

This commit filters unknown menu items from processing. As a result, menu items will be able to work with different versions of Jpsonic and only those available for that version will be displayed.

## System information

 * **Jpsonic version**: From v114.1.1 to v114.1.5


## Additional Notes

Such backwards-compatible fixes are usually included in major version releases. This is because if the major versions are the same, can be easily replaced, making it easier to verify the differences between them.

With upcoming v114.x releases (v114.2.0 and later), it will be easy to roll back to v114.1.6. Rolling back from v114.1.1 to v114.1.5 would not be guaranteed. (This is not a serious data corruption issue. If you really want to revert to a version between v114.1.1 and v114.1.5, you can do so by editing using SQL. Just delete the menu that was added in a later version.) 

In most cases, Jpsonic becomes more accurate or has fewer bugs with each new version. Basically, except for verification, there are few use cases for reverting the main body to a previous version. On this issue, the contents of this Pull Request should be sufficient.
