### PR TITLE
Add Ubuntu 24.04 (Noble Numbat) base Docker Image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,230 @@ jobs:
           docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
           docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t jpsonic/jpsonic:ea .
   ##########################################################################
+  ship-docker-image-ubi9:
+    name: Docker(ubi9-amd)
+    needs: ship-war
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 21
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+      - name: Get current date
+        id: date
+        run: echo "current=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+      - name: Download package
+        uses: actions/download-artifact@v4
+        with:
+          name: jpsonic-jetty-embedded-for-jdk21-${{ steps.date.outputs.current }}
+      - name: Create Tag
+        run: |
+          echo "DOCKER_TAG=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
+      - name: Copy artifact
+        run: |
+          mkdir -p install/docker/ubi9/target/dependency
+          mv jpsonic.war install/docker/ubi9/target/dependency
+      - name: Release with Version Tag
+        if: "(github.ref == 'refs/heads/master')"
+        run: |
+          if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            cd install/docker/ubi9
+            sed -i -e "s/21-jdk-ubi9-minimal/21-jre-ubi9-minimal/g" Dockerfile
+            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
+            mvn -DdockerTag=${{ env.DOCKER_TAG }}-ubi9 package
+            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+            docker buildx build --push --platform linux/amd64 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-ubi9 .
+            mvn -DdockerTag=${DOCKER_TAG%.*}-ubi9 package
+            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+            docker buildx build --push --platform linux/amd64 -t jpsonic/jpsonic:${DOCKER_TAG%.*}-ubi9 .
+            mvn -DdockerTag=${DOCKER_TAG%.*.*}-ubi9 package
+            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+            docker buildx build --push --platform linux/amd64 -t jpsonic/jpsonic:${DOCKER_TAG%.*.*}-ubi9 .
+          fi
+      - name: Release with Latest Tag
+        if: github.ref == 'refs/heads/master'
+        run: |
+          if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            cd install/docker/ubi9
+            sed -i -e "s/21-jdk-ubi9-minimal/21-jre-ubi9-minimal/g" Dockerfile
+            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
+            mvn -DdockerTag=latest-ubi9 package
+            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+            docker buildx build --push --platform linux/amd64 -t jpsonic/jpsonic:latest-ubi9 .
+          fi
+      - name: Release with Alpha/Beta Tag
+        if: github.ref == 'refs/heads/master'
+        run: |
+          if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.(alpha|beta)\.[0-9]+\.[0-9]+$ ]]; then
+            cd install/docker/ubi9
+            sed -i -e "s/21-jdk-ubi9-minimal/21-jre-ubi9-minimal/g" Dockerfile
+            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
+            mvn -DdockerTag=latest-ubi9 package
+            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+            docker buildx build --push --platform linux/amd64 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-ubi9 .
+          fi
+      - name: Release with Early-Access Tag
+        if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/feature/docker'
+        run: |
+          cd install/docker/ubi9
+          mvn -DdockerTag=ea-ubi9 package
+          docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+          docker buildx build --push --platform linux/amd64 -t jpsonic/jpsonic:ea-ubi9 .
+  ##########################################################################
+  ship-docker-image-noble:
+    name: Docker(noble-amd,arm)
+    needs: ship-war
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 21
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+      - name: Get current date
+        id: date
+        run: echo "current=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+      - name: Download package
+        uses: actions/download-artifact@v4
+        with:
+          name: jpsonic-jetty-embedded-for-jdk21-${{ steps.date.outputs.current }}
+      - name: Create Tag
+        run: |
+          echo "DOCKER_TAG=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
+      - name: Copy artifact
+        run: |
+          mkdir -p install/docker/noble/target/dependency
+          mv jpsonic.war install/docker/noble/target/dependency
+      - name: Release with Version Tag
+        if: "(github.ref == 'refs/heads/master')"
+        run: |
+          if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            cd install/docker/noble
+            sed -i -e "s/21-jdk-noble/21-jre-noble/g" Dockerfile
+            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
+            mvn -DdockerTag=${{ env.DOCKER_TAG }}-noble package
+            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+            docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-noble .
+            mvn -DdockerTag=${DOCKER_TAG%.*}-noble package
+            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+            docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t jpsonic/jpsonic:${DOCKER_TAG%.*}-noble .
+            mvn -DdockerTag=${DOCKER_TAG%.*.*}-noble package
+            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+            docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t jpsonic/jpsonic:${DOCKER_TAG%.*.*}-noble .
+          fi
+      - name: Release with Latest Tag
+        if: github.ref == 'refs/heads/master'
+        run: |
+          if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            cd install/docker/noble
+            sed -i -e "s/21-jdk-noble/21-jre-noble/g" Dockerfile
+            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
+            mvn -DdockerTag=latest-noble package
+            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+            docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t jpsonic/jpsonic:latest-noble .
+          fi
+      - name: Release with Alpha/Beta Tag
+        if: github.ref == 'refs/heads/master'
+        run: |
+          if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.(alpha|beta)\.[0-9]+\.[0-9]+$ ]]; then
+            cd install/docker/noble
+            sed -i -e "s/21-jdk-noble/21-jre-noble/g" Dockerfile
+            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
+            mvn -DdockerTag=latest-noble package
+            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+            docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-noble .
+          fi
+      - name: Release with Early-Access Tag
+        if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/feature/docker'
+        run: |
+          cd install/docker/noble
+          mvn -DdockerTag=ea-noble package
+          docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+          docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t jpsonic/jpsonic:ea-noble .
+  ##########################################################################
+  ship-docker-image-noble-v7:
+    name: Docker(noble-arm/v7)
+    needs: ship-war
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+      - name: Get current date
+        id: date
+        run: echo "current=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+      - name: Download package
+        uses: actions/download-artifact@v4
+        with:
+          name: jpsonic-jetty-embedded-for-jdk17-${{ steps.date.outputs.current }}
+      - name: Create Tag
+        run: |
+          echo "DOCKER_TAG=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
+      - name: Copy artifact
+        run: |
+          mkdir -p install/docker/noble/target/dependency
+          mv jpsonic.war install/docker/noble/target/dependency
+      - name: Release with Version Tag
+        if: "(github.ref == 'refs/heads/master')"
+        run: |
+          if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            cd install/docker/noble
+            sed -i -e "s/21-jdk-noble/17-jre-noble/g" Dockerfile
+            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
+            mvn -DdockerTag=${{ env.DOCKER_TAG }}-noble package
+            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+            docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-noble-v7 .
+            mvn -DdockerTag=${DOCKER_TAG%.*}-noble package
+            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+            docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${DOCKER_TAG%.*}-noble-v7 .
+            mvn -DdockerTag=${DOCKER_TAG%.*.*}-noble package
+            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+            docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${DOCKER_TAG%.*.*}-noble-v7 .
+          fi
+      - name: Release with Latest Tag
+        if: github.ref == 'refs/heads/master'
+        run: |
+          if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            cd install/docker/noble
+            sed -i -e "s/21-jdk-noble/17-jre-noble/g" Dockerfile
+            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
+            mvn -DdockerTag=latest-noble package
+            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+            docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:latest-noble-v7 .
+          fi
+      - name: Release with Alpha/Beta Tag
+        if: github.ref == 'refs/heads/master'
+        run: |
+          if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.(alpha|beta)\.[0-9]+\.[0-9]+$ ]]; then
+            cd install/docker/noble
+            sed -i -e "s/21-jdk-noble/17-jre-noble/g" Dockerfile
+            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
+            mvn -DdockerTag=latest-noble package
+            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+            docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-noble-v7 .
+          fi
+  ##########################################################################
   ship-docker-image-jammy:
     name: Docker(jammy-amd,arm)
     needs: ship-war
@@ -434,91 +658,14 @@ jobs:
             docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-jammy-v7 .
           fi
   ##########################################################################
-  ship-docker-image-ubi9:
-    name: Docker(ubi9-amd)
-    needs: ship-war
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 21
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASS }}
-      - name: Get current date
-        id: date
-        run: echo "current=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
-      - name: Download package
-        uses: actions/download-artifact@v4
-        with:
-          name: jpsonic-jetty-embedded-for-jdk21-${{ steps.date.outputs.current }}
-      - name: Create Tag
-        run: |
-          echo "DOCKER_TAG=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
-      - name: Copy artifact
-        run: |
-          mkdir -p install/docker/ubi9/target/dependency
-          mv jpsonic.war install/docker/ubi9/target/dependency
-      - name: Release with Version Tag
-        if: "(github.ref == 'refs/heads/master')"
-        run: |
-          if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            cd install/docker/ubi9
-            sed -i -e "s/21-jdk-ubi9-minimal/21-jre-ubi9-minimal/g" Dockerfile
-            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
-            mvn -DdockerTag=${{ env.DOCKER_TAG }}-ubi9 package
-            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
-            docker buildx build --push --platform linux/amd64 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-ubi9 .
-            mvn -DdockerTag=${DOCKER_TAG%.*}-ubi9 package
-            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
-            docker buildx build --push --platform linux/amd64 -t jpsonic/jpsonic:${DOCKER_TAG%.*}-ubi9 .
-            mvn -DdockerTag=${DOCKER_TAG%.*.*}-ubi9 package
-            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
-            docker buildx build --push --platform linux/amd64 -t jpsonic/jpsonic:${DOCKER_TAG%.*.*}-ubi9 .
-          fi
-      - name: Release with Latest Tag
-        if: github.ref == 'refs/heads/master'
-        run: |
-          if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            cd install/docker/ubi9
-            sed -i -e "s/21-jdk-ubi9-minimal/21-jre-ubi9-minimal/g" Dockerfile
-            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
-            mvn -DdockerTag=latest-ubi9 package
-            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
-            docker buildx build --push --platform linux/amd64 -t jpsonic/jpsonic:latest-ubi9 .
-          fi
-      - name: Release with Alpha/Beta Tag
-        if: github.ref == 'refs/heads/master'
-        run: |
-          if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.(alpha|beta)\.[0-9]+\.[0-9]+$ ]]; then
-            cd install/docker/ubi9
-            sed -i -e "s/21-jdk-ubi9-minimal/21-jre-ubi9-minimal/g" Dockerfile
-            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
-            mvn -DdockerTag=latest-ubi9 package
-            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
-            docker buildx build --push --platform linux/amd64 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-ubi9 .
-          fi
-      - name: Release with Early-Access Tag
-        if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/feature/docker'
-        run: |
-          cd install/docker/ubi9
-          mvn -DdockerTag=ea-ubi9 package
-          docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
-          docker buildx build --push --platform linux/amd64 -t jpsonic/jpsonic:ea-ubi9 .
-  ##########################################################################
   run-docker4latest:
     name: Run ${{ matrix.tag }}
-    needs: [ ship-docker-image, ship-docker-image-jammy, ship-docker-image-jammy-v7, ship-docker-image-ubi9 ]
+    needs: [ ship-docker-image, ship-docker-image-ubi9, ship-docker-image-noble, ship-docker-image-noble-v7, ship-docker-image-jammy, ship-docker-image-jammy-v7 ]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tag: [ latest, latest-jammy ]
+        tag: [ latest, latest-ubi9, latest-noble, latest-jammy ]
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -530,25 +677,25 @@ jobs:
       - name: Boot test for ea (Within 30 sec)
         run: |
           mkdir -p /tmp/${{ matrix.tag }}
-          cp install/docker/production.windows.yml /tmp/${{ matrix.tag }}
+          cp install/docker/production.synology.yml /tmp/${{ matrix.tag }}
           cd /tmp/${{ matrix.tag }}
           mkdir -p /tmp/${{ matrix.tag }}/jpsonic/data /tmp/${{ matrix.tag }}/jpsonic/music /tmp/${{ matrix.tag }}/jpsonic/podcasts /tmp/${{ matrix.tag }}/jpsonic/playlists
-          sed -i -e "s/image: 'jpsonic\/jpsonic:latest'/image: 'jpsonic\/jpsonic:${{ matrix.tag }}'/g" production.windows.yml
-          sed -i -e "s/container_name: 'jpsonic'/container_name: 'jpsonic_${{ matrix.tag }}'/g" production.windows.yml
-          sed -i -e "s/\/c\/tmp\/jpsonic/\/tmp\/${{ matrix.tag }}\/jpsonic/g" production.windows.yml
-          cat production.windows.yml
+          sed -i -e "s/image: 'jpsonic\/jpsonic:latest'/image: 'jpsonic\/jpsonic:${{ matrix.tag }}'/g" production.synology.yml
+          sed -i -e "s/container_name: 'jpsonic'/container_name: 'jpsonic_${{ matrix.tag }}'/g" production.synology.yml
+          sed -i -e "s/\/c\/tmp\/jpsonic/\/tmp\/${{ matrix.tag }}\/jpsonic/g" production.synology.yml
+          cat production.synology.yml
           set -x
-          docker compose -f production.windows.yml up -d
-          for i in {1..30};do sleep 1;curl http://localhost:8080/rest/ping&&break;done
+          docker compose -f production.synology.yml up -d
+          for i in {1..30};do sleep 1;curl http://localhost:4040/rest/ping&&break;done
   ##########################################################################
   run-docker4ea:
     name: Run ${{ matrix.tag }}
-    needs: [ ship-docker-image, ship-docker-image-jammy, ship-docker-image-jammy-v7, ship-docker-image-ubi9 ]
+    needs: [ ship-docker-image, ship-docker-image-ubi9, ship-docker-image-noble, ship-docker-image-noble-v7, ship-docker-image-jammy, ship-docker-image-jammy-v7 ]
     if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/feature/docker'
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tag: [ ea, ea-jammy ]
+        tag: [ ea, ea-ubi9, ea-noble, ea-jammy ]
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -560,13 +707,13 @@ jobs:
       - name: Boot test for ea (Within 30 sec)
         run: |
           mkdir -p /tmp/${{ matrix.tag }}
-          cp install/docker/production.windows.yml /tmp/${{ matrix.tag }}
+          cp install/docker/production.synology.yml /tmp/${{ matrix.tag }}
           cd /tmp/${{ matrix.tag }}
           mkdir -p /tmp/${{ matrix.tag }}/jpsonic/data /tmp/${{ matrix.tag }}/jpsonic/music /tmp/${{ matrix.tag }}/jpsonic/podcasts /tmp/${{ matrix.tag }}/jpsonic/playlists
-          sed -i -e "s/image: 'jpsonic\/jpsonic:latest'/image: 'jpsonic\/jpsonic:${{ matrix.tag }}'/g" production.windows.yml
-          sed -i -e "s/container_name: 'jpsonic'/container_name: 'jpsonic_${{ matrix.tag }}'/g" production.windows.yml
-          sed -i -e "s/\/c\/tmp\/jpsonic/\/tmp\/${{ matrix.tag }}\/jpsonic/g" production.windows.yml
-          cat production.windows.yml
+          sed -i -e "s/image: 'jpsonic\/jpsonic:latest'/image: 'jpsonic\/jpsonic:${{ matrix.tag }}'/g" production.synology.yml
+          sed -i -e "s/container_name: 'jpsonic'/container_name: 'jpsonic_${{ matrix.tag }}'/g" production.synology.yml
+          sed -i -e "s/\/c\/tmp\/jpsonic/\/tmp\/${{ matrix.tag }}\/jpsonic/g" production.synology.yml
+          cat production.synology.yml
           set -x
-          docker compose -f production.windows.yml up -d
-          for i in {1..30};do sleep 1;curl http://localhost:8080/rest/ping&&break;done
+          docker compose -f production.synology.yml up -d
+          for i in {1..30};do sleep 1;curl http://localhost:4040/rest/ping&&break;done

--- a/install/docker/jammy/Dockerfile
+++ b/install/docker/jammy/Dockerfile
@@ -31,7 +31,7 @@ WORKDIR $JPSONIC_DIR
 
 COPY local.conf /etc/fonts
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     software-properties-common \
     gosu \
     tini \

--- a/install/docker/noble/.dockerignore
+++ b/install/docker/noble/.dockerignore
@@ -1,0 +1,5 @@
+.gitignore
+pom.xml
+production.yml
+target/
+!target/dependency/*

--- a/install/docker/noble/Dockerfile
+++ b/install/docker/noble/Dockerfile
@@ -1,0 +1,64 @@
+FROM eclipse-temurin:21-jdk-noble
+
+LABEL description="Jpsonic is a free, web-based media streamer, providing ubiquitious access to your music." \
+      url="https://github.com/jpsonic/jpsonic"
+
+ENV JPSONIC_DIR=/jpsonic \
+    CONTEXT_PATH=/ \
+    JPSONIC_PORT=4040 \
+    UPNP_PORT=4041 \
+    UPNP_IDLE_INTERVAL=30 \
+    UPNP_MAX_CONNECTIONS=50 \
+    UPNP_MAX_IDLE_CONNECTIONS=30 \
+    UPNP_DRAIN_AMOUNT=65536 \
+    UPNP_MAX_REQ_HEADERS=200 \
+    UPNP_MAX_REQ_TIME=500 \
+    UPNP_MAX_RSP_TIME=500 \
+    UPNP_NODELAY=true \
+    SHOW_DATA_DIR=true \
+    USER_ID=1000 \
+    GROUP_ID=1000 \
+    TIME_ZONE=GB \
+    BANNER_MODE=OFF \
+    LOG_LEVEL=WARN \
+    SCAN_ON_BOOT=false \
+    EMBEDDED_FONT=false \
+    MIME_DSF=audio/x-dsd \
+    MIME_DFF=audio/x-dsd \
+    JAVA_OPTS="-Xms512m -Xmx512m -XX:+UseG1GC -XX:MaxGCPauseMillis=500"
+
+WORKDIR $JPSONIC_DIR
+
+COPY local.conf /etc/fonts
+
+RUN apt-get update && apt-get -q install -y --no-install-recommends \
+    software-properties-common \
+    gosu \
+    tini \
+    fonts-noto-cjk \
+    ffmpeg \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm /usr/share/fonts/opentype/noto/NotoSansCJK-Bold.ttc \
+    && rm /usr/share/fonts/opentype/noto/NotoSerifCJK-Bold.ttc \
+    && rm /usr/share/fonts/opentype/noto/NotoSerifCJK-Regular.ttc \
+    && fc-cache -vf
+
+EXPOSE $JPSONIC_PORT
+EXPOSE $UPNP_PORT
+EXPOSE 1900/udp
+EXPOSE 3333
+
+VOLUME \
+    $JPSONIC_DIR/data \
+    $JPSONIC_DIR/music \
+    $JPSONIC_DIR/playlists \
+    $JPSONIC_DIR/podcasts
+
+HEALTHCHECK --interval=30s --timeout=2s CMD export HEALTHCHECK_QUERY=$(echo localhost:"$JPSONIC_PORT""$CONTEXT_PATH"/rest/ping | tr -s /);wget -q http://"$HEALTHCHECK_QUERY" -O /dev/null || exit 1
+
+COPY entry-point.sh /usr/local/bin/entry-point.sh
+RUN chmod +x /usr/local/bin/entry-point.sh
+COPY target/dependency/jpsonic.war jpsonic.war
+
+ENTRYPOINT ["tini", "-e", "143", "--", "entry-point.sh"]

--- a/install/docker/noble/entry-point.sh
+++ b/install/docker/noble/entry-point.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+groupname=$(getent group "$GROUP_ID" | cut -d":" -f1)
+if [ -z "$groupname" ]; then
+    groupname=jpsonic
+    addgroup -g "$GROUP_ID" -S $groupname
+fi
+
+username=$(getent passwd "$USER_ID" | cut -d":" -f1)
+if [ -z "$username" ]; then
+    username=jpsonic
+	adduser \
+	    -u "$USER_ID" \
+	    --disabled-password \
+	    --gecos "" \
+	    --home "$JPSONIC_DIR" \
+	    --ingroup "$groupname" \
+	    jpsonic
+fi
+
+addgroup "$username" "$groupname"
+
+gosu "$username":"$groupname" mkdir -p "$JPSONIC_DIR"/data/transcode
+rm -f "$JPSONIC_DIR"/data/transcode/ffmpeg
+gosu "$username":"$groupname" ln -fs /usr/bin/ffmpeg "$JPSONIC_DIR"/data/transcode/ffmpeg
+rm -f "$JPSONIC_DIR"/data/transcode/ffprobe
+gosu "$username":"$groupname" ln -fs /usr/bin/ffprobe "$JPSONIC_DIR"/data/transcode/ffprobe
+
+if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
+
+    java_opts_array=()
+    while IFS= read -r -d '' item; do
+        java_opts_array+=( "$item" )
+    done < <([[ $JAVA_OPTS ]] && xargs printf '%s\0' <<<"$JAVA_OPTS")
+
+    # su-exec and gosu may obscure exit codes.
+    # Use set to enable graceful shutdown.
+    set -- gosu "$username":"$groupname" java \
+     -Dserver.host=0.0.0.0 \
+     -Dserver.port="$JPSONIC_PORT" \
+     -Dserver.servlet.context-path="$CONTEXT_PATH" \
+     -Djpsonic.home="$JPSONIC_DIR"/data \
+     -Djpsonic.defaultMusicFolder="$JPSONIC_DIR"/music \
+     -Djpsonic.defaultPodcastFolder="$JPSONIC_DIR"/podcasts \
+     -Djpsonic.defaultPlaylistFolder="$JPSONIC_DIR"/playlists \
+     -Djpsonic.scan.onboot="$SCAN_ON_BOOT" \
+     -Djpsonic.embeddedfont="$EMBEDDED_FONT" \
+     -Djpsonic.mime.dsf="$MIME_DSF" \
+     -Djpsonic.mime.dff="$MIME_DFF" \
+     -DUPNP_PORT="$UPNP_PORT" \
+     -Dsun.net.httpserver.idleInterval="$UPNP_IDLE_INTERVAL" \
+     -Djdk.httpserver.maxConnections="$UPNP_MAX_CONNECTIONS" \
+     -Dsun.net.httpserver.maxIdleConnections="$UPNP_MAX_IDLE_CONNECTIONS" \
+     -Dsun.net.httpserver.drainAmount="$UPNP_DRAIN_AMOUNT" \
+     -Dsun.net.httpserver.maxReqHeaders="$UPNP_MAX_REQ_HEADERS" \
+     -Dsun.net.httpserver.maxReqTime="$UPNP_MAX_REQ_TIME" \
+     -Dsun.net.httpserver.maxRspTime="$UPNP_MAX_RSP_TIME" \
+     -Dsun.net.httpserver.nodelay="$UPNP_NODELAY" \
+     -Dspring.main.banner-mode="$BANNER_MODE" \
+     -Dlogging.level.com.tesshu.jpsonic="$LOG_LEVEL" \
+     -Djava.awt.headless=true \
+     -Duser.timezone="$TIME_ZONE" \
+     "${java_opts_array[@]}" \
+     -jar jpsonic.war "$@"
+fi
+
+exec "$@"

--- a/install/docker/noble/local.conf
+++ b/install/docker/noble/local.conf
@@ -1,0 +1,12 @@
+<?xml version='1.0'?>
+<!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
+<fontconfig>
+    <match target="pattern">
+        <test qual="any" name="family">
+            <string>sans-serif</string>
+        </test>
+        <edit name="family" mode="prepend" binding="same">
+            <string>Noto Sans CJK JP</string>
+        </edit>
+    </match>
+</fontconfig>

--- a/install/docker/noble/pom.xml
+++ b/install/docker/noble/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <relativePath>../../../pom.xml</relativePath>
+        <artifactId>jpsonic</artifactId>
+        <version>114.1.0</version>
+        <groupId>com.tesshu.jpsonic.player</groupId>
+    </parent>
+    <packaging>pom</packaging>
+    <artifactId>jpsonic-docker-noble</artifactId>
+    <name>Jpsonic Docker Image</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.40.1</version>
+                <executions>
+                    <execution>
+                        <id>build-image</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <name>${docker.container.repo}</name>
+                                    <build>
+                                        <dockerFile>${project.basedir}/Dockerfile</dockerFile>
+                                        <tags>${dockerTag}</tags>
+                                    </build>
+                                </image>
+                            </images>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <configuration>
+                    <stripClassifier>true</stripClassifier>
+                    <stripVersion>true</stripVersion>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
## Overview

A Docker image based on Ubuntu 24.04 (Noble Numbat) will be added. `noble` will be added as a suffix variation of Docker Tag.

 - latest-noble
 - latest-noble-v7
 - ea-noble

etc.

## Details

This is the planned successor to Ubuntu Jammy. However, it is not currently a silver bullet.

 - In the upstream image (temurin), the number of vulnerabilities in Noble is less than those in Jammy.
 - On Ubuntu, apt install requires an update, which brings in some new vulnerabilities.
 - As a result, at the Jpsonic layer, the number of vulnerabilities will be higher for Noble than for Jamay.

If we want a compact and elegant packaging, Ubuntu is not a very good starting point. (And that's probably not where Ubuntu excels.) Please understand that this image is intended for limited purposes such as verification, or support for arm/v7.

## Vulnerabilities 

Distributions other than Ubuntu, such as Alpine and Red Hat, have mostly been rated as No Vulnerabilities. (Of course it varies depending on the time and the timing, but in the long term it is very stable.) On machines with normal CPUs, using one of these may be desirable. i.e. latest or latest-ubi9.

![image](https://github.com/user-attachments/assets/d301ac01-382d-4a90-a32b-e130330f1820)





