### PR TITLE
Remove UPnP Genre count display

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/DLNASettingsCommand.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/command/DLNASettingsCommand.java
@@ -57,7 +57,6 @@ public class DLNASettingsCommand extends SettingsPageCommons {
     private Sort albumGenreSort;
     private List<Sort> avairableSongGenreSort;
     private Sort songGenreSort;
-    private boolean dlnaGenreCountVisible;
     private Integer dlnaRandomMax;
     private boolean dlnaGuestPublish;
 
@@ -207,14 +206,6 @@ public class DLNASettingsCommand extends SettingsPageCommons {
 
     public void setSongGenreSort(Sort musicGenreSort) {
         this.songGenreSort = musicGenreSort;
-    }
-
-    public boolean isDlnaGenreCountVisible() {
-        return dlnaGenreCountVisible;
-    }
-
-    public void setDlnaGenreCountVisible(boolean dlnaGenreCountVisible) {
-        this.dlnaGenreCountVisible = dlnaGenreCountVisible;
     }
 
     public Integer getDlnaRandomMax() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DLNASettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DLNASettingsController.java
@@ -156,7 +156,6 @@ public class DLNASettingsController {
         command.setAlbumGenreSort(Sort.of(settingsService.getUPnPAlbumGenreSort()));
         command.setAvairableSongGenreSort(Arrays.asList(Sort.FREQUENCY, Sort.NAME, Sort.SONG_COUNT));
         command.setSongGenreSort(Sort.of(settingsService.getUPnPSongGenreSort()));
-        command.setDlnaGenreCountVisible(settingsService.isDlnaGenreCountVisible());
         command.setDlnaRandomMax(settingsService.getDlnaRandomMax());
         command.setDlnaGuestPublish(settingsService.isDlnaGuestPublish());
 
@@ -202,9 +201,6 @@ public class DLNASettingsController {
         settingsService.setUPnPSongGenreSort(command.getSongGenreSort().name());
         final List<Integer> allowedIds = Arrays.stream(command.getAllowedMusicFolderIds()).boxed()
                 .collect(Collectors.toList());
-        List<Integer> allIds = musicFolderService.getAllMusicFolders().stream().map(MusicFolder::getId)
-                .collect(Collectors.toList());
-        settingsService.setDlnaGenreCountVisible(command.isDlnaGenreCountVisible() && allIds.equals(allowedIds));
         settingsService.setDlnaGuestPublish(command.isDlnaGuestPublish());
         int randomMax = Objects.isNull(command.getDlnaRandomMax()) || command.getDlnaRandomMax() == 0
                 ? DLNA_RANDOM_DEFAULT : command.getDlnaRandomMax();

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SettingsConstants.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SettingsConstants.java
@@ -282,7 +282,6 @@ final class SettingsConstants {
                     GenreMasterCriteria.Sort.FREQUENCY.name());
             static final Pair<String> UPNP_SONG_GENRE_SORT = Pair.of("UPnPSongGenreSort",
                     GenreMasterCriteria.Sort.FREQUENCY.name());
-            static final Pair<Boolean> GENRE_COUNT = Pair.of("DlnaGenreCountVisible", false);
             static final Pair<Integer> RANDOM_MAX = Pair.of("DlnaRandomMax", 50);
             static final Pair<Boolean> GUEST_PUBLISH = Pair.of("DlnaGuestPublish", true);
 

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SettingsService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SettingsService.java
@@ -104,7 +104,7 @@ public class SettingsService implements ReadWriteLockSupport {
             "DlnaArtistByFolderVisible", "DlnaAlbumVisible", "DlnaPlaylistVisible", "DlnaAlbumByGenreVisible",
             "DlnaSongByGenreVisible", "DlnaRecentAlbumVisible", "DlnaRecentAlbumId3Visible", "DlnaRandomSongVisible",
             "DlnaRandomAlbumVisible", "DlnaRandomSongByArtistVisible", "DlnaRandomSongByFolderArtistVisible",
-            "DlnaPodcastVisible");
+            "DlnaPodcastVisible", "DlnaGenreCountVisible");
 
     private static final int ELEMENT_COUNT_IN_LINE_OF_THEME = 2;
 
@@ -1258,14 +1258,6 @@ public class SettingsService implements ReadWriteLockSupport {
 
     public void setUPnPSongGenreSort(String s) {
         setProperty(SettingsConstants.UPnP.Options.UPNP_SONG_GENRE_SORT, s);
-    }
-
-    public boolean isDlnaGenreCountVisible() {
-        return getBoolean(SettingsConstants.UPnP.Options.GENRE_COUNT);
-    }
-
-    public void setDlnaGenreCountVisible(boolean b) {
-        setProperty(SettingsConstants.UPnP.Options.GENRE_COUNT, b);
     }
 
     public int getDlnaRandomMax() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/AlbumByGenreProc.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/AlbumByGenreProc.java
@@ -55,7 +55,7 @@ public class AlbumByGenreProc extends DirectChildrenContentProc<Genre, MediaFile
 
     @Override
     public Container createContainer(Genre genre) {
-        return factory.toGenre(genre, getProcId(), util.isGenreCountAvailable(), genre.getSongCount());
+        return factory.toGenre(genre, getProcId(), genre.getSongCount());
     }
 
     @Override

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/AlbumId3ByGenreProc.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/AlbumId3ByGenreProc.java
@@ -71,7 +71,7 @@ public class AlbumId3ByGenreProc extends DirectChildrenContentProc<Genre, GenreA
 
     @Override
     public Container createContainer(Genre genre) {
-        return factory.toId3Genre(genre, getProcId(), util.isGenreCountAvailable(), genre.getAlbumCount());
+        return factory.toId3Genre(genre, getProcId(), genre.getAlbumCount());
     }
 
     @Override

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/SongByGenreProc.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/SongByGenreProc.java
@@ -67,7 +67,7 @@ public class SongByGenreProc extends DirectChildrenContentProc<Genre, MediaFile>
 
     @Override
     public Container createContainer(Genre genre) {
-        return factory.toGenre(genre, getProcId(), util.isGenreCountAvailable(), genre.getSongCount());
+        return factory.toGenre(genre, getProcId(), genre.getSongCount());
     }
 
     @Override

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/UpnpDIDLFactory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/UpnpDIDLFactory.java
@@ -225,22 +225,20 @@ public class UpnpDIDLFactory implements CoverArtPresentation {
         return container;
     }
 
-    public GenreContainer toGenre(Genre genre, ProcId procId, boolean isCountVisible, int childCount) {
+    public GenreContainer toGenre(Genre genre, ProcId procId, int childCount) {
         GenreContainer container = new GenreContainer();
         container.setId(procId.getValue() + ProcId.CID_SEPA + genre.getName());
         container.setParentID(procId.getValue());
-        container.setTitle(isCountVisible ? genre.getName().concat(" ").concat(Integer.toString(genre.getSongCount()))
-                : genre.getName());
+        container.setTitle(genre.getName());
         container.setChildCount(childCount);
         return container;
     }
 
-    public GenreContainer toId3Genre(Genre genre, ProcId procId, boolean isCountVisible, int childCount) {
+    public GenreContainer toId3Genre(Genre genre, ProcId procId, int childCount) {
         GenreContainer container = new GenreContainer();
         container.setId(procId.getValue() + ProcId.CID_SEPA + genre.getName());
         container.setParentID(procId.getValue());
-        container.setTitle(isCountVisible ? genre.getName().concat(" ").concat(Integer.toString(genre.getSongCount()))
-                : genre.getName());
+        container.setTitle(genre.getName());
         container.setChildCount(childCount);
         return container;
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/UpnpProcessorUtil.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/UpnpProcessorUtil.java
@@ -25,20 +25,17 @@ import com.tesshu.jpsonic.domain.JpsonicComparators;
 import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.service.MusicFolderService;
 import com.tesshu.jpsonic.service.SecurityService;
-import com.tesshu.jpsonic.service.SettingsService;
 import org.springframework.stereotype.Component;
 
 @Component
 public class UpnpProcessorUtil {
 
-    private final SettingsService settingsService;
     private final MusicFolderService musicFolderService;
     private final SecurityService securityService;
     private final JpsonicComparators comparators;
 
-    public UpnpProcessorUtil(SettingsService settingsService, MusicFolderService musicFolderService,
-            SecurityService securityService, JpsonicComparators comparators) {
-        this.settingsService = settingsService;
+    public UpnpProcessorUtil(MusicFolderService musicFolderService, SecurityService securityService,
+            JpsonicComparators comparators) {
         this.musicFolderService = musicFolderService;
         this.securityService = securityService;
         this.comparators = comparators;
@@ -46,11 +43,6 @@ public class UpnpProcessorUtil {
 
     public List<MusicFolder> getGuestFolders() {
         return musicFolderService.getMusicFoldersForUser(securityService.getGuestUser().getUsername());
-    }
-
-    public boolean isGenreCountAvailable() {
-        return settingsService.isDlnaGenreCountVisible()
-                && getGuestFolders().equals(musicFolderService.getAllMusicFolders());
     }
 
     public boolean isSortAlbumsByYear(String artist) {

--- a/jpsonic-main/src/main/resources/com/tesshu/jpsonic/i18n/ResourceBundle_en.properties
+++ b/jpsonic-main/src/main/resources/com/tesshu/jpsonic/i18n/ResourceBundle_en.properties
@@ -883,7 +883,6 @@ dlnasettings.dlnasettings.genresort.frequency=Song cnt order
 dlnasettings.dlnasettings.genresort.name=Name order
 dlnasettings.dlnasettings.genresort.album_count=Album cnt, Name
 dlnasettings.dlnasettings.genresort.song_count=Song cnt, Name
-dlnasettings.genreCountVisible=Show counts
 dlnasettings.guestpublish=Visible Only
 dlnasettings.randommax=Maximum size
 dlnasettings.functionName=The name of function

--- a/jpsonic-main/src/main/resources/com/tesshu/jpsonic/i18n/ResourceBundle_ja_JP.properties
+++ b/jpsonic-main/src/main/resources/com/tesshu/jpsonic/i18n/ResourceBundle_ja_JP.properties
@@ -863,7 +863,6 @@ dlnasettings.dlnasettings.genresort.name=\u540d\u79f0\u9806
 dlnasettings.dlnasettings.genresort.album_count=\u30a2\u30eb\u30d0\u30e0\u6570/\u540d\u79f0\u9806
 dlnasettings.dlnasettings.genresort.song_count=\u66f2\u6570/\u540d\u79f0\u9806
 dlnasettings.filestructuresearch=Web\u753b\u9762\u3068\u540c\u3058\u691c\u7d22\u65b9\u5f0f\u3092\u4f7f\u7528\u3059\u308b
-dlnasettings.genreCountVisible=\u4ef6\u6570\u3092\u8868\u793a
 dlnasettings.guestpublish=\u300c\u516c\u958b\u4e2d\u300d\u306e\u307f
 dlnasettings.randommax=\u6700\u5927\u30b5\u30a4\u30ba
 dlnasettings.functionName=\u6a5f\u80fd\u9805\u76ee

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/dlnaSettings.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/dlnaSettings.jsp
@@ -325,26 +325,13 @@
                                         </form:select>
                                     </td>
                                 </c:when>
-                                <c:when test="${subMenuItem.id eq MenuItemId.ALBUM_BY_GENRE}">
-                                    <td class="${ifDisabled}">
-                                        <form:checkbox path="dlnaGenreCountVisible" id="dlnaGenreCountVisible"/>
-                                        <label for="dlnaGenreCountVisible"><fmt:message key="dlnasettings.genreCountVisible"/></label>
-                                        <c:import url="helpToolTip.jsp"><c:param name="topic" value="dlnagenrecountvisible"/></c:import>
-                                    </td>
-                                </c:when>
                                 <c:otherwise>
+                                    <td class="${ifDisabled}"/>
                                 </c:otherwise>
                             </c:choose>
                         </c:when>
                         <c:when test="${isFirstSubMenu}">
                             <c:choose>
-                                <c:when test="${subMenuItem.parent eq MenuItemId.GENRE}">
-                                    <td rowspan="${rowInfo.count()}" class="${ifDisabled}">
-                                        <form:checkbox path="dlnaGenreCountVisible" id="dlnaGenreCountVisible"/>
-                                        <label for="dlnaGenreCountVisible"><fmt:message key="dlnasettings.genreCountVisible"/></label>
-                                        <c:import url="helpToolTip.jsp"><c:param name="topic" value="dlnagenrecountvisible"/></c:import>
-                                    </td>
-                                </c:when>
                                 <c:when test="${subMenuItem.parent eq MenuItemId.SHUFFLE}">
                                     <td rowspan="${rowInfo.count()}" class="${ifDisabled}">
                                         <label for="dlnaRandomMax"><fmt:message key="dlnasettings.randommax"/></label>

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DLNASettingsControllerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/DLNASettingsControllerTest.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.annotation.Documented;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -39,10 +38,8 @@ import com.tesshu.jpsonic.domain.GenreMasterCriteria.Sort;
 import com.tesshu.jpsonic.domain.MenuItem;
 import com.tesshu.jpsonic.domain.MenuItem.ViewType;
 import com.tesshu.jpsonic.domain.MenuItemId;
-import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.domain.Player;
 import com.tesshu.jpsonic.domain.TranscodeScheme;
-import com.tesshu.jpsonic.domain.User;
 import com.tesshu.jpsonic.service.ApacheCommonsConfigurationService;
 import com.tesshu.jpsonic.service.MenuItemService;
 import com.tesshu.jpsonic.service.MenuItemService.MenuItemWithDefaultName;
@@ -227,56 +224,6 @@ class DLNASettingsControllerTest {
                     command.getSubMenuItemRowInfos().get(MenuItemId.ALBUM).firstChild().getId());
             assertEquals(1, command.getSubMenuItemRowInfos().get(MenuItemId.ALBUM).count());
         }
-    }
-
-    @Test
-    void testIsDlnaGenreCountVisible() {
-        settingsService = mock(SettingsService.class);
-        musicFolderService = mock(MusicFolderService.class);
-        upnpService = mock(UPnPService.class);
-        controller = new DLNASettingsController(settingsService, musicFolderService, mock(SecurityService.class),
-                mock(PlayerService.class), mock(TranscodingService.class), upnpService, mock(ShareService.class),
-                mock(MenuItemService.class), mock(OutlineHelpSelector.class));
-        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
-
-        DLNASettingsCommand command = new DLNASettingsCommand();
-        command.setDlnaGenreCountVisible(false);
-        command.setTopMenuItems(Collections.emptyList());
-        command.setSubMenuItems(Collections.emptyList());
-        command.setAlbumGenreSort(Sort.FREQUENCY);
-        command.setSongGenreSort(Sort.FREQUENCY);
-        ArgumentCaptor<Boolean> captor = ArgumentCaptor.forClass(boolean.class);
-        Mockito.doNothing().when(settingsService).setDlnaGenreCountVisible(captor.capture());
-        controller.post(command, Mockito.mock(RedirectAttributes.class));
-        Mockito.verify(settingsService, Mockito.times(1)).setDlnaGenreCountVisible(Mockito.any(boolean.class));
-        assertFalse(captor.getValue());
-
-        command.setDlnaGenreCountVisible(true);
-        Mockito.doNothing().when(settingsService).setDlnaGenreCountVisible(captor.capture());
-        controller.post(command, Mockito.mock(RedirectAttributes.class));
-        Mockito.verify(settingsService, Mockito.times(2)).setDlnaGenreCountVisible(Mockito.any(boolean.class));
-        assertTrue(captor.getValue());
-
-        /*
-         * Always false if all folders are not allowed. Because the genre count is a statistical result for all
-         * directories.
-         */
-        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder("", null, true, null, false));
-        Mockito.when(musicFolderService.getAllMusicFolders()).thenReturn(musicFolders);
-        Mockito.when(musicFolderService.getMusicFoldersForUser(User.USERNAME_GUEST)).thenReturn(musicFolders);
-
-        command.setDlnaGenreCountVisible(false);
-        captor = ArgumentCaptor.forClass(boolean.class);
-        Mockito.doNothing().when(settingsService).setDlnaGenreCountVisible(captor.capture());
-        controller.post(command, Mockito.mock(RedirectAttributes.class));
-        Mockito.verify(settingsService, Mockito.times(3)).setDlnaGenreCountVisible(Mockito.any(boolean.class));
-        assertFalse(captor.getValue());
-
-        command.setDlnaGenreCountVisible(true);
-        Mockito.doNothing().when(settingsService).setDlnaGenreCountVisible(captor.capture());
-        controller.post(command, Mockito.mock(RedirectAttributes.class));
-        Mockito.verify(settingsService, Mockito.times(4)).setDlnaGenreCountVisible(Mockito.any(boolean.class));
-        assertFalse(captor.getValue());
     }
 
     @Nested

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/SettingsServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/SettingsServiceTest.java
@@ -587,11 +587,6 @@ class SettingsServiceTest {
     }
 
     @Test
-    void testIsDlnaGenreCountVisible() {
-        assertFalse(settingsService.isDlnaGenreCountVisible());
-    }
-
-    @Test
     void testIsDlnaGuestPublish() {
         assertTrue(settingsService.isDlnaGuestPublish());
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/UPnPSearchCriteriaDirectorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/UPnPSearchCriteriaDirectorTest.java
@@ -255,8 +255,7 @@ public class UPnPSearchCriteriaDirectorTest {
         path = path.trim();
         fid = fid.trim();
 
-        UpnpProcessorUtil util = new UpnpProcessorUtil(settingsService, musicFolderService, mock(SecurityService.class),
-                null);
+        UpnpProcessorUtil util = new UpnpProcessorUtil(musicFolderService, mock(SecurityService.class), null);
         director = new UPnPSearchCriteriaDirector(
                 new QueryFactory(settingsService, new AnalyzerFactory(settingsService)), util);
     }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/AlbumByGenreProcTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/AlbumByGenreProcTest.java
@@ -30,7 +30,6 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 
@@ -72,7 +71,7 @@ class AlbumByGenreProcTest {
                 transcodingService);
         mediaFileService = mock(MediaFileService.class);
         searchService = mock(SearchService.class);
-        util = new UpnpProcessorUtil(settingsService, mock(MusicFolderService.class), mock(SecurityService.class),
+        util = new UpnpProcessorUtil(mock(MusicFolderService.class), mock(SecurityService.class),
                 mock(JpsonicComparators.class));
         proc = new AlbumByGenreProc(util, factory, mediaFileService, searchService);
     }
@@ -91,10 +90,6 @@ class AlbumByGenreProcTest {
         assertEquals("abg", container.getParentID());
         assertEquals("English/Japanese", container.getTitle());
         assertEquals(50, container.getChildCount());
-
-        when(settingsService.isDlnaGenreCountVisible()).thenReturn(true);
-        container = proc.createContainer(genre);
-        assertEquals("English/Japanese 50", container.getTitle());
     }
 
     @Test

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/SongByGenreProcTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/SongByGenreProcTest.java
@@ -85,7 +85,7 @@ class SongByGenreProcTest {
             factory = new UpnpDIDLFactory(settingsService, jwtSecurityService, mediaFileService, playerService,
                     transcodingService);
             searchService = mock(SearchService.class);
-            util = new UpnpProcessorUtil(settingsService, mock(MusicFolderService.class), mock(SecurityService.class),
+            util = new UpnpProcessorUtil(mock(MusicFolderService.class), mock(SecurityService.class),
                     mock(JpsonicComparators.class));
             proc = new SongByGenreProc(settingsService, util, factory, searchService);
         }
@@ -104,10 +104,6 @@ class SongByGenreProcTest {
             assertEquals("sbg", container.getParentID());
             assertEquals("English/Japanese", container.getTitle());
             assertEquals(50, container.getChildCount());
-
-            when(settingsService.isDlnaGenreCountVisible()).thenReturn(true);
-            container = proc.createContainer(genre);
-            assertEquals("English/Japanese 50", container.getTitle());
         }
 
         @Test

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/UpnpProcessorUtilTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/UpnpProcessorUtilTest.java
@@ -21,16 +21,8 @@ package com.tesshu.jpsonic.service.upnp.processor;
 
 import static com.tesshu.jpsonic.service.ServiceMockUtils.mock;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 import com.tesshu.jpsonic.domain.JpsonicComparators;
-import com.tesshu.jpsonic.domain.MusicFolder;
-import com.tesshu.jpsonic.domain.User;
 import com.tesshu.jpsonic.service.MusicFolderService;
 import com.tesshu.jpsonic.service.SecurityService;
 import com.tesshu.jpsonic.service.SettingsService;
@@ -40,15 +32,13 @@ import org.mockito.Mockito;
 
 class UpnpProcessorUtilTest {
 
-    private MusicFolderService musicFolderService;
     private SettingsService settingsService;
     private UpnpProcessorUtil util;
 
     @BeforeEach
     public void setup() {
-        musicFolderService = mock(MusicFolderService.class);
         settingsService = mock(SettingsService.class);
-        util = new UpnpProcessorUtil(settingsService, musicFolderService, mock(SecurityService.class),
+        util = new UpnpProcessorUtil(mock(MusicFolderService.class), mock(SecurityService.class),
                 mock(JpsonicComparators.class));
     }
 
@@ -56,26 +46,5 @@ class UpnpProcessorUtilTest {
     void testGetAllMusicFolders() {
         Mockito.when(settingsService.isDlnaGuestPublish()).thenReturn(true);
         assertNotNull(util.getGuestFolders());
-    }
-
-    @Test
-    void testIsGenreCountAvailable() {
-        Mockito.when(settingsService.isDlnaGenreCountVisible()).thenReturn(false);
-        assertFalse(util.isGenreCountAvailable());
-
-        Mockito.when(settingsService.isDlnaGenreCountVisible()).thenReturn(true);
-        List<MusicFolder> musicFolders = Arrays.asList(new MusicFolder("", null, true, null, false));
-        Mockito.when(musicFolderService.getAllMusicFolders()).thenReturn(musicFolders);
-        Mockito.when(musicFolderService.getMusicFoldersForUser(User.USERNAME_GUEST)).thenReturn(musicFolders);
-        assertTrue(util.isGenreCountAvailable());
-
-        Mockito.when(musicFolderService.getAllMusicFolders()).thenReturn(Collections.emptyList());
-        Mockito.when(musicFolderService.getMusicFoldersForUser(User.USERNAME_GUEST)).thenReturn(musicFolders);
-        assertFalse(util.isGenreCountAvailable());
-
-        Mockito.when(musicFolderService.getAllMusicFolders()).thenReturn(musicFolders);
-        Mockito.when(musicFolderService.getMusicFoldersForUser(User.USERNAME_GUEST))
-                .thenReturn(Collections.emptyList());
-        assertFalse(util.isGenreCountAvailable());
     }
 }


### PR DESCRIPTION
Prerequisites: #2662

## Overview

Genre count display will be removed in UPnP.

![image](https://github.com/user-attachments/assets/2c6d7322-00ac-4c2b-9b8a-4ae40c5b8740)

## Details

 - Originally, totalMatch is included in the UPnP message, so the data is redundant. (Some client apps may use this for display purposes.)
 - The genre counting implemented in Jpsonic is different from before. All counts except "Subsonic Style" are accurate. This is because the Genre counts are calculated separately for each view. Displaying counts that rely on previous Genre designs is confusing and misleading.




