### PR TITLE
Revert commons-lang3

### DIFF
--- a/airsonic-taglibs/pom.xml
+++ b/airsonic-taglibs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.7</version>
+    <version>114.1.8</version>
   </parent>
   <artifactId>airsonic-taglibs</artifactId>
   <name>Airsonic Tag Libs</name>

--- a/airsonic-taglibs/pom.xml
+++ b/airsonic-taglibs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.6</version>
+    <version>114.1.7</version>
   </parent>
   <artifactId>airsonic-taglibs</artifactId>
   <name>Airsonic Tag Libs</name>

--- a/install/docker/alpine/pom.xml
+++ b/install/docker/alpine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.7</version>
+        <version>114.1.8</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/alpine/pom.xml
+++ b/install/docker/alpine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.6</version>
+        <version>114.1.7</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/jammy/pom.xml
+++ b/install/docker/jammy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.7</version>
+        <version>114.1.8</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/jammy/pom.xml
+++ b/install/docker/jammy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.6</version>
+        <version>114.1.7</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/ubi9/pom.xml
+++ b/install/docker/ubi9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.7</version>
+        <version>114.1.8</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/ubi9/pom.xml
+++ b/install/docker/ubi9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.6</version>
+        <version>114.1.7</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/jpsonic-concurent17/pom.xml
+++ b/jpsonic-concurent17/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.6</version>
+    <version>114.1.7</version>
   </parent>
   <artifactId>jpsonic-concurent17</artifactId>
   <name>Concurent Config for Java17</name>

--- a/jpsonic-concurent17/pom.xml
+++ b/jpsonic-concurent17/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.7</version>
+    <version>114.1.8</version>
   </parent>
   <artifactId>jpsonic-concurent17</artifactId>
   <name>Concurent Config for Java17</name>

--- a/jpsonic-concurent21/pom.xml
+++ b/jpsonic-concurent21/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.6</version>
+    <version>114.1.7</version>
   </parent>
   <artifactId>jpsonic-concurent21</artifactId>
   <name>Concurent Config for Java21</name>

--- a/jpsonic-concurent21/pom.xml
+++ b/jpsonic-concurent21/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.7</version>
+    <version>114.1.8</version>
   </parent>
   <artifactId>jpsonic-concurent21</artifactId>
   <name>Concurent Config for Java21</name>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.7</version>
+    <version>114.1.8</version>
   </parent>
   <artifactId>jpsonic-main</artifactId>
   <packaging>war</packaging>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.6</version>
+    <version>114.1.7</version>
   </parent>
   <artifactId>jpsonic-main</artifactId>
   <packaging>war</packaging>

--- a/jpsonic-upnp-template/pom.xml
+++ b/jpsonic-upnp-template/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.6</version>
+    <version>114.1.7</version>
   </parent>
   <artifactId>jpsonic-upnp-template</artifactId>
   <name>Upnp Template</name>

--- a/jpsonic-upnp-template/pom.xml
+++ b/jpsonic-upnp-template/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.7</version>
+    <version>114.1.8</version>
   </parent>
   <artifactId>jpsonic-upnp-template</artifactId>
   <name>Upnp Template</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tesshu.jpsonic.player</groupId>
   <artifactId>jpsonic</artifactId>
-  <version>114.1.7</version>
+  <version>114.1.8</version>
   <packaging>pom</packaging>
   <name>Jpsonic</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tesshu.jpsonic.player</groupId>
   <artifactId>jpsonic</artifactId>
-  <version>114.1.6</version>
+  <version>114.1.7</version>
   <packaging>pom</packaging>
   <name>Jpsonic</name>
 

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.7</version>
+    <version>114.1.8</version>
   </parent>
   <artifactId>subsonic-rest-api</artifactId>
   <name>Subsonic REST API</name>

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.6</version>
+    <version>114.1.7</version>
   </parent>
   <artifactId>subsonic-rest-api</artifactId>
   <name>Subsonic REST API</name>


### PR DESCRIPTION
## Overview

Some libraries will be reverted due to regressions identified in v114.1.7(#2668). 114.1.8 only includes the revert of commons-lang3.

## Details

v111.1.7 contains an issue where Docker becomes inoperable after a while after starting. (Docker Health Check also stays green for a while, then transitions to orange after a while.)

 - It appears to be slipping through the communication check that is performed immediately after startup, as is done in CI cases. 
 - They were not detected during a standalone Windows boot test.
 - You can work around this issue by reverting to the previous version v114.1.6, or by using the current latest version v114.1.8.

The commons-lang3 update may contain unknown Platform-related issues. Further investigation will take place later. (It won't be undertaken anytime soon)

## Additional Notes

After the release of v114.1.8, the v114.1.7 images will be removed from Dockerhub.


