### PR TITLE
Fix bug that Star in ID3Album was deleted by full scan

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -70,7 +70,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Repository
 public class MediaFileDao {
 
-    public static final int VERSION = 14;
+    public static final int VERSION = 15;
 
     private static final String INSERT_COLUMNS = DaoUtils.getInsertColumns(MediaFile.class);
     private static final String QUERY_COLUMNS = DaoUtils.getQueryColumns(MediaFile.class);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/MediaFileDao.java
@@ -526,6 +526,15 @@ public class MediaFileDao {
                 """, childrenLastUpdated, true, album.getArtist(), album.getName(), FAR_FUTURE, album.getPath());
     }
 
+    public void resetAlbumChildrenLastUpdated() {
+        template.update("""
+                update media_file
+                set children_last_updated = ?
+                where type in (?, ?, ?) and present
+                """, FAR_FUTURE, MediaFile.MediaType.MUSIC.name(), MediaFile.MediaType.AUDIOBOOK.name(),
+                MediaFile.MediaType.VIDEO.name());
+    }
+
     public int updateOrder(int id, int order) {
         return template.update("""
                 update media_file

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/scanner/ScannerProcedureService.java
@@ -213,7 +213,6 @@ public class ScannerProcedureService {
         if (settingsService.isIgnoreFileTimestamps()) {
             mediaFileDao.resetLastScanned(null);
             artistDao.deleteAll();
-            albumDao.deleteAll();
             indexManager.deleteAll();
         }
 
@@ -606,6 +605,11 @@ public class ScannerProcedureService {
         }
         boolean withPodcast = isPodcastInMusicFolders();
         iterateAlbumId3(scanDate, withPodcast);
+
+        if (settingsService.isIgnoreFileTimestamps()) {
+            mediaFileDao.resetAlbumChildrenLastUpdated();
+        }
+
         int countUpdate = updateAlbumId3s(scanDate, withPodcast);
         int countNew = createAlbumId3s(scanDate, withPodcast);
         String comment = "Update(%d)/New(%d)".formatted(countUpdate, countNew);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
@@ -107,7 +107,7 @@ public class IndexManager implements ReadWriteLockSupport {
      * of AnalyzerFactory, DocumentFactory or the class that they use.
      *
      */
-    private static final int INDEX_VERSION = 27;
+    private static final int INDEX_VERSION = 28;
 
     /**
      * Literal name of index top directory.

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/SubsonicRESTStarredTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/SubsonicRESTStarredTest.java
@@ -426,6 +426,36 @@ class SubsonicRESTStarredTest extends AbstractNeedsScan {
         Starred2 starred2 = response.getStarred2();
         assertNotNull(starred2);
         assertEquals(0, starred2.getArtist().size()); // TODO This is a case that has not yet been fixed.
-        assertEquals(0, starred2.getAlbum().size()); // TODO This is a case that has not yet been fixed.
+        assertEquals(1, starred2.getAlbum().size());
+        assertEquals("_ID3_ALBUM_ Bach: Goldberg Variations, Canons [Disc 1]", starred2.getAlbum().get(0).getName());
+        assertEquals(0, starred2.getSong().size());
+
+        // unstar
+        mvc.perform(MockMvcRequestBuilders.get("/rest/unstar").param(Attributes.Request.V.value(), apiVerion)
+                .param(Attributes.Request.C.value(), CLIENT_NAME)
+                .param(Attributes.Request.U.value(), ServiceMockUtils.ADMIN_NAME)
+                .param(Attributes.Request.P.value(), ADMIN_PASS).param(Attributes.Request.F.value(), EXPECTED_FORMAT)
+                // .param("artistId", Integer.toString(artists.get(0).getId()))
+                .param("albumId", Integer.toString(albums.get(0).getId())).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_STATUS).value(JSON_VALUE_OK))
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_VERSION).value(apiVerion));
+
+        result = mvc
+                .perform(MockMvcRequestBuilders.get("/rest/getStarred2").param(Attributes.Request.V.value(), apiVerion)
+                        .param(Attributes.Request.C.value(), CLIENT_NAME)
+                        .param(Attributes.Request.U.value(), ServiceMockUtils.ADMIN_NAME)
+                        .param(Attributes.Request.P.value(), ADMIN_PASS)
+                        .param(Attributes.Request.F.value(), EXPECTED_FORMAT).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_STATUS).value(JSON_VALUE_OK))
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_VERSION).value(apiVerion)).andReturn();
+
+        response = readResponse(result.getResponse().getContentAsString());
+        starred2 = response.getStarred2();
+        assertNotNull(starred2);
+        assertEquals(0, starred2.getArtist().size());
+        assertEquals(0, starred2.getAlbum().size());
+        assertEquals(0, starred2.getSong().size());
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/SubsonicRESTStarredTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/controller/SubsonicRESTStarredTest.java
@@ -1,0 +1,431 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.controller;
+
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.annotation.Documented;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tesshu.jpsonic.AbstractNeedsScan;
+import com.tesshu.jpsonic.TestCaseUtils;
+import com.tesshu.jpsonic.dao.AlbumDao;
+import com.tesshu.jpsonic.dao.ArtistDao;
+import com.tesshu.jpsonic.dao.MediaFileDao;
+import com.tesshu.jpsonic.domain.Album;
+import com.tesshu.jpsonic.domain.Artist;
+import com.tesshu.jpsonic.domain.MediaFile;
+import com.tesshu.jpsonic.domain.MusicFolder;
+import com.tesshu.jpsonic.service.ServiceMockUtils;
+import com.tesshu.jpsonic.service.SettingsService;
+import com.tesshu.jpsonic.util.connector.api.JsonResult;
+import com.tesshu.jpsonic.util.connector.api.Response;
+import com.tesshu.jpsonic.util.connector.api.Starred;
+import com.tesshu.jpsonic.util.connector.api.Starred2;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@AutoConfigureMockMvc
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class SubsonicRESTStarredTest extends AbstractNeedsScan {
+
+    private static final String CLIENT_NAME = "jpsonic";
+    private static final String ADMIN_PASS = "admin";
+    private static final String EXPECTED_FORMAT = "json";
+    private static final String JSON_PATH_STATUS = "$.subsonic-response.status";
+    private static final String JSON_PATH_VERSION = "$.subsonic-response.version";
+    private static final String JSON_VALUE_OK = "ok";
+
+    private final String apiVerion = TestCaseUtils.restApiVersion();
+    private final List<MusicFolder> musicFolders = List
+            .of(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 1, false));
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).findAndRegisterModules();
+
+    @Autowired
+    private MockMvc mvc;
+    @Autowired
+    private SettingsService settingsService;
+    @Autowired
+    private MediaFileDao mediaFileDao;
+    @Autowired
+    private ArtistDao artistDao;
+    @Autowired
+    private AlbumDao albumDao;
+
+    @Override
+    public List<MusicFolder> getMusicFolders() {
+        return musicFolders;
+    }
+
+    @BeforeEach
+    public void setup() {
+        populateDatabaseOnlyOnce();
+    }
+
+    private Response readResponse(String jsonContent) throws JsonMappingException, JsonProcessingException {
+        return objectMapper.readValue(jsonContent, JsonResult.class).getResponse();
+    }
+
+    @Documented
+    private @interface Decisions {
+        @interface DataType {
+            @interface FileStructure {
+            }
+
+            @interface Id3 {
+            }
+        }
+
+        @interface IgnoreTimestamp {
+            @interface False {
+            }
+
+            @interface True {
+            }
+        }
+    }
+
+    @Test
+    @Order(1)
+    @Decisions.DataType.FileStructure
+    @Decisions.IgnoreTimestamp.False
+    void testStarAndUnstar() throws Exception {
+
+        List<MediaFile> artists = mediaFileDao.getArtistAll(musicFolders);
+        assertEquals(2, artists.size());
+        assertEquals("_DIR_ Ravel", artists.get(0).getArtist());
+        assertEquals("_DIR_ Sixteen Horsepower", artists.get(1).getArtist());
+
+        List<MediaFile> albums = mediaFileDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, false, musicFolders);
+        assertEquals(4, albums.size());
+        assertEquals("_ID3_ALBUM_ Bach: Goldberg Variations, Canons [Disc 1]", albums.get(0).getAlbumName());
+        assertEquals("_ID3_ALBUM_ Ravel - Chamber Music With Voice", albums.get(1).getAlbumName());
+        assertEquals("_ID3_ALBUM_ Sackcloth 'n' Ashes", albums.get(2).getAlbumName());
+        assertEquals("Complete Piano Works", albums.get(3).getAlbumName());
+
+        List<MediaFile> songs = mediaFileDao.getSongsByArtist(artists.get(0).getArtist(), 0, 1);
+        assertEquals(1, songs.size());
+        assertEquals("01 - Gaspard de la Nuit - i. Ondine", songs.get(0).getTitle());
+
+        // star
+        mvc.perform(MockMvcRequestBuilders.get("/rest/star").param(Attributes.Request.V.value(), apiVerion)
+                .param(Attributes.Request.C.value(), CLIENT_NAME)
+                .param(Attributes.Request.U.value(), ServiceMockUtils.ADMIN_NAME)
+                .param(Attributes.Request.P.value(), ADMIN_PASS).param(Attributes.Request.F.value(), EXPECTED_FORMAT)
+                .param("id", Integer.toString(artists.get(0).getId()))
+                .param("id", Integer.toString(albums.get(0).getId()))
+                .param("id", Integer.toString(songs.get(0).getId())).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_STATUS).value(JSON_VALUE_OK))
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_VERSION).value(apiVerion));
+
+        // getStarred
+        MvcResult result = mvc
+                .perform(MockMvcRequestBuilders.get("/rest/getStarred").param(Attributes.Request.V.value(), apiVerion)
+                        .param(Attributes.Request.C.value(), CLIENT_NAME)
+                        .param(Attributes.Request.U.value(), ServiceMockUtils.ADMIN_NAME)
+                        .param(Attributes.Request.P.value(), ADMIN_PASS)
+                        .param(Attributes.Request.F.value(), EXPECTED_FORMAT).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_STATUS).value(JSON_VALUE_OK))
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_VERSION).value(apiVerion)).andReturn();
+
+        Response response = readResponse(result.getResponse().getContentAsString());
+        Starred starred = response.getStarred();
+        assertNotNull(starred);
+        assertEquals(1, starred.getArtist().size());
+        assertEquals("_DIR_ Ravel", starred.getArtist().get(0).getName());
+        assertEquals(1, starred.getAlbum().size());
+        assertEquals("_ID3_ALBUM_ Bach: Goldberg Variations, Canons [Disc 1]", starred.getAlbum().get(0).getAlbum());
+        assertEquals(1, starred.getSong().size());
+        assertEquals("01 - Gaspard de la Nuit - i. Ondine", starred.getSong().get(0).getTitle());
+
+        // unstar
+        mvc.perform(MockMvcRequestBuilders.get("/rest/unstar").param(Attributes.Request.V.value(), apiVerion)
+                .param(Attributes.Request.C.value(), CLIENT_NAME)
+                .param(Attributes.Request.U.value(), ServiceMockUtils.ADMIN_NAME)
+                .param(Attributes.Request.P.value(), ADMIN_PASS).param(Attributes.Request.F.value(), EXPECTED_FORMAT)
+                .param("id", Integer.toString(artists.get(0).getId()))
+                .param("id", Integer.toString(albums.get(0).getId()))
+                .param("id", Integer.toString(songs.get(0).getId())).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_STATUS).value(JSON_VALUE_OK))
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_VERSION).value(apiVerion));
+
+        result = mvc
+                .perform(MockMvcRequestBuilders.get("/rest/getStarred").param(Attributes.Request.V.value(), apiVerion)
+                        .param(Attributes.Request.C.value(), CLIENT_NAME)
+                        .param(Attributes.Request.U.value(), ServiceMockUtils.ADMIN_NAME)
+                        .param(Attributes.Request.P.value(), ADMIN_PASS)
+                        .param(Attributes.Request.F.value(), EXPECTED_FORMAT).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_STATUS).value(JSON_VALUE_OK))
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_VERSION).value(apiVerion)).andReturn();
+
+        response = readResponse(result.getResponse().getContentAsString());
+        starred = response.getStarred();
+        assertNotNull(starred);
+        assertEquals(0, starred.getArtist().size());
+        assertEquals(0, starred.getAlbum().size());
+        assertEquals(0, starred.getSong().size());
+    }
+
+    @Test
+    @Order(2)
+    @Decisions.DataType.FileStructure
+    @Decisions.IgnoreTimestamp.True
+    void testStarAndUnstarAfterScanWithIgnoreStamp() throws Exception {
+
+        List<MediaFile> artists = mediaFileDao.getArtistAll(musicFolders);
+        assertEquals(2, artists.size());
+        assertEquals("_DIR_ Ravel", artists.get(0).getArtist());
+        assertEquals("_DIR_ Sixteen Horsepower", artists.get(1).getArtist());
+
+        List<MediaFile> albums = mediaFileDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, false, musicFolders);
+        assertEquals(4, albums.size());
+        assertEquals("_ID3_ALBUM_ Bach: Goldberg Variations, Canons [Disc 1]", albums.get(0).getAlbumName());
+        assertEquals("_ID3_ALBUM_ Ravel - Chamber Music With Voice", albums.get(1).getAlbumName());
+        assertEquals("_ID3_ALBUM_ Sackcloth 'n' Ashes", albums.get(2).getAlbumName());
+        assertEquals("Complete Piano Works", albums.get(3).getAlbumName());
+
+        List<MediaFile> songs = mediaFileDao.getSongsByArtist(artists.get(0).getArtist(), 0, 1);
+        assertEquals(1, songs.size());
+        assertEquals("01 - Gaspard de la Nuit - i. Ondine", songs.get(0).getTitle());
+
+        // star
+        mvc.perform(MockMvcRequestBuilders.get("/rest/star").param(Attributes.Request.V.value(), apiVerion)
+                .param(Attributes.Request.C.value(), CLIENT_NAME)
+                .param(Attributes.Request.U.value(), ServiceMockUtils.ADMIN_NAME)
+                .param(Attributes.Request.P.value(), ADMIN_PASS).param(Attributes.Request.F.value(), EXPECTED_FORMAT)
+                .param("id", Integer.toString(artists.get(0).getId()))
+                .param("id", Integer.toString(albums.get(0).getId()))
+                .param("id", Integer.toString(songs.get(0).getId())).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_STATUS).value(JSON_VALUE_OK))
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_VERSION).value(apiVerion));
+
+        // Scan with IgnoreFileTimestamps enabled
+        settingsService.setIgnoreFileTimestamps(true);
+        settingsService.save();
+        TestCaseUtils.execScan(mediaScannerService);
+
+        // getStarred
+        MvcResult result = mvc
+                .perform(MockMvcRequestBuilders.get("/rest/getStarred").param(Attributes.Request.V.value(), apiVerion)
+                        .param(Attributes.Request.C.value(), CLIENT_NAME)
+                        .param(Attributes.Request.U.value(), ServiceMockUtils.ADMIN_NAME)
+                        .param(Attributes.Request.P.value(), ADMIN_PASS)
+                        .param(Attributes.Request.F.value(), EXPECTED_FORMAT).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_STATUS).value(JSON_VALUE_OK))
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_VERSION).value(apiVerion)).andReturn();
+
+        Response response = readResponse(result.getResponse().getContentAsString());
+        Starred starred = response.getStarred();
+        assertNotNull(starred);
+        assertEquals(1, starred.getArtist().size());
+        assertEquals("_DIR_ Ravel", starred.getArtist().get(0).getName());
+        assertEquals(1, starred.getAlbum().size());
+        assertEquals("_ID3_ALBUM_ Bach: Goldberg Variations, Canons [Disc 1]", starred.getAlbum().get(0).getAlbum());
+        assertEquals(1, starred.getSong().size());
+        assertEquals("01 - Gaspard de la Nuit - i. Ondine", starred.getSong().get(0).getTitle());
+
+        // unstar
+        mvc.perform(MockMvcRequestBuilders.get("/rest/unstar").param(Attributes.Request.V.value(), apiVerion)
+                .param(Attributes.Request.C.value(), CLIENT_NAME)
+                .param(Attributes.Request.U.value(), ServiceMockUtils.ADMIN_NAME)
+                .param(Attributes.Request.P.value(), ADMIN_PASS).param(Attributes.Request.F.value(), EXPECTED_FORMAT)
+                .param("id", Integer.toString(artists.get(0).getId()))
+                .param("id", Integer.toString(albums.get(0).getId()))
+                .param("id", Integer.toString(songs.get(0).getId())).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_STATUS).value(JSON_VALUE_OK))
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_VERSION).value(apiVerion));
+
+        result = mvc
+                .perform(MockMvcRequestBuilders.get("/rest/getStarred").param(Attributes.Request.V.value(), apiVerion)
+                        .param(Attributes.Request.C.value(), CLIENT_NAME)
+                        .param(Attributes.Request.U.value(), ServiceMockUtils.ADMIN_NAME)
+                        .param(Attributes.Request.P.value(), ADMIN_PASS)
+                        .param(Attributes.Request.F.value(), EXPECTED_FORMAT).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_STATUS).value(JSON_VALUE_OK))
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_VERSION).value(apiVerion)).andReturn();
+
+        response = readResponse(result.getResponse().getContentAsString());
+        starred = response.getStarred();
+        assertNotNull(starred);
+        assertEquals(0, starred.getArtist().size());
+        assertEquals(0, starred.getAlbum().size());
+        assertEquals(0, starred.getSong().size());
+    }
+
+    @Test
+    @Order(3)
+    @Decisions.DataType.Id3
+    @Decisions.IgnoreTimestamp.False
+    void testStarAndUnstar2() throws Exception {
+
+        List<Artist> artists = artistDao.getAlphabetialArtists(0, Integer.MAX_VALUE, musicFolders);
+        assertEquals(4, artists.size());
+        assertEquals("_DIR_ Ravel", artists.get(0).getName());
+        assertEquals("_ID3_ALBUMARTIST_ Sarah Walker/Nash Ensemble", artists.get(1).getName());
+        assertEquals("_ID3_ARTIST_ Céline Frisch: Café Zimmermann", artists.get(2).getName());
+        assertEquals("_ID3_ARTIST_ Sixteen Horsepower", artists.get(3).getName());
+
+        List<Album> albums = albumDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, false, true, musicFolders);
+        assertEquals(4, albums.size());
+        assertEquals("_ID3_ALBUM_ Bach: Goldberg Variations, Canons [Disc 1]", albums.get(0).getName());
+        assertEquals("_ID3_ALBUM_ Ravel - Chamber Music With Voice", albums.get(1).getName());
+        assertEquals("_ID3_ALBUM_ Sackcloth 'n' Ashes", albums.get(2).getName());
+        assertEquals("Complete Piano Works", albums.get(3).getName());
+
+        // star
+        mvc.perform(MockMvcRequestBuilders.get("/rest/star").param(Attributes.Request.V.value(), apiVerion)
+                .param(Attributes.Request.C.value(), CLIENT_NAME)
+                .param(Attributes.Request.U.value(), ServiceMockUtils.ADMIN_NAME)
+                .param(Attributes.Request.P.value(), ADMIN_PASS).param(Attributes.Request.F.value(), EXPECTED_FORMAT)
+                .param("artistId", Integer.toString(artists.get(0).getId()))
+                .param("albumId", Integer.toString(albums.get(0).getId())).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_STATUS).value(JSON_VALUE_OK))
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_VERSION).value(apiVerion));
+
+        // getStarred
+        MvcResult result = mvc
+                .perform(MockMvcRequestBuilders.get("/rest/getStarred2").param(Attributes.Request.V.value(), apiVerion)
+                        .param(Attributes.Request.C.value(), CLIENT_NAME)
+                        .param(Attributes.Request.U.value(), ServiceMockUtils.ADMIN_NAME)
+                        .param(Attributes.Request.P.value(), ADMIN_PASS)
+                        .param(Attributes.Request.F.value(), EXPECTED_FORMAT).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_STATUS).value(JSON_VALUE_OK))
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_VERSION).value(apiVerion)).andReturn();
+
+        Response response = readResponse(result.getResponse().getContentAsString());
+        Starred2 starred2 = response.getStarred2();
+        assertNotNull(starred2);
+        assertEquals(1, starred2.getArtist().size());
+        assertEquals("_DIR_ Ravel", starred2.getArtist().get(0).getName());
+        assertEquals(1, starred2.getAlbum().size());
+        assertEquals("_ID3_ALBUM_ Bach: Goldberg Variations, Canons [Disc 1]", starred2.getAlbum().get(0).getName());
+        assertEquals(0, starred2.getSong().size());
+
+        // unstar
+        mvc.perform(MockMvcRequestBuilders.get("/rest/unstar").param(Attributes.Request.V.value(), apiVerion)
+                .param(Attributes.Request.C.value(), CLIENT_NAME)
+                .param(Attributes.Request.U.value(), ServiceMockUtils.ADMIN_NAME)
+                .param(Attributes.Request.P.value(), ADMIN_PASS).param(Attributes.Request.F.value(), EXPECTED_FORMAT)
+                .param("artistId", Integer.toString(artists.get(0).getId()))
+                .param("albumId", Integer.toString(albums.get(0).getId())).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_STATUS).value(JSON_VALUE_OK))
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_VERSION).value(apiVerion));
+
+        result = mvc
+                .perform(MockMvcRequestBuilders.get("/rest/getStarred2").param(Attributes.Request.V.value(), apiVerion)
+                        .param(Attributes.Request.C.value(), CLIENT_NAME)
+                        .param(Attributes.Request.U.value(), ServiceMockUtils.ADMIN_NAME)
+                        .param(Attributes.Request.P.value(), ADMIN_PASS)
+                        .param(Attributes.Request.F.value(), EXPECTED_FORMAT).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_STATUS).value(JSON_VALUE_OK))
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_VERSION).value(apiVerion)).andReturn();
+
+        response = readResponse(result.getResponse().getContentAsString());
+        starred2 = response.getStarred2();
+        assertNotNull(starred2);
+        assertEquals(0, starred2.getArtist().size());
+        assertEquals(0, starred2.getAlbum().size());
+        assertEquals(0, starred2.getSong().size());
+    }
+
+    @Test
+    @Order(4)
+    @Decisions.DataType.Id3
+    @Decisions.IgnoreTimestamp.True
+    void testStarAndUnstar2AfterScanWithIgnoreStamp() throws Exception {
+
+        List<Artist> artists = artistDao.getAlphabetialArtists(0, Integer.MAX_VALUE, musicFolders);
+        assertEquals(4, artists.size());
+        assertEquals("_DIR_ Ravel", artists.get(0).getName());
+        assertEquals("_ID3_ALBUMARTIST_ Sarah Walker/Nash Ensemble", artists.get(1).getName());
+        assertEquals("_ID3_ARTIST_ Céline Frisch: Café Zimmermann", artists.get(2).getName());
+        assertEquals("_ID3_ARTIST_ Sixteen Horsepower", artists.get(3).getName());
+
+        List<Album> albums = albumDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, false, true, musicFolders);
+        assertEquals(4, albums.size());
+        assertEquals("_ID3_ALBUM_ Bach: Goldberg Variations, Canons [Disc 1]", albums.get(0).getName());
+        assertEquals("_ID3_ALBUM_ Ravel - Chamber Music With Voice", albums.get(1).getName());
+        assertEquals("_ID3_ALBUM_ Sackcloth 'n' Ashes", albums.get(2).getName());
+        assertEquals("Complete Piano Works", albums.get(3).getName());
+
+        // star
+        mvc.perform(MockMvcRequestBuilders.get("/rest/star").param(Attributes.Request.V.value(), apiVerion)
+                .param(Attributes.Request.C.value(), CLIENT_NAME)
+                .param(Attributes.Request.U.value(), ServiceMockUtils.ADMIN_NAME)
+                .param(Attributes.Request.P.value(), ADMIN_PASS).param(Attributes.Request.F.value(), EXPECTED_FORMAT)
+                .param("artistId", Integer.toString(artists.get(0).getId()))
+                .param("albumId", Integer.toString(albums.get(0).getId())).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_STATUS).value(JSON_VALUE_OK))
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_VERSION).value(apiVerion));
+
+        // Scan with IgnoreFileTimestamps enabled
+        settingsService.setIgnoreFileTimestamps(true);
+        settingsService.save();
+        TestCaseUtils.execScan(mediaScannerService);
+
+        // getStarred
+        MvcResult result = mvc
+                .perform(MockMvcRequestBuilders.get("/rest/getStarred2").param(Attributes.Request.V.value(), apiVerion)
+                        .param(Attributes.Request.C.value(), CLIENT_NAME)
+                        .param(Attributes.Request.U.value(), ServiceMockUtils.ADMIN_NAME)
+                        .param(Attributes.Request.P.value(), ADMIN_PASS)
+                        .param(Attributes.Request.F.value(), EXPECTED_FORMAT).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_STATUS).value(JSON_VALUE_OK))
+                .andExpect(MockMvcResultMatchers.jsonPath(JSON_PATH_VERSION).value(apiVerion)).andReturn();
+
+        Response response = readResponse(result.getResponse().getContentAsString());
+        Starred2 starred2 = response.getStarred2();
+        assertNotNull(starred2);
+        assertEquals(0, starred2.getArtist().size()); // TODO This is a case that has not yet been fixed.
+        assertEquals(0, starred2.getAlbum().size()); // TODO This is a case that has not yet been fixed.
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/AlbumDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/AlbumDaoTest.java
@@ -19,22 +19,30 @@
 
 package com.tesshu.jpsonic.dao;
 
+import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.IOException;
 import java.lang.annotation.Documented;
 import java.util.Collections;
 import java.util.List;
 
+import com.tesshu.jpsonic.AbstractNeedsScan;
+import com.tesshu.jpsonic.TestCaseUtils;
 import com.tesshu.jpsonic.dao.base.TemplateWrapper;
 import com.tesshu.jpsonic.dao.dialect.DialectAlbumDao;
+import com.tesshu.jpsonic.domain.Album;
 import com.tesshu.jpsonic.domain.MusicFolder;
+import com.tesshu.jpsonic.service.SettingsService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.RowMapper;
 
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class AlbumDaoTest {
 
     private TemplateWrapper templateWrapper;
@@ -135,6 +143,137 @@ class AlbumDaoTest {
             ArgumentCaptor<String> query = getQuery(false, false);
             assertEquals("", getJoin(query));
             assertEquals("album.name_reading", getOrderBy(query));
+        }
+    }
+
+    /*
+     * Confirm (bug) that Starred Albums are deleted when the scan ignoring timestamps.
+     */
+    @Nested
+    class StarredPersistenceTest extends AbstractNeedsScan {
+
+        public static final String ADMIN_NAME = "admin";
+
+        @Autowired
+        private AlbumDao albumDao;
+        @Autowired
+        private SettingsService settingsService;
+
+        private final List<MusicFolder> folders = List
+                .of(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 0, false));
+
+        @Override
+        public List<MusicFolder> getMusicFolders() {
+            return folders;
+        }
+
+        @BeforeEach
+        public void setup() throws IOException {
+            populateDatabase();
+        }
+
+        @Test
+        void testStarredPersistence() throws IOException, InterruptedException {
+
+            // Checking registered data
+            assertEquals(4, albumDao.getAlbumCount(folders));
+            List<Album> albums = albumDao.getAlphabeticalAlbums(0, Integer.MAX_VALUE, false, true, folders);
+            assertEquals(4, albums.size());
+            assertEquals("_ID3_ALBUM_ Bach: Goldberg Variations, Canons [Disc 1]", albums.get(0).getName());
+            assertEquals("_ID3_ALBUM_ Ravel - Chamber Music With Voice", albums.get(1).getName());
+            assertEquals("_ID3_ALBUM_ Sackcloth 'n' Ashes", albums.get(2).getName());
+            assertEquals("Complete Piano Works", albums.get(3).getName());
+
+            // Give a Star
+            albumDao.starAlbum(albums.get(0).getId(), ADMIN_NAME);
+            Thread.sleep(200);
+            albumDao.starAlbum(albums.get(2).getId(), ADMIN_NAME);
+            List<Album> starred = albumDao.getStarredAlbums(0, Integer.MAX_VALUE, ADMIN_NAME, folders);
+            assertEquals(2, starred.size());
+
+            // Note that the order is 'created desc'
+            assertEquals("_ID3_ALBUM_ Sackcloth 'n' Ashes", starred.get(0).getName());
+            assertEquals("_ID3_ALBUM_ Bach: Goldberg Variations, Canons [Disc 1]", starred.get(1).getName());
+
+            // Run a scan
+            TestCaseUtils.execScan(mediaScannerService);
+
+            // Of course the result remains the same
+            starred = albumDao.getStarredAlbums(0, Integer.MAX_VALUE, ADMIN_NAME, folders);
+            assertEquals(2, starred.size());
+            assertEquals("_ID3_ALBUM_ Sackcloth 'n' Ashes", starred.get(0).getName());
+            assertEquals("_ID3_ALBUM_ Bach: Goldberg Variations, Canons [Disc 1]", starred.get(1).getName());
+
+            // Scan with IgnoreFileTimestamps enabled
+            settingsService.setIgnoreFileTimestamps(true);
+            settingsService.save();
+            TestCaseUtils.execScan(mediaScannerService);
+
+            // Starred will be deleted (this is not the intended behavior)
+            starred = albumDao.getStarredAlbums(0, Integer.MAX_VALUE, ADMIN_NAME, folders);
+            assertEquals(0, starred.size());
+        }
+    }
+
+    /*
+     * Even if the timestamp is ignored when scanning, it is confirmed that Created does not change.
+     */
+    @Nested
+    class CreatedPersistenceTest extends AbstractNeedsScan {
+
+        public static final String ADMIN_NAME = "admin";
+
+        @Autowired
+        private AlbumDao albumDao;
+        @Autowired
+        private SettingsService settingsService;
+
+        private final List<MusicFolder> folders = List
+                .of(new MusicFolder(1, resolveBaseMediaPath("Music"), "Music", true, now(), 0, false));
+
+        @Override
+        public List<MusicFolder> getMusicFolders() {
+            return folders;
+        }
+
+        @BeforeEach
+        public void setup() throws IOException {
+            populateDatabase();
+        }
+
+        @Test
+        void testCreatedPersistence() throws IOException, InterruptedException {
+
+            // Checking registered data
+            List<Album> albums = albumDao.getNewestAlbums(0, Integer.MAX_VALUE, folders);
+            assertEquals(4, albums.size());
+
+            // Run a scan
+            TestCaseUtils.execScan(mediaScannerService);
+
+            List<Album> scanedAlbums = albumDao.getNewestAlbums(0, Integer.MAX_VALUE, folders);
+            assertEquals(4, scanedAlbums.size());
+            assertEquals(albums.get(0).getCreated(), scanedAlbums.get(0).getCreated());
+            assertEquals(albums.get(1).getCreated(), scanedAlbums.get(1).getCreated());
+            assertEquals(albums.get(2).getCreated(), scanedAlbums.get(2).getCreated());
+            assertEquals(albums.get(3).getCreated(), scanedAlbums.get(3).getCreated());
+
+            // Scan with IgnoreFileTimestamps enabled
+            settingsService.setIgnoreFileTimestamps(true);
+            settingsService.save();
+            TestCaseUtils.execScan(mediaScannerService);
+
+            /*
+             * Nothing changes. album#created comes from file#changed. (The Newest in ID3 indicates the most recent
+             * Change. This has been the case since legacy servers.) Therefore, regardless of the scan logic, this value
+             * will not change unless the file is changed.
+             */
+            List<Album> fullScanedAlbums = albumDao.getNewestAlbums(0, Integer.MAX_VALUE, folders);
+            assertEquals(4, fullScanedAlbums.size());
+            assertEquals(albums.get(0).getCreated(), fullScanedAlbums.get(0).getCreated());
+            assertEquals(albums.get(1).getCreated(), fullScanedAlbums.get(1).getCreated());
+            assertEquals(albums.get(2).getCreated(), fullScanedAlbums.get(2).getCreated());
+            assertEquals(albums.get(3).getCreated(), fullScanedAlbums.get(3).getCreated());
         }
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/AlbumDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/AlbumDaoTest.java
@@ -147,7 +147,7 @@ class AlbumDaoTest {
     }
 
     /*
-     * Confirm (bug) that Starred Albums are deleted when the scan ignoring timestamps.
+     * Make sure that scanning ignoring timestamps will not delete starred albums.
      */
     @Nested
     class StarredPersistenceTest extends AbstractNeedsScan {
@@ -209,9 +209,11 @@ class AlbumDaoTest {
             settingsService.save();
             TestCaseUtils.execScan(mediaScannerService);
 
-            // Starred will be deleted (this is not the intended behavior)
+            // The result remains the same
             starred = albumDao.getStarredAlbums(0, Integer.MAX_VALUE, ADMIN_NAME, folders);
-            assertEquals(0, starred.size());
+            assertEquals(2, starred.size());
+            assertEquals("_ID3_ALBUM_ Sackcloth 'n' Ashes", starred.get(0).getName());
+            assertEquals("_ID3_ALBUM_ Bach: Goldberg Variations, Canons [Disc 1]", starred.get(1).getName());
         }
     }
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImplTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/scanner/MediaScannerServiceImplTest.java
@@ -93,11 +93,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.exception.UncheckedException;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.JRE;
@@ -544,7 +541,6 @@ class MediaScannerServiceImplTest {
     }
 
     @Nested
-    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
     class GenreCRUDTest extends AbstractNeedsScan {
 
         @Autowired
@@ -569,7 +565,6 @@ class MediaScannerServiceImplTest {
         }
 
         @Test
-        @Order(1)
         void testCRUD() throws IOException {
 
             // Test CR
@@ -696,6 +691,117 @@ class MediaScannerServiceImplTest {
             // Some of the multi-genres have been changed.
             assertEquals("GENRE_L-CHANGED", genres.get(12).getName());
             assertEquals(1, genres.get(12).getAlbumCount());
+        }
+    }
+
+    /*
+     * Confirm that the Genre Count does not increase or decrease during Normal-Scan and Scan with IgnoreTimestamp.
+     */
+    @Nested
+    class GenrePersistenceTest extends AbstractNeedsScan {
+
+        @Autowired
+        private SearchService searchService;
+
+        private final List<MusicFolder> folders = List
+                .of(new MusicFolder(1, resolveBaseMediaPath("MultiGenre"), "MultiGenre", true, now(), 0, false));
+
+        @Override
+        public List<MusicFolder> getMusicFolders() {
+            return folders;
+        }
+
+        @BeforeEach
+        public void setup() throws IOException {
+            populateDatabase();
+        }
+
+        @Test
+        void testGenreCountPersistence() throws IOException {
+            GenreMasterCriteria albumGenreCriteria = new GenreMasterCriteria(folders, Scope.ALBUM, Sort.NAME);
+            GenreMasterCriteria songGenreCriteria = new GenreMasterCriteria(folders, Scope.SONG, Sort.NAME);
+            assertTrue(assertAlbumGenreCount(searchService.getGenres(albumGenreCriteria, 0, Integer.MAX_VALUE)));
+            assertTrue(assertSongGenreCount(searchService.getGenres(songGenreCriteria, 0, Integer.MAX_VALUE)));
+
+            // Run a scan
+            TestCaseUtils.execScan(mediaScannerService);
+            assertTrue(assertAlbumGenreCount(searchService.getGenres(albumGenreCriteria, 0, Integer.MAX_VALUE)));
+            assertTrue(assertSongGenreCount(searchService.getGenres(songGenreCriteria, 0, Integer.MAX_VALUE)));
+
+            // Scan with IgnoreFileTimestamps enabled
+            settingsService.setIgnoreFileTimestamps(true);
+            settingsService.save();
+            TestCaseUtils.execScan(mediaScannerService);
+            assertTrue(assertAlbumGenreCount(searchService.getGenres(albumGenreCriteria, 0, Integer.MAX_VALUE)));
+            assertTrue(assertSongGenreCount(searchService.getGenres(songGenreCriteria, 0, Integer.MAX_VALUE)));
+        }
+
+        private boolean assertAlbumGenreCount(List<Genre> genres) {
+            assertEquals(14, genres.size());
+            assertEquals("Audiobook - Historical", genres.get(0).getName());
+            assertEquals(1, genres.get(0).getAlbumCount());
+            assertEquals("Audiobook - Sports", genres.get(1).getName());
+            assertEquals(1, genres.get(1).getAlbumCount());
+            assertEquals("GENRE_A", genres.get(2).getName());
+            assertEquals(1, genres.get(2).getAlbumCount());
+            assertEquals("GENRE_B", genres.get(3).getName());
+            assertEquals(1, genres.get(3).getAlbumCount());
+            assertEquals("GENRE_C", genres.get(4).getName());
+            assertEquals(1, genres.get(4).getAlbumCount());
+            assertEquals("GENRE_D", genres.get(5).getName());
+            assertEquals(2, genres.get(5).getAlbumCount());
+            assertEquals("GENRE_E", genres.get(6).getName());
+            assertEquals(1, genres.get(6).getAlbumCount());
+            assertEquals("GENRE_F", genres.get(7).getName());
+            assertEquals(1, genres.get(7).getAlbumCount());
+            assertEquals("GENRE_G", genres.get(8).getName());
+            assertEquals(1, genres.get(8).getAlbumCount());
+            assertEquals("GENRE_H", genres.get(9).getName());
+            assertEquals(1, genres.get(9).getAlbumCount());
+            assertEquals("GENRE_I", genres.get(10).getName());
+            assertEquals(1, genres.get(10).getAlbumCount());
+            assertEquals("GENRE_J", genres.get(11).getName());
+            assertEquals(1, genres.get(11).getAlbumCount());
+            assertEquals("GENRE_K", genres.get(12).getName());
+            assertEquals(2, genres.get(12).getAlbumCount());
+            assertEquals("GENRE_L", genres.get(13).getName());
+            assertEquals(2, genres.get(13).getAlbumCount());
+            return true;
+        }
+
+        private boolean assertSongGenreCount(List<Genre> genres) {
+            assertEquals(15, genres.size());
+            assertEquals("Audiobook - Historical", genres.get(0).getName());
+            assertEquals(1, genres.get(0).getSongCount());
+            assertEquals("Audiobook - Sports", genres.get(1).getName());
+            assertEquals(1, genres.get(1).getSongCount());
+            assertEquals("GENRE_A", genres.get(2).getName());
+            assertEquals(2, genres.get(2).getSongCount());
+            assertEquals("GENRE_B", genres.get(3).getName());
+            assertEquals(1, genres.get(3).getSongCount());
+            assertEquals("GENRE_C", genres.get(4).getName());
+            assertEquals(1, genres.get(4).getSongCount());
+            assertEquals("GENRE_D", genres.get(5).getName());
+            assertEquals(2, genres.get(5).getSongCount());
+            assertEquals("GENRE_E", genres.get(6).getName());
+            assertEquals(2, genres.get(6).getSongCount());
+            assertEquals("GENRE_F", genres.get(7).getName());
+            assertEquals(2, genres.get(7).getSongCount());
+            assertEquals("GENRE_G", genres.get(8).getName());
+            assertEquals(1, genres.get(8).getSongCount());
+            assertEquals("GENRE_H", genres.get(9).getName());
+            assertEquals(1, genres.get(9).getSongCount());
+            assertEquals("GENRE_I", genres.get(10).getName());
+            assertEquals(1, genres.get(10).getSongCount());
+            assertEquals("GENRE_J", genres.get(11).getName());
+            assertEquals(1, genres.get(11).getSongCount());
+            assertEquals("GENRE_K", genres.get(12).getName());
+            assertEquals(2, genres.get(12).getSongCount());
+            assertEquals("GENRE_L", genres.get(13).getName());
+            assertEquals(2, genres.get(13).getSongCount());
+            assertEquals("NO_ALBUM", genres.get(14).getName());
+            assertEquals(1, genres.get(14).getSongCount());
+            return true;
         }
     }
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/AlbumID3.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/AlbumID3.java
@@ -1,0 +1,158 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlSeeAlso;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "AlbumID3")
+@XmlSeeAlso({ AlbumWithSongsID3.class })
+public class AlbumID3 {
+
+    @XmlAttribute(name = "id", required = true)
+    protected String id;
+    @XmlAttribute(name = "name", required = true)
+    protected String name;
+    @XmlAttribute(name = "artist")
+    protected String artist;
+    @XmlAttribute(name = "artistId")
+    protected String artistId;
+    @XmlAttribute(name = "coverArt")
+    protected String coverArt;
+    @XmlAttribute(name = "songCount", required = true)
+    protected int songCount;
+    @XmlAttribute(name = "duration", required = true)
+    protected int duration;
+    @XmlAttribute(name = "playCount")
+    protected Long playCount;
+    @XmlAttribute(name = "created", required = true)
+    @XmlSchemaType(name = "dateTime")
+    protected XMLGregorianCalendar created;
+    @XmlAttribute(name = "starred")
+    @XmlSchemaType(name = "dateTime")
+    protected XMLGregorianCalendar starred;
+    @XmlAttribute(name = "year")
+    protected Integer year;
+    @XmlAttribute(name = "genre")
+    protected String genre;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String value) {
+        this.id = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String value) {
+        this.name = value;
+    }
+
+    public String getArtist() {
+        return artist;
+    }
+
+    public void setArtist(String value) {
+        this.artist = value;
+    }
+
+    public String getArtistId() {
+        return artistId;
+    }
+
+    public void setArtistId(String value) {
+        this.artistId = value;
+    }
+
+    public String getCoverArt() {
+        return coverArt;
+    }
+
+    public void setCoverArt(String value) {
+        this.coverArt = value;
+    }
+
+    public int getSongCount() {
+        return songCount;
+    }
+
+    public void setSongCount(int value) {
+        this.songCount = value;
+    }
+
+    public int getDuration() {
+        return duration;
+    }
+
+    public void setDuration(int value) {
+        this.duration = value;
+    }
+
+    public Long getPlayCount() {
+        return playCount;
+    }
+
+    public void setPlayCount(Long value) {
+        this.playCount = value;
+    }
+
+    public XMLGregorianCalendar getCreated() {
+        return created;
+    }
+
+    public void setCreated(XMLGregorianCalendar value) {
+        this.created = value;
+    }
+
+    public XMLGregorianCalendar getStarred() {
+        return starred;
+    }
+
+    public void setStarred(XMLGregorianCalendar value) {
+        this.starred = value;
+    }
+
+    public Integer getYear() {
+        return year;
+    }
+
+    public void setYear(Integer value) {
+        this.year = value;
+    }
+
+    public String getGenre() {
+        return genre;
+    }
+
+    public void setGenre(String value) {
+        this.genre = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/AlbumInfo.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/AlbumInfo.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "AlbumInfo", propOrder = { "notes", "musicBrainzId", "lastFmUrl", "smallImageUrl", "mediumImageUrl",
+        "largeImageUrl" })
+public class AlbumInfo {
+
+    protected String notes;
+    protected String musicBrainzId;
+    protected String lastFmUrl;
+    protected String smallImageUrl;
+    protected String mediumImageUrl;
+    protected String largeImageUrl;
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String value) {
+        this.notes = value;
+    }
+
+    public String getMusicBrainzId() {
+        return musicBrainzId;
+    }
+
+    public void setMusicBrainzId(String value) {
+        this.musicBrainzId = value;
+    }
+
+    public String getLastFmUrl() {
+        return lastFmUrl;
+    }
+
+    public void setLastFmUrl(String value) {
+        this.lastFmUrl = value;
+    }
+
+    public String getSmallImageUrl() {
+        return smallImageUrl;
+    }
+
+    public void setSmallImageUrl(String value) {
+        this.smallImageUrl = value;
+    }
+
+    public String getMediumImageUrl() {
+        return mediumImageUrl;
+    }
+
+    public void setMediumImageUrl(String value) {
+        this.mediumImageUrl = value;
+    }
+
+    public String getLargeImageUrl() {
+        return largeImageUrl;
+    }
+
+    public void setLargeImageUrl(String value) {
+        this.largeImageUrl = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/AlbumList.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/AlbumList.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "AlbumList", propOrder = { "album" })
+public class AlbumList {
+
+    protected List<Child> album;
+
+    public List<Child> getAlbum() {
+        if (album == null) {
+            album = new ArrayList<>();
+        }
+        return this.album;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/AlbumList2.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/AlbumList2.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "AlbumList2", propOrder = { "album" })
+public class AlbumList2 {
+
+    protected List<AlbumID3> album;
+
+    public List<AlbumID3> getAlbum() {
+        if (album == null) {
+            album = new ArrayList<>();
+        }
+        return this.album;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/AlbumWithSongsID3.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/AlbumWithSongsID3.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "AlbumWithSongsID3", propOrder = { "song" })
+public class AlbumWithSongsID3 extends AlbumID3 {
+
+    protected List<Child> song;
+
+    public List<Child> getSong() {
+        if (song == null) {
+            song = new ArrayList<>();
+        }
+        return this.song;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Artist.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Artist.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Artist")
+public class Artist {
+
+    @XmlAttribute(name = "id", required = true)
+    protected String id;
+    @XmlAttribute(name = "name", required = true)
+    protected String name;
+    @XmlAttribute(name = "starred")
+    @XmlSchemaType(name = "dateTime")
+    protected XMLGregorianCalendar starred;
+    @XmlAttribute(name = "userRating")
+    protected Integer userRating;
+    @XmlAttribute(name = "averageRating")
+    protected Double averageRating;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String value) {
+        this.id = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String value) {
+        this.name = value;
+    }
+
+    public XMLGregorianCalendar getStarred() {
+        return starred;
+    }
+
+    public void setStarred(XMLGregorianCalendar value) {
+        this.starred = value;
+    }
+
+    public Integer getUserRating() {
+        return userRating;
+    }
+
+    public void setUserRating(Integer value) {
+        this.userRating = value;
+    }
+
+    public Double getAverageRating() {
+        return averageRating;
+    }
+
+    public void setAverageRating(Double value) {
+        this.averageRating = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ArtistID3.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ArtistID3.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlSeeAlso;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ArtistID3")
+@XmlSeeAlso({ ArtistWithAlbumsID3.class })
+public class ArtistID3 {
+
+    @XmlAttribute(name = "id", required = true)
+    protected String id;
+    @XmlAttribute(name = "name", required = true)
+    protected String name;
+    @XmlAttribute(name = "coverArt")
+    protected String coverArt;
+    @XmlAttribute(name = "albumCount", required = true)
+    protected int albumCount;
+    @XmlAttribute(name = "starred")
+    @XmlSchemaType(name = "dateTime")
+    protected XMLGregorianCalendar starred;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String value) {
+        this.id = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String value) {
+        this.name = value;
+    }
+
+    public String getCoverArt() {
+        return coverArt;
+    }
+
+    public void setCoverArt(String value) {
+        this.coverArt = value;
+    }
+
+    public int getAlbumCount() {
+        return albumCount;
+    }
+
+    public void setAlbumCount(int value) {
+        this.albumCount = value;
+    }
+
+    public XMLGregorianCalendar getStarred() {
+        return starred;
+    }
+
+    public void setStarred(XMLGregorianCalendar value) {
+        this.starred = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ArtistInfo.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ArtistInfo.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ArtistInfo", propOrder = { "similarArtist" })
+public class ArtistInfo extends ArtistInfoBase {
+
+    protected List<Artist> similarArtist;
+
+    public List<Artist> getSimilarArtist() {
+        if (similarArtist == null) {
+            similarArtist = new ArrayList<>();
+        }
+        return this.similarArtist;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ArtistInfo2.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ArtistInfo2.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ArtistInfo2", propOrder = { "similarArtist" })
+public class ArtistInfo2 extends ArtistInfoBase {
+
+    protected List<ArtistID3> similarArtist;
+
+    public List<ArtistID3> getSimilarArtist() {
+        if (similarArtist == null) {
+            similarArtist = new ArrayList<>();
+        }
+        return this.similarArtist;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ArtistInfoBase.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ArtistInfoBase.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlSeeAlso;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ArtistInfoBase", propOrder = { "biography", "musicBrainzId", "lastFmUrl", "smallImageUrl",
+        "mediumImageUrl", "largeImageUrl" })
+@XmlSeeAlso({ ArtistInfo.class, ArtistInfo2.class })
+public class ArtistInfoBase {
+
+    protected String biography;
+    protected String musicBrainzId;
+    protected String lastFmUrl;
+    protected String smallImageUrl;
+    protected String mediumImageUrl;
+    protected String largeImageUrl;
+
+    public String getBiography() {
+        return biography;
+    }
+
+    public void setBiography(String value) {
+        this.biography = value;
+    }
+
+    public String getMusicBrainzId() {
+        return musicBrainzId;
+    }
+
+    public void setMusicBrainzId(String value) {
+        this.musicBrainzId = value;
+    }
+
+    public String getLastFmUrl() {
+        return lastFmUrl;
+    }
+
+    public void setLastFmUrl(String value) {
+        this.lastFmUrl = value;
+    }
+
+    public String getSmallImageUrl() {
+        return smallImageUrl;
+    }
+
+    public void setSmallImageUrl(String value) {
+        this.smallImageUrl = value;
+    }
+
+    public String getMediumImageUrl() {
+        return mediumImageUrl;
+    }
+
+    public void setMediumImageUrl(String value) {
+        this.mediumImageUrl = value;
+    }
+
+    public String getLargeImageUrl() {
+        return largeImageUrl;
+    }
+
+    public void setLargeImageUrl(String value) {
+        this.largeImageUrl = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ArtistWithAlbumsID3.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ArtistWithAlbumsID3.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ArtistWithAlbumsID3", propOrder = { "album" })
+public class ArtistWithAlbumsID3 extends ArtistID3 {
+
+    protected List<AlbumID3> album;
+
+    public List<AlbumID3> getAlbum() {
+        if (album == null) {
+            album = new ArrayList<>();
+        }
+        return this.album;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ArtistsID3.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ArtistsID3.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ArtistsID3", propOrder = { "index" })
+public class ArtistsID3 {
+
+    protected List<IndexID3> index;
+    @XmlAttribute(name = "ignoredArticles", required = true)
+    protected String ignoredArticles;
+
+    public List<IndexID3> getIndex() {
+        if (index == null) {
+            index = new ArrayList<>();
+        }
+        return this.index;
+    }
+
+    public String getIgnoredArticles() {
+        return ignoredArticles;
+    }
+
+    public void setIgnoredArticles(String value) {
+        this.ignoredArticles = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/AudioTrack.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/AudioTrack.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "AudioTrack")
+public class AudioTrack {
+
+    @XmlAttribute(name = "id", required = true)
+    protected String id;
+    @XmlAttribute(name = "name")
+    protected String name;
+    @XmlAttribute(name = "languageCode")
+    protected String languageCode;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String value) {
+        this.id = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String value) {
+        this.name = value;
+    }
+
+    public String getLanguageCode() {
+        return languageCode;
+    }
+
+    public void setLanguageCode(String value) {
+        this.languageCode = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Bookmark.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Bookmark.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Bookmark", propOrder = { "entry" })
+public class Bookmark {
+
+    @XmlElement(required = true)
+    protected Child entry;
+    @XmlAttribute(name = "position", required = true)
+    protected long position;
+    @XmlAttribute(name = "username", required = true)
+    protected String username;
+    @XmlAttribute(name = "comment")
+    protected String comment;
+    @XmlAttribute(name = "created", required = true)
+    @XmlSchemaType(name = "dateTime")
+    protected XMLGregorianCalendar created;
+    @XmlAttribute(name = "changed", required = true)
+    @XmlSchemaType(name = "dateTime")
+    protected XMLGregorianCalendar changed;
+
+    public Child getEntry() {
+        return entry;
+    }
+
+    public void setEntry(Child value) {
+        this.entry = value;
+    }
+
+    public long getPosition() {
+        return position;
+    }
+
+    public void setPosition(long value) {
+        this.position = value;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String value) {
+        this.username = value;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String value) {
+        this.comment = value;
+    }
+
+    public XMLGregorianCalendar getCreated() {
+        return created;
+    }
+
+    public void setCreated(XMLGregorianCalendar value) {
+        this.created = value;
+    }
+
+    public XMLGregorianCalendar getChanged() {
+        return changed;
+    }
+
+    public void setChanged(XMLGregorianCalendar value) {
+        this.changed = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Bookmarks.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Bookmarks.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Bookmarks", propOrder = { "bookmark" })
+public class Bookmarks {
+
+    protected List<Bookmark> bookmark;
+
+    public List<Bookmark> getBookmark() {
+        if (bookmark == null) {
+            bookmark = new ArrayList<>();
+        }
+        return this.bookmark;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Captions.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Captions.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Captions")
+public class Captions {
+
+    @XmlAttribute(name = "id", required = true)
+    protected String id;
+    @XmlAttribute(name = "name")
+    protected String name;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String value) {
+        this.id = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String value) {
+        this.name = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ChatMessage.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ChatMessage.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ChatMessage")
+public class ChatMessage {
+
+    @XmlAttribute(name = "username", required = true)
+    protected String username;
+    @XmlAttribute(name = "time", required = true)
+    protected long time;
+    @XmlAttribute(name = "message", required = true)
+    protected String message;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String value) {
+        this.username = value;
+    }
+
+    public long getTime() {
+        return time;
+    }
+
+    public void setTime(long value) {
+        this.time = value;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String value) {
+        this.message = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ChatMessages.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ChatMessages.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ChatMessages", propOrder = { "chatMessage" })
+public class ChatMessages {
+
+    protected List<ChatMessage> chatMessage;
+
+    public List<ChatMessage> getChatMessage() {
+        if (chatMessage == null) {
+            chatMessage = new ArrayList<>();
+        }
+        return this.chatMessage;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Child.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Child.java
@@ -1,0 +1,348 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlSeeAlso;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Child")
+@XmlSeeAlso({ NowPlayingEntry.class, PodcastEpisode.class })
+public class Child {
+
+    @XmlAttribute(name = "id", required = true)
+    protected String id;
+    @XmlAttribute(name = "parent")
+    protected String parent;
+    @XmlAttribute(name = "isDir", required = true)
+    protected boolean isDir;
+    @XmlAttribute(name = "title", required = true)
+    protected String title;
+    @XmlAttribute(name = "album")
+    protected String album;
+    @XmlAttribute(name = "artist")
+    protected String artist;
+    @XmlAttribute(name = "track")
+    protected Integer track;
+    @XmlAttribute(name = "year")
+    protected Integer year;
+    @XmlAttribute(name = "genre")
+    protected String genre;
+    @XmlAttribute(name = "coverArt")
+    protected String coverArt;
+    @XmlAttribute(name = "size")
+    protected Long size;
+    @XmlAttribute(name = "contentType")
+    protected String contentType;
+    @XmlAttribute(name = "suffix")
+    protected String suffix;
+    @XmlAttribute(name = "transcodedContentType")
+    protected String transcodedContentType;
+    @XmlAttribute(name = "transcodedSuffix")
+    protected String transcodedSuffix;
+    @XmlAttribute(name = "duration")
+    protected Integer duration;
+    @XmlAttribute(name = "bitRate")
+    protected Integer bitRate;
+    @XmlAttribute(name = "path")
+    protected String path;
+    @XmlAttribute(name = "isVideo")
+    protected Boolean isVideo;
+    @XmlAttribute(name = "userRating")
+    protected Integer userRating;
+    @XmlAttribute(name = "averageRating")
+    protected Double averageRating;
+    @XmlAttribute(name = "playCount")
+    protected Long playCount;
+    @XmlAttribute(name = "discNumber")
+    protected Integer discNumber;
+    @XmlAttribute(name = "created")
+    @XmlSchemaType(name = "dateTime")
+    protected XMLGregorianCalendar created;
+    @XmlAttribute(name = "starred")
+    @XmlSchemaType(name = "dateTime")
+    protected XMLGregorianCalendar starred;
+    @XmlAttribute(name = "albumId")
+    protected String albumId;
+    @XmlAttribute(name = "artistId")
+    protected String artistId;
+    @XmlAttribute(name = "type")
+    protected MediaType type;
+    @XmlAttribute(name = "bookmarkPosition")
+    protected Long bookmarkPosition;
+    @XmlAttribute(name = "originalWidth")
+    protected Integer originalWidth;
+    @XmlAttribute(name = "originalHeight")
+    protected Integer originalHeight;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String value) {
+        this.id = value;
+    }
+
+    public String getParent() {
+        return parent;
+    }
+
+    public void setParent(String value) {
+        this.parent = value;
+    }
+
+    public boolean isIsDir() {
+        return isDir;
+    }
+
+    public void setIsDir(boolean value) {
+        this.isDir = value;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String value) {
+        this.title = value;
+    }
+
+    public String getAlbum() {
+        return album;
+    }
+
+    public void setAlbum(String value) {
+        this.album = value;
+    }
+
+    public String getArtist() {
+        return artist;
+    }
+
+    public void setArtist(String value) {
+        this.artist = value;
+    }
+
+    public Integer getTrack() {
+        return track;
+    }
+
+    public void setTrack(Integer value) {
+        this.track = value;
+    }
+
+    public Integer getYear() {
+        return year;
+    }
+
+    public void setYear(Integer value) {
+        this.year = value;
+    }
+
+    public String getGenre() {
+        return genre;
+    }
+
+    public void setGenre(String value) {
+        this.genre = value;
+    }
+
+    public String getCoverArt() {
+        return coverArt;
+    }
+
+    public void setCoverArt(String value) {
+        this.coverArt = value;
+    }
+
+    public Long getSize() {
+        return size;
+    }
+
+    public void setSize(Long value) {
+        this.size = value;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String value) {
+        this.contentType = value;
+    }
+
+    public String getSuffix() {
+        return suffix;
+    }
+
+    public void setSuffix(String value) {
+        this.suffix = value;
+    }
+
+    public String getTranscodedContentType() {
+        return transcodedContentType;
+    }
+
+    public void setTranscodedContentType(String value) {
+        this.transcodedContentType = value;
+    }
+
+    public String getTranscodedSuffix() {
+        return transcodedSuffix;
+    }
+
+    public void setTranscodedSuffix(String value) {
+        this.transcodedSuffix = value;
+    }
+
+    public Integer getDuration() {
+        return duration;
+    }
+
+    public void setDuration(Integer value) {
+        this.duration = value;
+    }
+
+    public Integer getBitRate() {
+        return bitRate;
+    }
+
+    public void setBitRate(Integer value) {
+        this.bitRate = value;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String value) {
+        this.path = value;
+    }
+
+    public Boolean isIsVideo() {
+        return isVideo;
+    }
+
+    public void setIsVideo(Boolean value) {
+        this.isVideo = value;
+    }
+
+    public Integer getUserRating() {
+        return userRating;
+    }
+
+    public void setUserRating(Integer value) {
+        this.userRating = value;
+    }
+
+    public Double getAverageRating() {
+        return averageRating;
+    }
+
+    public void setAverageRating(Double value) {
+        this.averageRating = value;
+    }
+
+    public Long getPlayCount() {
+        return playCount;
+    }
+
+    public void setPlayCount(Long value) {
+        this.playCount = value;
+    }
+
+    public Integer getDiscNumber() {
+        return discNumber;
+    }
+
+    public void setDiscNumber(Integer value) {
+        this.discNumber = value;
+    }
+
+    public XMLGregorianCalendar getCreated() {
+        return created;
+    }
+
+    public void setCreated(XMLGregorianCalendar value) {
+        this.created = value;
+    }
+
+    public XMLGregorianCalendar getStarred() {
+        return starred;
+    }
+
+    public void setStarred(XMLGregorianCalendar value) {
+        this.starred = value;
+    }
+
+    public String getAlbumId() {
+        return albumId;
+    }
+
+    public void setAlbumId(String value) {
+        this.albumId = value;
+    }
+
+    public String getArtistId() {
+        return artistId;
+    }
+
+    public void setArtistId(String value) {
+        this.artistId = value;
+    }
+
+    public MediaType getType() {
+        return type;
+    }
+
+    public void setType(MediaType value) {
+        this.type = value;
+    }
+
+    public Long getBookmarkPosition() {
+        return bookmarkPosition;
+    }
+
+    public void setBookmarkPosition(Long value) {
+        this.bookmarkPosition = value;
+    }
+
+    public Integer getOriginalWidth() {
+        return originalWidth;
+    }
+
+    public void setOriginalWidth(Integer value) {
+        this.originalWidth = value;
+    }
+
+    public Integer getOriginalHeight() {
+        return originalHeight;
+    }
+
+    public void setOriginalHeight(Integer value) {
+        this.originalHeight = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Directory.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Directory.java
@@ -1,0 +1,116 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Directory", propOrder = { "child" })
+public class Directory {
+
+    protected List<Child> child;
+    @XmlAttribute(name = "id", required = true)
+    protected String id;
+    @XmlAttribute(name = "parent")
+    protected String parent;
+    @XmlAttribute(name = "name", required = true)
+    protected String name;
+    @XmlAttribute(name = "starred")
+    @XmlSchemaType(name = "dateTime")
+    protected XMLGregorianCalendar starred;
+    @XmlAttribute(name = "userRating")
+    protected Integer userRating;
+    @XmlAttribute(name = "averageRating")
+    protected Double averageRating;
+    @XmlAttribute(name = "playCount")
+    protected Long playCount;
+
+    public List<Child> getChild() {
+        if (child == null) {
+            child = new ArrayList<>();
+        }
+        return this.child;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String value) {
+        this.id = value;
+    }
+
+    public String getParent() {
+        return parent;
+    }
+
+    public void setParent(String value) {
+        this.parent = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String value) {
+        this.name = value;
+    }
+
+    public XMLGregorianCalendar getStarred() {
+        return starred;
+    }
+
+    public void setStarred(XMLGregorianCalendar value) {
+        this.starred = value;
+    }
+
+    public Integer getUserRating() {
+        return userRating;
+    }
+
+    public void setUserRating(Integer value) {
+        this.userRating = value;
+    }
+
+    public Double getAverageRating() {
+        return averageRating;
+    }
+
+    public void setAverageRating(Double value) {
+        this.averageRating = value;
+    }
+
+    public Long getPlayCount() {
+        return playCount;
+    }
+
+    public void setPlayCount(Long value) {
+        this.playCount = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Error.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Error.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Error")
+public class Error {
+
+    @XmlAttribute(name = "code", required = true)
+    protected int code;
+    @XmlAttribute(name = "message")
+    protected String message;
+
+    public int getCode() {
+        return code;
+    }
+
+    public void setCode(int value) {
+        this.code = value;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String value) {
+        this.message = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Genre.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Genre.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlValue;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Genre", propOrder = { "content" })
+public class Genre {
+
+    @XmlValue
+    protected String content;
+    @XmlAttribute(name = "songCount", required = true)
+    protected int songCount;
+    @XmlAttribute(name = "albumCount", required = true)
+    protected int albumCount;
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String value) {
+        this.content = value;
+    }
+
+    public int getSongCount() {
+        return songCount;
+    }
+
+    public void setSongCount(int value) {
+        this.songCount = value;
+    }
+
+    public int getAlbumCount() {
+        return albumCount;
+    }
+
+    public void setAlbumCount(int value) {
+        this.albumCount = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Genres.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Genres.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Genres", propOrder = { "genre" })
+public class Genres {
+
+    protected List<Genre> genre;
+
+    public List<Genre> getGenre() {
+        if (genre == null) {
+            genre = new ArrayList<>();
+        }
+        return this.genre;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Index.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Index.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Index", propOrder = { "artist" })
+public class Index {
+
+    protected List<Artist> artist;
+    @XmlAttribute(name = "name", required = true)
+    protected String name;
+
+    public List<Artist> getArtist() {
+        if (artist == null) {
+            artist = new ArrayList<>();
+        }
+        return this.artist;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String value) {
+        this.name = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/IndexID3.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/IndexID3.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "IndexID3", propOrder = { "artist" })
+public class IndexID3 {
+
+    protected List<ArtistID3> artist;
+    @XmlAttribute(name = "name", required = true)
+    protected String name;
+
+    public List<ArtistID3> getArtist() {
+        if (artist == null) {
+            artist = new ArrayList<>();
+        }
+        return this.artist;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String value) {
+        this.name = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Indexes.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Indexes.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Indexes", propOrder = { "shortcut", "index", "child" })
+public class Indexes {
+
+    protected List<Artist> shortcut;
+    protected List<Index> index;
+    protected List<Child> child;
+    @XmlAttribute(name = "lastModified", required = true)
+    protected long lastModified;
+    @XmlAttribute(name = "ignoredArticles", required = true)
+    protected String ignoredArticles;
+
+    public List<Artist> getShortcut() {
+        if (shortcut == null) {
+            shortcut = new ArrayList<>();
+        }
+        return this.shortcut;
+    }
+
+    public List<Index> getIndex() {
+        if (index == null) {
+            index = new ArrayList<>();
+        }
+        return this.index;
+    }
+
+    public List<Child> getChild() {
+        if (child == null) {
+            child = new ArrayList<>();
+        }
+        return this.child;
+    }
+
+    public long getLastModified() {
+        return lastModified;
+    }
+
+    public void setLastModified(long value) {
+        this.lastModified = value;
+    }
+
+    public String getIgnoredArticles() {
+        return ignoredArticles;
+    }
+
+    public void setIgnoredArticles(String value) {
+        this.ignoredArticles = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/InternetRadioStation.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/InternetRadioStation.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "InternetRadioStation")
+public class InternetRadioStation {
+
+    @XmlAttribute(name = "id", required = true)
+    protected String id;
+    @XmlAttribute(name = "name", required = true)
+    protected String name;
+    @XmlAttribute(name = "streamUrl", required = true)
+    protected String streamUrl;
+    @XmlAttribute(name = "homePageUrl")
+    protected String homePageUrl;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String value) {
+        this.id = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String value) {
+        this.name = value;
+    }
+
+    public String getStreamUrl() {
+        return streamUrl;
+    }
+
+    public void setStreamUrl(String value) {
+        this.streamUrl = value;
+    }
+
+    public String getHomePageUrl() {
+        return homePageUrl;
+    }
+
+    public void setHomePageUrl(String value) {
+        this.homePageUrl = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/InternetRadioStations.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/InternetRadioStations.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "InternetRadioStations", propOrder = { "internetRadioStation" })
+public class InternetRadioStations {
+
+    protected List<InternetRadioStation> internetRadioStation;
+
+    public List<InternetRadioStation> getInternetRadioStation() {
+        if (internetRadioStation == null) {
+            internetRadioStation = new ArrayList<>();
+        }
+        return this.internetRadioStation;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/JsonResult.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/JsonResult.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class JsonResult {
+
+    @JsonProperty("subsonic-response")
+    private Response response;
+
+    public Response getResponse() {
+        return response;
+    }
+
+    public void setResponse(Response response) {
+        this.response = response;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/JukeboxPlaylist.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/JukeboxPlaylist.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "JukeboxPlaylist", propOrder = { "entry" })
+public class JukeboxPlaylist extends JukeboxStatus {
+
+    protected List<Child> entry;
+
+    public List<Child> getEntry() {
+        if (entry == null) {
+            entry = new ArrayList<>();
+        }
+        return this.entry;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/JukeboxStatus.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/JukeboxStatus.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlSeeAlso;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "JukeboxStatus")
+@XmlSeeAlso({ JukeboxPlaylist.class })
+public class JukeboxStatus {
+
+    @XmlAttribute(name = "currentIndex", required = true)
+    protected int currentIndex;
+    @XmlAttribute(name = "playing", required = true)
+    protected boolean playing;
+    @XmlAttribute(name = "gain", required = true)
+    protected float gain;
+    @XmlAttribute(name = "position")
+    protected Integer position;
+
+    public int getCurrentIndex() {
+        return currentIndex;
+    }
+
+    public void setCurrentIndex(int value) {
+        this.currentIndex = value;
+    }
+
+    public boolean isPlaying() {
+        return playing;
+    }
+
+    public void setPlaying(boolean value) {
+        this.playing = value;
+    }
+
+    public float getGain() {
+        return gain;
+    }
+
+    public void setGain(float value) {
+        this.gain = value;
+    }
+
+    public Integer getPosition() {
+        return position;
+    }
+
+    public void setPosition(Integer value) {
+        this.position = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/License.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/License.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "License")
+public class License {
+
+    @XmlAttribute(name = "valid", required = true)
+    protected boolean valid;
+    @XmlAttribute(name = "email")
+    protected String email;
+    @XmlAttribute(name = "licenseExpires")
+    @XmlSchemaType(name = "dateTime")
+    protected XMLGregorianCalendar licenseExpires;
+    @XmlAttribute(name = "trialExpires")
+    @XmlSchemaType(name = "dateTime")
+    protected XMLGregorianCalendar trialExpires;
+
+    public boolean isValid() {
+        return valid;
+    }
+
+    public void setValid(boolean value) {
+        this.valid = value;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String value) {
+        this.email = value;
+    }
+
+    public XMLGregorianCalendar getLicenseExpires() {
+        return licenseExpires;
+    }
+
+    public void setLicenseExpires(XMLGregorianCalendar value) {
+        this.licenseExpires = value;
+    }
+
+    public XMLGregorianCalendar getTrialExpires() {
+        return trialExpires;
+    }
+
+    public void setTrialExpires(XMLGregorianCalendar value) {
+        this.trialExpires = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Lyrics.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Lyrics.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlValue;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Lyrics", propOrder = { "content" })
+public class Lyrics {
+
+    @XmlValue
+    protected String content;
+    @XmlAttribute(name = "artist")
+    protected String artist;
+    @XmlAttribute(name = "title")
+    protected String title;
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String value) {
+        this.content = value;
+    }
+
+    public String getArtist() {
+        return artist;
+    }
+
+    public void setArtist(String value) {
+        this.artist = value;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String value) {
+        this.title = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/MediaType.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/MediaType.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.tesshu.jpsonic.util.connector.deserializer.MediaTypeDeserializer;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlType(name = "MediaType")
+@XmlEnum
+@JsonDeserialize(using = MediaTypeDeserializer.class)
+public enum MediaType {
+
+    @XmlEnumValue("music")
+    MUSIC("music"), @XmlEnumValue("podcast")
+    PODCAST("podcast"), @XmlEnumValue("audiobook")
+    AUDIOBOOK("audiobook"), @XmlEnumValue("video")
+    VIDEO("video");
+
+    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName") // XJC Naming Conventions
+    private final String value;
+
+    MediaType(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static MediaType fromValue(String v) {
+        for (MediaType c : values()) {
+            if (c.value.equals(v)) {
+                return c;
+            }
+        }
+        throw new IllegalArgumentException(v);
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/MusicFolder.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/MusicFolder.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "MusicFolder")
+public class MusicFolder {
+
+    @XmlAttribute(name = "id", required = true)
+    protected int id;
+    @XmlAttribute(name = "name")
+    protected String name;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int value) {
+        this.id = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String value) {
+        this.name = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/MusicFolders.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/MusicFolders.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "MusicFolders", propOrder = { "musicFolder" })
+public class MusicFolders {
+
+    protected List<MusicFolder> musicFolder;
+
+    public List<MusicFolder> getMusicFolder() {
+        if (musicFolder == null) {
+            musicFolder = new ArrayList<>();
+        }
+        return this.musicFolder;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/NewestPodcasts.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/NewestPodcasts.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "NewestPodcasts", propOrder = { "episode" })
+public class NewestPodcasts {
+
+    protected List<PodcastEpisode> episode;
+
+    public List<PodcastEpisode> getEpisode() {
+        if (episode == null) {
+            episode = new ArrayList<>();
+        }
+        return this.episode;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/NowPlaying.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/NowPlaying.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "NowPlaying", propOrder = { "entry" })
+public class NowPlaying {
+
+    protected List<NowPlayingEntry> entry;
+
+    public List<NowPlayingEntry> getEntry() {
+        if (entry == null) {
+            entry = new ArrayList<>();
+        }
+        return this.entry;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/NowPlayingEntry.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/NowPlayingEntry.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "NowPlayingEntry")
+public class NowPlayingEntry extends Child {
+
+    @XmlAttribute(name = "username", required = true)
+    protected String username;
+    @XmlAttribute(name = "minutesAgo", required = true)
+    protected int minutesAgo;
+    @XmlAttribute(name = "playerId", required = true)
+    protected int playerId;
+    @XmlAttribute(name = "playerName")
+    protected String playerName;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String value) {
+        this.username = value;
+    }
+
+    public int getMinutesAgo() {
+        return minutesAgo;
+    }
+
+    public void setMinutesAgo(int value) {
+        this.minutesAgo = value;
+    }
+
+    public int getPlayerId() {
+        return playerId;
+    }
+
+    public void setPlayerId(int value) {
+        this.playerId = value;
+    }
+
+    public String getPlayerName() {
+        return playerName;
+    }
+
+    public void setPlayerName(String value) {
+        this.playerName = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ObjectFactory.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ObjectFactory.java
@@ -1,0 +1,553 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import javax.xml.namespace.QName;
+
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.annotation.XmlElementDecl;
+import jakarta.xml.bind.annotation.XmlRegistry;
+
+/**
+ * This object contains factory methods for each Java content interface and Java element interface generated in the
+ * com.tesshu.jpsonic.util.connector.api package.
+ * <p>
+ * An ObjectFactory allows you to programatically construct new instances of the Java representation for XML content.
+ * The Java representation of XML content can consist of schema derived interfaces and classes representing the binding
+ * of schema type definitions, element declarations and model groups. Factory methods for each of these are provided in
+ * this class.
+ *
+ */
+@XmlRegistry
+public class ObjectFactory {
+
+    @SuppressWarnings("PMD.FieldNamingConventions") // XJC Naming Conventions
+    private static final QName _SubsonicResponse_QNAME = new QName("http://subsonic.org/restapi", "subsonic-response");
+
+    /**
+     * Create an instance of {@link Response }
+     *
+     */
+    public Response createResponse() {
+        return new Response();
+    }
+
+    /**
+     * Create an instance of {@link MusicFolders }
+     *
+     */
+    public MusicFolders createMusicFolders() {
+        return new MusicFolders();
+    }
+
+    /**
+     * Create an instance of {@link MusicFolder }
+     *
+     */
+    public MusicFolder createMusicFolder() {
+        return new MusicFolder();
+    }
+
+    /**
+     * Create an instance of {@link Indexes }
+     *
+     */
+    public Indexes createIndexes() {
+        return new Indexes();
+    }
+
+    /**
+     * Create an instance of {@link Index }
+     *
+     */
+    public Index createIndex() {
+        return new Index();
+    }
+
+    /**
+     * Create an instance of {@link Artist }
+     *
+     */
+    public Artist createArtist() {
+        return new Artist();
+    }
+
+    /**
+     * Create an instance of {@link Genres }
+     *
+     */
+    public Genres createGenres() {
+        return new Genres();
+    }
+
+    /**
+     * Create an instance of {@link Genre }
+     *
+     */
+    public Genre createGenre() {
+        return new Genre();
+    }
+
+    /**
+     * Create an instance of {@link ArtistsID3 }
+     *
+     */
+    public ArtistsID3 createArtistsID3() {
+        return new ArtistsID3();
+    }
+
+    /**
+     * Create an instance of {@link IndexID3 }
+     *
+     */
+    public IndexID3 createIndexID3() {
+        return new IndexID3();
+    }
+
+    /**
+     * Create an instance of {@link ArtistID3 }
+     *
+     */
+    public ArtistID3 createArtistID3() {
+        return new ArtistID3();
+    }
+
+    /**
+     * Create an instance of {@link ArtistWithAlbumsID3 }
+     *
+     */
+    public ArtistWithAlbumsID3 createArtistWithAlbumsID3() {
+        return new ArtistWithAlbumsID3();
+    }
+
+    /**
+     * Create an instance of {@link AlbumID3 }
+     *
+     */
+    public AlbumID3 createAlbumID3() {
+        return new AlbumID3();
+    }
+
+    /**
+     * Create an instance of {@link AlbumWithSongsID3 }
+     *
+     */
+    public AlbumWithSongsID3 createAlbumWithSongsID3() {
+        return new AlbumWithSongsID3();
+    }
+
+    /**
+     * Create an instance of {@link Videos }
+     *
+     */
+    public Videos createVideos() {
+        return new Videos();
+    }
+
+    /**
+     * Create an instance of {@link VideoInfo }
+     *
+     */
+    public VideoInfo createVideoInfo() {
+        return new VideoInfo();
+    }
+
+    /**
+     * Create an instance of {@link Captions }
+     *
+     */
+    public Captions createCaptions() {
+        return new Captions();
+    }
+
+    /**
+     * Create an instance of {@link AudioTrack }
+     *
+     */
+    public AudioTrack createAudioTrack() {
+        return new AudioTrack();
+    }
+
+    /**
+     * Create an instance of {@link VideoConversion }
+     *
+     */
+    public VideoConversion createVideoConversion() {
+        return new VideoConversion();
+    }
+
+    /**
+     * Create an instance of {@link Directory }
+     *
+     */
+    public Directory createDirectory() {
+        return new Directory();
+    }
+
+    /**
+     * Create an instance of {@link Child }
+     *
+     */
+    public Child createChild() {
+        return new Child();
+    }
+
+    /**
+     * Create an instance of {@link NowPlaying }
+     *
+     */
+    public NowPlaying createNowPlaying() {
+        return new NowPlaying();
+    }
+
+    /**
+     * Create an instance of {@link NowPlayingEntry }
+     *
+     */
+    public NowPlayingEntry createNowPlayingEntry() {
+        return new NowPlayingEntry();
+    }
+
+    /**
+     * Create an instance of {@link SearchResult }
+     *
+     */
+    public SearchResult createSearchResult() {
+        return new SearchResult();
+    }
+
+    /**
+     * Create an instance of {@link SearchResult2 }
+     *
+     */
+    public SearchResult2 createSearchResult2() {
+        return new SearchResult2();
+    }
+
+    /**
+     * Create an instance of {@link SearchResult3 }
+     *
+     */
+    public SearchResult3 createSearchResult3() {
+        return new SearchResult3();
+    }
+
+    /**
+     * Create an instance of {@link Playlists }
+     *
+     */
+    public Playlists createPlaylists() {
+        return new Playlists();
+    }
+
+    /**
+     * Create an instance of {@link Playlist }
+     *
+     */
+    public Playlist createPlaylist() {
+        return new Playlist();
+    }
+
+    /**
+     * Create an instance of {@link PlaylistWithSongs }
+     *
+     */
+    public PlaylistWithSongs createPlaylistWithSongs() {
+        return new PlaylistWithSongs();
+    }
+
+    /**
+     * Create an instance of {@link JukeboxStatus }
+     *
+     */
+    public JukeboxStatus createJukeboxStatus() {
+        return new JukeboxStatus();
+    }
+
+    /**
+     * Create an instance of {@link JukeboxPlaylist }
+     *
+     */
+    public JukeboxPlaylist createJukeboxPlaylist() {
+        return new JukeboxPlaylist();
+    }
+
+    /**
+     * Create an instance of {@link ChatMessages }
+     *
+     */
+    public ChatMessages createChatMessages() {
+        return new ChatMessages();
+    }
+
+    /**
+     * Create an instance of {@link ChatMessage }
+     *
+     */
+    public ChatMessage createChatMessage() {
+        return new ChatMessage();
+    }
+
+    /**
+     * Create an instance of {@link AlbumList }
+     *
+     */
+    public AlbumList createAlbumList() {
+        return new AlbumList();
+    }
+
+    /**
+     * Create an instance of {@link AlbumList2 }
+     *
+     */
+    public AlbumList2 createAlbumList2() {
+        return new AlbumList2();
+    }
+
+    /**
+     * Create an instance of {@link Songs }
+     *
+     */
+    public Songs createSongs() {
+        return new Songs();
+    }
+
+    /**
+     * Create an instance of {@link Lyrics }
+     *
+     */
+    public Lyrics createLyrics() {
+        return new Lyrics();
+    }
+
+    /**
+     * Create an instance of {@link Podcasts }
+     *
+     */
+    public Podcasts createPodcasts() {
+        return new Podcasts();
+    }
+
+    /**
+     * Create an instance of {@link PodcastChannel }
+     *
+     */
+    public PodcastChannel createPodcastChannel() {
+        return new PodcastChannel();
+    }
+
+    /**
+     * Create an instance of {@link NewestPodcasts }
+     *
+     */
+    public NewestPodcasts createNewestPodcasts() {
+        return new NewestPodcasts();
+    }
+
+    /**
+     * Create an instance of {@link PodcastEpisode }
+     *
+     */
+    public PodcastEpisode createPodcastEpisode() {
+        return new PodcastEpisode();
+    }
+
+    /**
+     * Create an instance of {@link InternetRadioStations }
+     *
+     */
+    public InternetRadioStations createInternetRadioStations() {
+        return new InternetRadioStations();
+    }
+
+    /**
+     * Create an instance of {@link InternetRadioStation }
+     *
+     */
+    public InternetRadioStation createInternetRadioStation() {
+        return new InternetRadioStation();
+    }
+
+    /**
+     * Create an instance of {@link Bookmarks }
+     *
+     */
+    public Bookmarks createBookmarks() {
+        return new Bookmarks();
+    }
+
+    /**
+     * Create an instance of {@link Bookmark }
+     *
+     */
+    public Bookmark createBookmark() {
+        return new Bookmark();
+    }
+
+    /**
+     * Create an instance of {@link PlayQueue }
+     *
+     */
+    public PlayQueue createPlayQueue() {
+        return new PlayQueue();
+    }
+
+    /**
+     * Create an instance of {@link Shares }
+     *
+     */
+    public Shares createShares() {
+        return new Shares();
+    }
+
+    /**
+     * Create an instance of {@link Share }
+     *
+     */
+    public Share createShare() {
+        return new Share();
+    }
+
+    /**
+     * Create an instance of {@link Starred }
+     *
+     */
+    public Starred createStarred() {
+        return new Starred();
+    }
+
+    /**
+     * Create an instance of {@link AlbumInfo }
+     *
+     */
+    public AlbumInfo createAlbumInfo() {
+        return new AlbumInfo();
+    }
+
+    /**
+     * Create an instance of {@link ArtistInfoBase }
+     *
+     */
+    public ArtistInfoBase createArtistInfoBase() {
+        return new ArtistInfoBase();
+    }
+
+    /**
+     * Create an instance of {@link ArtistInfo }
+     *
+     */
+    public ArtistInfo createArtistInfo() {
+        return new ArtistInfo();
+    }
+
+    /**
+     * Create an instance of {@link ArtistInfo2 }
+     *
+     */
+    public ArtistInfo2 createArtistInfo2() {
+        return new ArtistInfo2();
+    }
+
+    /**
+     * Create an instance of {@link SimilarSongs }
+     *
+     */
+    public SimilarSongs createSimilarSongs() {
+        return new SimilarSongs();
+    }
+
+    /**
+     * Create an instance of {@link SimilarSongs2 }
+     *
+     */
+    public SimilarSongs2 createSimilarSongs2() {
+        return new SimilarSongs2();
+    }
+
+    /**
+     * Create an instance of {@link TopSongs }
+     *
+     */
+    public TopSongs createTopSongs() {
+        return new TopSongs();
+    }
+
+    /**
+     * Create an instance of {@link Starred2 }
+     *
+     */
+    public Starred2 createStarred2() {
+        return new Starred2();
+    }
+
+    /**
+     * Create an instance of {@link License }
+     *
+     */
+    public License createLicense() {
+        return new License();
+    }
+
+    /**
+     * Create an instance of {@link ScanStatus }
+     *
+     */
+    public ScanStatus createScanStatus() {
+        return new ScanStatus();
+    }
+
+    /**
+     * Create an instance of {@link Users }
+     *
+     */
+    public Users createUsers() {
+        return new Users();
+    }
+
+    /**
+     * Create an instance of {@link User }
+     *
+     */
+    public User createUser() {
+        return new User();
+    }
+
+    /**
+     * Create an instance of {@link Error }
+     *
+     */
+    public Error createError() {
+        return new Error();
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link Response }{@code >}
+     *
+     * @param value
+     *            Java instance representing xml element's value.
+     *
+     * @return the new instance of {@link JAXBElement }{@code <}{@link Response }{@code >}
+     */
+    @XmlElementDecl(namespace = "http://subsonic.org/restapi", name = "subsonic-response")
+    public JAXBElement<Response> createSubsonicResponse(Response value) {
+        return new JAXBElement<>(_SubsonicResponse_QNAME, Response.class, null, value);
+    }
+
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/PlayQueue.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/PlayQueue.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "PlayQueue", propOrder = { "entry" })
+public class PlayQueue {
+
+    protected List<Child> entry;
+    @XmlAttribute(name = "current")
+    protected Integer current;
+    @XmlAttribute(name = "position")
+    protected Long position;
+    @XmlAttribute(name = "username", required = true)
+    protected String username;
+    @XmlAttribute(name = "changed", required = true)
+    @XmlSchemaType(name = "dateTime")
+    protected XMLGregorianCalendar changed;
+    @XmlAttribute(name = "changedBy", required = true)
+    protected String changedBy;
+
+    public List<Child> getEntry() {
+        if (entry == null) {
+            entry = new ArrayList<>();
+        }
+        return this.entry;
+    }
+
+    public Integer getCurrent() {
+        return current;
+    }
+
+    public void setCurrent(Integer value) {
+        this.current = value;
+    }
+
+    public Long getPosition() {
+        return position;
+    }
+
+    public void setPosition(Long value) {
+        this.position = value;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String value) {
+        this.username = value;
+    }
+
+    public XMLGregorianCalendar getChanged() {
+        return changed;
+    }
+
+    public void setChanged(XMLGregorianCalendar value) {
+        this.changed = value;
+    }
+
+    public String getChangedBy() {
+        return changedBy;
+    }
+
+    public void setChangedBy(String value) {
+        this.changedBy = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Playlist.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Playlist.java
@@ -1,0 +1,150 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlSeeAlso;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Playlist", propOrder = { "allowedUser" })
+@XmlSeeAlso({ PlaylistWithSongs.class })
+public class Playlist {
+
+    protected List<String> allowedUser;
+    @XmlAttribute(name = "id", required = true)
+    protected String id;
+    @XmlAttribute(name = "name", required = true)
+    protected String name;
+    @XmlAttribute(name = "comment")
+    protected String comment;
+    @XmlAttribute(name = "owner")
+    protected String owner;
+    @XmlAttribute(name = "public")
+    @SuppressWarnings("PMD.FieldNamingConventions") // XJC Naming Conventions
+    protected Boolean _public;
+    @XmlAttribute(name = "songCount", required = true)
+    protected int songCount;
+    @XmlAttribute(name = "duration", required = true)
+    protected int duration;
+    @XmlAttribute(name = "created", required = true)
+    @XmlSchemaType(name = "dateTime")
+    protected XMLGregorianCalendar created;
+    @XmlAttribute(name = "changed", required = true)
+    @XmlSchemaType(name = "dateTime")
+    protected XMLGregorianCalendar changed;
+    @XmlAttribute(name = "coverArt")
+    protected String coverArt;
+
+    public List<String> getAllowedUser() {
+        if (allowedUser == null) {
+            allowedUser = new ArrayList<>();
+        }
+        return this.allowedUser;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String value) {
+        this.id = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String value) {
+        this.name = value;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String value) {
+        this.comment = value;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String value) {
+        this.owner = value;
+    }
+
+    public Boolean isPublic() {
+        return _public;
+    }
+
+    public void setPublic(Boolean value) {
+        this._public = value;
+    }
+
+    public int getSongCount() {
+        return songCount;
+    }
+
+    public void setSongCount(int value) {
+        this.songCount = value;
+    }
+
+    public int getDuration() {
+        return duration;
+    }
+
+    public void setDuration(int value) {
+        this.duration = value;
+    }
+
+    public XMLGregorianCalendar getCreated() {
+        return created;
+    }
+
+    public void setCreated(XMLGregorianCalendar value) {
+        this.created = value;
+    }
+
+    public XMLGregorianCalendar getChanged() {
+        return changed;
+    }
+
+    public void setChanged(XMLGregorianCalendar value) {
+        this.changed = value;
+    }
+
+    public String getCoverArt() {
+        return coverArt;
+    }
+
+    public void setCoverArt(String value) {
+        this.coverArt = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/PlaylistWithSongs.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/PlaylistWithSongs.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "PlaylistWithSongs", propOrder = { "entry" })
+public class PlaylistWithSongs extends Playlist {
+
+    protected List<Child> entry;
+
+    public List<Child> getEntry() {
+        if (entry == null) {
+            entry = new ArrayList<>();
+        }
+        return this.entry;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Playlists.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Playlists.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Playlists", propOrder = { "playlist" })
+public class Playlists {
+
+    protected List<Playlist> playlist;
+
+    public List<Playlist> getPlaylist() {
+        if (playlist == null) {
+            playlist = new ArrayList<>();
+        }
+        return this.playlist;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/PodcastChannel.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/PodcastChannel.java
@@ -1,0 +1,122 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "PodcastChannel", propOrder = { "episode" })
+public class PodcastChannel {
+
+    protected List<PodcastEpisode> episode;
+    @XmlAttribute(name = "id", required = true)
+    protected String id;
+    @XmlAttribute(name = "url", required = true)
+    protected String url;
+    @XmlAttribute(name = "title")
+    protected String title;
+    @XmlAttribute(name = "description")
+    protected String description;
+    @XmlAttribute(name = "coverArt")
+    protected String coverArt;
+    @XmlAttribute(name = "originalImageUrl")
+    protected String originalImageUrl;
+    @XmlAttribute(name = "status", required = true)
+    protected PodcastStatus status;
+    @XmlAttribute(name = "errorMessage")
+    protected String errorMessage;
+
+    public List<PodcastEpisode> getEpisode() {
+        if (episode == null) {
+            episode = new ArrayList<>();
+        }
+        return this.episode;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String value) {
+        this.id = value;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String value) {
+        this.url = value;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String value) {
+        this.title = value;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String value) {
+        this.description = value;
+    }
+
+    public String getCoverArt() {
+        return coverArt;
+    }
+
+    public void setCoverArt(String value) {
+        this.coverArt = value;
+    }
+
+    public String getOriginalImageUrl() {
+        return originalImageUrl;
+    }
+
+    public void setOriginalImageUrl(String value) {
+        this.originalImageUrl = value;
+    }
+
+    public PodcastStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(PodcastStatus value) {
+        this.status = value;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String value) {
+        this.errorMessage = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/PodcastEpisode.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/PodcastEpisode.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "PodcastEpisode")
+public class PodcastEpisode extends Child {
+
+    @XmlAttribute(name = "streamId")
+    protected String streamId;
+    @XmlAttribute(name = "channelId", required = true)
+    protected String channelId;
+    @XmlAttribute(name = "description")
+    protected String description;
+    @XmlAttribute(name = "status", required = true)
+    protected PodcastStatus status;
+    @XmlAttribute(name = "publishDate")
+    @XmlSchemaType(name = "dateTime")
+    protected XMLGregorianCalendar publishDate;
+
+    public String getStreamId() {
+        return streamId;
+    }
+
+    public void setStreamId(String value) {
+        this.streamId = value;
+    }
+
+    public String getChannelId() {
+        return channelId;
+    }
+
+    public void setChannelId(String value) {
+        this.channelId = value;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String value) {
+        this.description = value;
+    }
+
+    public PodcastStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(PodcastStatus value) {
+        this.status = value;
+    }
+
+    public XMLGregorianCalendar getPublishDate() {
+        return publishDate;
+    }
+
+    public void setPublishDate(XMLGregorianCalendar value) {
+        this.publishDate = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/PodcastStatus.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/PodcastStatus.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlType(name = "PodcastStatus")
+@XmlEnum
+public enum PodcastStatus {
+
+    @XmlEnumValue("new")
+    NEW("new"), @XmlEnumValue("downloading")
+    DOWNLOADING("downloading"), @XmlEnumValue("completed")
+    COMPLETED("completed"), @XmlEnumValue("error")
+    ERROR("error"), @XmlEnumValue("deleted")
+    DELETED("deleted"), @XmlEnumValue("skipped")
+    SKIPPED("skipped");
+
+    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName") // XJC Naming Conventions
+    private final String value;
+
+    PodcastStatus(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static PodcastStatus fromValue(String v) {
+        for (PodcastStatus c : values()) {
+            if (c.value.equals(v)) {
+                return c;
+            }
+        }
+        throw new IllegalArgumentException(v);
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Podcasts.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Podcasts.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Podcasts", propOrder = { "channel" })
+public class Podcasts {
+
+    protected List<PodcastChannel> channel;
+
+    public List<PodcastChannel> getChannel() {
+        if (channel == null) {
+            channel = new ArrayList<>();
+        }
+        return this.channel;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Response.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Response.java
@@ -1,0 +1,443 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Response", propOrder = { "musicFolders", "indexes", "directory", "genres", "artists", "artist",
+        "album", "song", "videos", "videoInfo", "nowPlaying", "searchResult", "searchResult2", "searchResult3",
+        "playlists", "playlist", "jukeboxStatus", "jukeboxPlaylist", "license", "users", "user", "chatMessages",
+        "albumList", "albumList2", "randomSongs", "songsByGenre", "lyrics", "podcasts", "newestPodcasts",
+        "internetRadioStations", "bookmarks", "playQueue", "shares", "starred", "starred2", "albumInfo", "artistInfo",
+        "artistInfo2", "similarSongs", "similarSongs2", "topSongs", "scanStatus", "error" })
+public class Response {
+
+    protected MusicFolders musicFolders;
+    protected Indexes indexes;
+    protected Directory directory;
+    protected Genres genres;
+    protected ArtistsID3 artists;
+    protected ArtistWithAlbumsID3 artist;
+    protected AlbumWithSongsID3 album;
+    protected Child song;
+    protected Videos videos;
+    protected VideoInfo videoInfo;
+    protected NowPlaying nowPlaying;
+    protected SearchResult searchResult;
+    protected SearchResult2 searchResult2;
+    protected SearchResult3 searchResult3;
+    protected Playlists playlists;
+    protected PlaylistWithSongs playlist;
+    protected JukeboxStatus jukeboxStatus;
+    protected JukeboxPlaylist jukeboxPlaylist;
+    protected License license;
+    protected Users users;
+    protected User user;
+    protected ChatMessages chatMessages;
+    protected AlbumList albumList;
+    protected AlbumList2 albumList2;
+    protected Songs randomSongs;
+    protected Songs songsByGenre;
+    protected Lyrics lyrics;
+    protected Podcasts podcasts;
+    protected NewestPodcasts newestPodcasts;
+    protected InternetRadioStations internetRadioStations;
+    protected Bookmarks bookmarks;
+    protected PlayQueue playQueue;
+    protected Shares shares;
+    protected Starred starred;
+    protected Starred2 starred2;
+    protected AlbumInfo albumInfo;
+    protected ArtistInfo artistInfo;
+    protected ArtistInfo2 artistInfo2;
+    protected SimilarSongs similarSongs;
+    protected SimilarSongs2 similarSongs2;
+    protected TopSongs topSongs;
+    protected ScanStatus scanStatus;
+    protected Error error;
+    @XmlAttribute(name = "status", required = true)
+    protected ResponseStatus status;
+    @XmlAttribute(name = "version", required = true)
+    protected String version;
+
+    public MusicFolders getMusicFolders() {
+        return musicFolders;
+    }
+
+    public void setMusicFolders(MusicFolders value) {
+        this.musicFolders = value;
+    }
+
+    public Indexes getIndexes() {
+        return indexes;
+    }
+
+    public void setIndexes(Indexes value) {
+        this.indexes = value;
+    }
+
+    public Directory getDirectory() {
+        return directory;
+    }
+
+    public void setDirectory(Directory value) {
+        this.directory = value;
+    }
+
+    public Genres getGenres() {
+        return genres;
+    }
+
+    public void setGenres(Genres value) {
+        this.genres = value;
+    }
+
+    public ArtistsID3 getArtists() {
+        return artists;
+    }
+
+    public void setArtists(ArtistsID3 value) {
+        this.artists = value;
+    }
+
+    public ArtistWithAlbumsID3 getArtist() {
+        return artist;
+    }
+
+    public void setArtist(ArtistWithAlbumsID3 value) {
+        this.artist = value;
+    }
+
+    public AlbumWithSongsID3 getAlbum() {
+        return album;
+    }
+
+    public void setAlbum(AlbumWithSongsID3 value) {
+        this.album = value;
+    }
+
+    public Child getSong() {
+        return song;
+    }
+
+    public void setSong(Child value) {
+        this.song = value;
+    }
+
+    public Videos getVideos() {
+        return videos;
+    }
+
+    public void setVideos(Videos value) {
+        this.videos = value;
+    }
+
+    public VideoInfo getVideoInfo() {
+        return videoInfo;
+    }
+
+    public void setVideoInfo(VideoInfo value) {
+        this.videoInfo = value;
+    }
+
+    public NowPlaying getNowPlaying() {
+        return nowPlaying;
+    }
+
+    public void setNowPlaying(NowPlaying value) {
+        this.nowPlaying = value;
+    }
+
+    public SearchResult getSearchResult() {
+        return searchResult;
+    }
+
+    public void setSearchResult(SearchResult value) {
+        this.searchResult = value;
+    }
+
+    public SearchResult2 getSearchResult2() {
+        return searchResult2;
+    }
+
+    public void setSearchResult2(SearchResult2 value) {
+        this.searchResult2 = value;
+    }
+
+    public SearchResult3 getSearchResult3() {
+        return searchResult3;
+    }
+
+    public void setSearchResult3(SearchResult3 value) {
+        this.searchResult3 = value;
+    }
+
+    public Playlists getPlaylists() {
+        return playlists;
+    }
+
+    public void setPlaylists(Playlists value) {
+        this.playlists = value;
+    }
+
+    public PlaylistWithSongs getPlaylist() {
+        return playlist;
+    }
+
+    public void setPlaylist(PlaylistWithSongs value) {
+        this.playlist = value;
+    }
+
+    public JukeboxStatus getJukeboxStatus() {
+        return jukeboxStatus;
+    }
+
+    public void setJukeboxStatus(JukeboxStatus value) {
+        this.jukeboxStatus = value;
+    }
+
+    public JukeboxPlaylist getJukeboxPlaylist() {
+        return jukeboxPlaylist;
+    }
+
+    public void setJukeboxPlaylist(JukeboxPlaylist value) {
+        this.jukeboxPlaylist = value;
+    }
+
+    public License getLicense() {
+        return license;
+    }
+
+    public void setLicense(License value) {
+        this.license = value;
+    }
+
+    public Users getUsers() {
+        return users;
+    }
+
+    public void setUsers(Users value) {
+        this.users = value;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User value) {
+        this.user = value;
+    }
+
+    public ChatMessages getChatMessages() {
+        return chatMessages;
+    }
+
+    public void setChatMessages(ChatMessages value) {
+        this.chatMessages = value;
+    }
+
+    public AlbumList getAlbumList() {
+        return albumList;
+    }
+
+    public void setAlbumList(AlbumList value) {
+        this.albumList = value;
+    }
+
+    public AlbumList2 getAlbumList2() {
+        return albumList2;
+    }
+
+    public void setAlbumList2(AlbumList2 value) {
+        this.albumList2 = value;
+    }
+
+    public Songs getRandomSongs() {
+        return randomSongs;
+    }
+
+    public void setRandomSongs(Songs value) {
+        this.randomSongs = value;
+    }
+
+    public Songs getSongsByGenre() {
+        return songsByGenre;
+    }
+
+    public void setSongsByGenre(Songs value) {
+        this.songsByGenre = value;
+    }
+
+    public Lyrics getLyrics() {
+        return lyrics;
+    }
+
+    public void setLyrics(Lyrics value) {
+        this.lyrics = value;
+    }
+
+    public Podcasts getPodcasts() {
+        return podcasts;
+    }
+
+    public void setPodcasts(Podcasts value) {
+        this.podcasts = value;
+    }
+
+    public NewestPodcasts getNewestPodcasts() {
+        return newestPodcasts;
+    }
+
+    public void setNewestPodcasts(NewestPodcasts value) {
+        this.newestPodcasts = value;
+    }
+
+    public InternetRadioStations getInternetRadioStations() {
+        return internetRadioStations;
+    }
+
+    public void setInternetRadioStations(InternetRadioStations value) {
+        this.internetRadioStations = value;
+    }
+
+    public Bookmarks getBookmarks() {
+        return bookmarks;
+    }
+
+    public void setBookmarks(Bookmarks value) {
+        this.bookmarks = value;
+    }
+
+    public PlayQueue getPlayQueue() {
+        return playQueue;
+    }
+
+    public void setPlayQueue(PlayQueue value) {
+        this.playQueue = value;
+    }
+
+    public Shares getShares() {
+        return shares;
+    }
+
+    public void setShares(Shares value) {
+        this.shares = value;
+    }
+
+    public Starred getStarred() {
+        return starred;
+    }
+
+    public void setStarred(Starred value) {
+        this.starred = value;
+    }
+
+    public Starred2 getStarred2() {
+        return starred2;
+    }
+
+    public void setStarred2(Starred2 value) {
+        this.starred2 = value;
+    }
+
+    public AlbumInfo getAlbumInfo() {
+        return albumInfo;
+    }
+
+    public void setAlbumInfo(AlbumInfo value) {
+        this.albumInfo = value;
+    }
+
+    public ArtistInfo getArtistInfo() {
+        return artistInfo;
+    }
+
+    public void setArtistInfo(ArtistInfo value) {
+        this.artistInfo = value;
+    }
+
+    public ArtistInfo2 getArtistInfo2() {
+        return artistInfo2;
+    }
+
+    public void setArtistInfo2(ArtistInfo2 value) {
+        this.artistInfo2 = value;
+    }
+
+    public SimilarSongs getSimilarSongs() {
+        return similarSongs;
+    }
+
+    public void setSimilarSongs(SimilarSongs value) {
+        this.similarSongs = value;
+    }
+
+    public SimilarSongs2 getSimilarSongs2() {
+        return similarSongs2;
+    }
+
+    public void setSimilarSongs2(SimilarSongs2 value) {
+        this.similarSongs2 = value;
+    }
+
+    public TopSongs getTopSongs() {
+        return topSongs;
+    }
+
+    public void setTopSongs(TopSongs value) {
+        this.topSongs = value;
+    }
+
+    public ScanStatus getScanStatus() {
+        return scanStatus;
+    }
+
+    public void setScanStatus(ScanStatus value) {
+        this.scanStatus = value;
+    }
+
+    public Error getError() {
+        return error;
+    }
+
+    public void setError(Error value) {
+        this.error = value;
+    }
+
+    public ResponseStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ResponseStatus value) {
+        this.status = value;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String value) {
+        this.version = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ResponseStatus.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ResponseStatus.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.tesshu.jpsonic.util.connector.deserializer.ResponseStatusDeserializer;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlType(name = "ResponseStatus")
+@XmlEnum
+@JsonDeserialize(using = ResponseStatusDeserializer.class)
+public enum ResponseStatus {
+
+    @XmlEnumValue("ok")
+    OK("ok"), @XmlEnumValue("failed")
+    FAILED("failed");
+
+    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName") // XJC Naming Conventions
+    private final String value;
+
+    ResponseStatus(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static ResponseStatus fromValue(String v) {
+        for (ResponseStatus c : values()) {
+            if (c.value.equals(v)) {
+                return c;
+            }
+        }
+        throw new IllegalArgumentException(v);
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ScanStatus.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/ScanStatus.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ScanStatus")
+public class ScanStatus {
+
+    @XmlAttribute(name = "scanning", required = true)
+    protected boolean scanning;
+    @XmlAttribute(name = "count")
+    protected Long count;
+
+    public boolean isScanning() {
+        return scanning;
+    }
+
+    public void setScanning(boolean value) {
+        this.scanning = value;
+    }
+
+    public Long getCount() {
+        return count;
+    }
+
+    public void setCount(Long value) {
+        this.count = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/SearchResult.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/SearchResult.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "SearchResult", propOrder = { "match" })
+public class SearchResult {
+
+    protected List<Child> match;
+    @XmlAttribute(name = "offset", required = true)
+    protected int offset;
+    @XmlAttribute(name = "totalHits", required = true)
+    protected int totalHits;
+
+    public List<Child> getMatch() {
+        if (match == null) {
+            match = new ArrayList<>();
+        }
+        return this.match;
+    }
+
+    public int getOffset() {
+        return offset;
+    }
+
+    public void setOffset(int value) {
+        this.offset = value;
+    }
+
+    public int getTotalHits() {
+        return totalHits;
+    }
+
+    public void setTotalHits(int value) {
+        this.totalHits = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/SearchResult2.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/SearchResult2.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "SearchResult2", propOrder = { "artist", "album", "song" })
+public class SearchResult2 {
+
+    protected List<Artist> artist;
+    protected List<Child> album;
+    protected List<Child> song;
+
+    public List<Artist> getArtist() {
+        if (artist == null) {
+            artist = new ArrayList<>();
+        }
+        return this.artist;
+    }
+
+    public List<Child> getAlbum() {
+        if (album == null) {
+            album = new ArrayList<>();
+        }
+        return this.album;
+    }
+
+    public List<Child> getSong() {
+        if (song == null) {
+            song = new ArrayList<>();
+        }
+        return this.song;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/SearchResult3.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/SearchResult3.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "SearchResult3", propOrder = { "artist", "album", "song" })
+public class SearchResult3 {
+
+    protected List<ArtistID3> artist;
+    protected List<AlbumID3> album;
+    protected List<Child> song;
+
+    public List<ArtistID3> getArtist() {
+        if (artist == null) {
+            artist = new ArrayList<>();
+        }
+        return this.artist;
+    }
+
+    public List<AlbumID3> getAlbum() {
+        if (album == null) {
+            album = new ArrayList<>();
+        }
+        return this.album;
+    }
+
+    public List<Child> getSong() {
+        if (song == null) {
+            song = new ArrayList<>();
+        }
+        return this.song;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Share.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Share.java
@@ -1,0 +1,128 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Share", propOrder = { "entry" })
+public class Share {
+
+    protected List<Child> entry;
+    @XmlAttribute(name = "id", required = true)
+    protected String id;
+    @XmlAttribute(name = "url", required = true)
+    protected String url;
+    @XmlAttribute(name = "description")
+    protected String description;
+    @XmlAttribute(name = "username", required = true)
+    protected String username;
+    @XmlAttribute(name = "created", required = true)
+    @XmlSchemaType(name = "dateTime")
+    protected XMLGregorianCalendar created;
+    @XmlAttribute(name = "expires")
+    @XmlSchemaType(name = "dateTime")
+    protected XMLGregorianCalendar expires;
+    @XmlAttribute(name = "lastVisited")
+    @XmlSchemaType(name = "dateTime")
+    protected XMLGregorianCalendar lastVisited;
+    @XmlAttribute(name = "visitCount", required = true)
+    protected int visitCount;
+
+    public List<Child> getEntry() {
+        if (entry == null) {
+            entry = new ArrayList<>();
+        }
+        return this.entry;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String value) {
+        this.id = value;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String value) {
+        this.url = value;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String value) {
+        this.description = value;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String value) {
+        this.username = value;
+    }
+
+    public XMLGregorianCalendar getCreated() {
+        return created;
+    }
+
+    public void setCreated(XMLGregorianCalendar value) {
+        this.created = value;
+    }
+
+    public XMLGregorianCalendar getExpires() {
+        return expires;
+    }
+
+    public void setExpires(XMLGregorianCalendar value) {
+        this.expires = value;
+    }
+
+    public XMLGregorianCalendar getLastVisited() {
+        return lastVisited;
+    }
+
+    public void setLastVisited(XMLGregorianCalendar value) {
+        this.lastVisited = value;
+    }
+
+    public int getVisitCount() {
+        return visitCount;
+    }
+
+    public void setVisitCount(int value) {
+        this.visitCount = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Shares.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Shares.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Shares", propOrder = { "share" })
+public class Shares {
+
+    protected List<Share> share;
+
+    public List<Share> getShare() {
+        if (share == null) {
+            share = new ArrayList<>();
+        }
+        return this.share;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/SimilarSongs.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/SimilarSongs.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "SimilarSongs", propOrder = { "song" })
+public class SimilarSongs {
+
+    protected List<Child> song;
+
+    public List<Child> getSong() {
+        if (song == null) {
+            song = new ArrayList<>();
+        }
+        return this.song;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/SimilarSongs2.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/SimilarSongs2.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "SimilarSongs2", propOrder = { "song" })
+public class SimilarSongs2 {
+
+    protected List<Child> song;
+
+    public List<Child> getSong() {
+        if (song == null) {
+            song = new ArrayList<>();
+        }
+        return this.song;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Songs.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Songs.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Songs", propOrder = { "song" })
+public class Songs {
+
+    protected List<Child> song;
+
+    public List<Child> getSong() {
+        if (song == null) {
+            song = new ArrayList<>();
+        }
+        return this.song;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Starred.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Starred.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Starred", propOrder = { "artist", "album", "song" })
+public class Starred {
+
+    protected List<Artist> artist;
+    protected List<Child> album;
+    protected List<Child> song;
+
+    public List<Artist> getArtist() {
+        if (artist == null) {
+            artist = new ArrayList<>();
+        }
+        return this.artist;
+    }
+
+    public List<Child> getAlbum() {
+        if (album == null) {
+            album = new ArrayList<>();
+        }
+        return this.album;
+    }
+
+    public List<Child> getSong() {
+        if (song == null) {
+            song = new ArrayList<>();
+        }
+        return this.song;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Starred2.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Starred2.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Starred2", propOrder = { "artist", "album", "song" })
+public class Starred2 {
+
+    protected List<ArtistID3> artist;
+    protected List<AlbumID3> album;
+    protected List<Child> song;
+
+    public List<ArtistID3> getArtist() {
+        if (artist == null) {
+            artist = new ArrayList<>();
+        }
+        return this.artist;
+    }
+
+    public List<AlbumID3> getAlbum() {
+        if (album == null) {
+            album = new ArrayList<>();
+        }
+        return this.album;
+    }
+
+    public List<Child> getSong() {
+        if (song == null) {
+            song = new ArrayList<>();
+        }
+        return this.song;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/TopSongs.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/TopSongs.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "TopSongs", propOrder = { "song" })
+public class TopSongs {
+
+    protected List<Child> song;
+
+    public List<Child> getSong() {
+        if (song == null) {
+            song = new ArrayList<>();
+        }
+        return this.song;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/User.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/User.java
@@ -1,0 +1,219 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "User", propOrder = { "folder" })
+@SuppressWarnings("PMD.ShortClassName") // XJC Naming Conventions
+public class User {
+
+    @XmlElement(type = Integer.class)
+    protected List<Integer> folder;
+    @XmlAttribute(name = "username", required = true)
+    protected String username;
+    @XmlAttribute(name = "email")
+    protected String email;
+    @XmlAttribute(name = "scrobblingEnabled", required = true)
+    protected boolean scrobblingEnabled;
+    @XmlAttribute(name = "maxBitRate")
+    protected Integer maxBitRate;
+    @XmlAttribute(name = "adminRole", required = true)
+    protected boolean adminRole;
+    @XmlAttribute(name = "settingsRole", required = true)
+    protected boolean settingsRole;
+    @XmlAttribute(name = "downloadRole", required = true)
+    protected boolean downloadRole;
+    @XmlAttribute(name = "uploadRole", required = true)
+    protected boolean uploadRole;
+    @XmlAttribute(name = "playlistRole", required = true)
+    protected boolean playlistRole;
+    @XmlAttribute(name = "coverArtRole", required = true)
+    protected boolean coverArtRole;
+    @XmlAttribute(name = "commentRole", required = true)
+    protected boolean commentRole;
+    @XmlAttribute(name = "podcastRole", required = true)
+    protected boolean podcastRole;
+    @XmlAttribute(name = "streamRole", required = true)
+    protected boolean streamRole;
+    @XmlAttribute(name = "jukeboxRole", required = true)
+    protected boolean jukeboxRole;
+    @XmlAttribute(name = "shareRole", required = true)
+    protected boolean shareRole;
+    @XmlAttribute(name = "videoConversionRole", required = true)
+    protected boolean videoConversionRole;
+    @XmlAttribute(name = "avatarLastChanged")
+    @XmlSchemaType(name = "dateTime")
+    protected XMLGregorianCalendar avatarLastChanged;
+
+    public List<Integer> getFolder() {
+        if (folder == null) {
+            folder = new ArrayList<>();
+        }
+        return this.folder;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String value) {
+        this.username = value;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String value) {
+        this.email = value;
+    }
+
+    public boolean isScrobblingEnabled() {
+        return scrobblingEnabled;
+    }
+
+    public void setScrobblingEnabled(boolean value) {
+        this.scrobblingEnabled = value;
+    }
+
+    public Integer getMaxBitRate() {
+        return maxBitRate;
+    }
+
+    public void setMaxBitRate(Integer value) {
+        this.maxBitRate = value;
+    }
+
+    public boolean isAdminRole() {
+        return adminRole;
+    }
+
+    public void setAdminRole(boolean value) {
+        this.adminRole = value;
+    }
+
+    public boolean isSettingsRole() {
+        return settingsRole;
+    }
+
+    public void setSettingsRole(boolean value) {
+        this.settingsRole = value;
+    }
+
+    public boolean isDownloadRole() {
+        return downloadRole;
+    }
+
+    public void setDownloadRole(boolean value) {
+        this.downloadRole = value;
+    }
+
+    public boolean isUploadRole() {
+        return uploadRole;
+    }
+
+    public void setUploadRole(boolean value) {
+        this.uploadRole = value;
+    }
+
+    public boolean isPlaylistRole() {
+        return playlistRole;
+    }
+
+    public void setPlaylistRole(boolean value) {
+        this.playlistRole = value;
+    }
+
+    public boolean isCoverArtRole() {
+        return coverArtRole;
+    }
+
+    public void setCoverArtRole(boolean value) {
+        this.coverArtRole = value;
+    }
+
+    public boolean isCommentRole() {
+        return commentRole;
+    }
+
+    public void setCommentRole(boolean value) {
+        this.commentRole = value;
+    }
+
+    public boolean isPodcastRole() {
+        return podcastRole;
+    }
+
+    public void setPodcastRole(boolean value) {
+        this.podcastRole = value;
+    }
+
+    public boolean isStreamRole() {
+        return streamRole;
+    }
+
+    public void setStreamRole(boolean value) {
+        this.streamRole = value;
+    }
+
+    public boolean isJukeboxRole() {
+        return jukeboxRole;
+    }
+
+    public void setJukeboxRole(boolean value) {
+        this.jukeboxRole = value;
+    }
+
+    public boolean isShareRole() {
+        return shareRole;
+    }
+
+    public void setShareRole(boolean value) {
+        this.shareRole = value;
+    }
+
+    public boolean isVideoConversionRole() {
+        return videoConversionRole;
+    }
+
+    public void setVideoConversionRole(boolean value) {
+        this.videoConversionRole = value;
+    }
+
+    public XMLGregorianCalendar getAvatarLastChanged() {
+        return avatarLastChanged;
+    }
+
+    public void setAvatarLastChanged(XMLGregorianCalendar value) {
+        this.avatarLastChanged = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Users.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Users.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Users", propOrder = { "user" })
+public class Users {
+
+    protected List<User> user;
+
+    public List<User> getUser() {
+        if (user == null) {
+            user = new ArrayList<>();
+        }
+        return this.user;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/VideoConversion.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/VideoConversion.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "VideoConversion")
+public class VideoConversion {
+
+    @XmlAttribute(name = "id", required = true)
+    protected String id;
+    @XmlAttribute(name = "bitRate")
+    protected Integer bitRate;
+    @XmlAttribute(name = "audioTrackId")
+    protected Integer audioTrackId;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String value) {
+        this.id = value;
+    }
+
+    public Integer getBitRate() {
+        return bitRate;
+    }
+
+    public void setBitRate(Integer value) {
+        this.bitRate = value;
+    }
+
+    public Integer getAudioTrackId() {
+        return audioTrackId;
+    }
+
+    public void setAudioTrackId(Integer value) {
+        this.audioTrackId = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/VideoInfo.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/VideoInfo.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "VideoInfo", propOrder = { "captions", "audioTrack", "conversion" })
+public class VideoInfo {
+
+    protected List<Captions> captions;
+    protected List<AudioTrack> audioTrack;
+    protected List<VideoConversion> conversion;
+    @XmlAttribute(name = "id", required = true)
+    protected String id;
+
+    public List<Captions> getCaptions() {
+        if (captions == null) {
+            captions = new ArrayList<>();
+        }
+        return this.captions;
+    }
+
+    public List<AudioTrack> getAudioTrack() {
+        if (audioTrack == null) {
+            audioTrack = new ArrayList<>();
+        }
+        return this.audioTrack;
+    }
+
+    public List<VideoConversion> getConversion() {
+        if (conversion == null) {
+            conversion = new ArrayList<>();
+        }
+        return this.conversion;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String value) {
+        this.id = value;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Videos.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/Videos.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Videos", propOrder = { "video" })
+public class Videos {
+
+    protected List<Child> video;
+
+    public List<Child> getVideo() {
+        if (video == null) {
+            video = new ArrayList<>();
+        }
+        return this.video;
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/package-info.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/api/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://subsonic.org/restapi", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+package com.tesshu.jpsonic.util.connector.api;

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/deserializer/MediaTypeDeserializer.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/deserializer/MediaTypeDeserializer.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.deserializer;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.tesshu.jpsonic.util.connector.api.MediaType;
+
+public class MediaTypeDeserializer extends JsonDeserializer<Object> {
+
+    @Override
+    public MediaType deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        return MediaType.fromValue(parser.getText());
+    }
+}

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/deserializer/ResponseStatusDeserializer.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/util/connector/deserializer/ResponseStatusDeserializer.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2024 tesshucom
+ */
+
+package com.tesshu.jpsonic.util.connector.deserializer;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.tesshu.jpsonic.util.connector.api.ResponseStatus;
+
+public class ResponseStatusDeserializer extends JsonDeserializer<Object> {
+    @Override
+    public ResponseStatus deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        return ResponseStatus.fromValue(parser.getText());
+    }
+
+}


### PR DESCRIPTION
## Overview

In v114.1, after registering an ID3 star, running a full scan (with IgnoreTimestamp enabled) will delete the star. This commit will improve this.

## Goal

The star is deleted because all Id3 data records are deleted during a full scan and then re-registered. (The star is an external reference to the Id3 data record, so it is cascade deleted.) This commit will turn this into a differential update. You can also see this in the detailed scan log. Unlike previous versions, it will be counted as an Update instead of a New one.

![image](https://github.com/user-attachments/assets/28f3d446-ef5c-4bf7-94a9-9fbb40a824fb)

## Non-Goal

Id3 Artist has a similar issue, but this version does not fix it. This will definitely be fixed in later versions.

## Details

Although categorically this is treated as a bug fix, it is a planned feature regression. 

Airsonic had previously reported issues with "duplicate entries" in data. Subsonic doesn't do any serious data cleansing to begin with, and Airsonic's implementation suffers from that as well. Subsonic and Airsonic do not have the ability to self-clean when ghost data occurs. Therefore, a temporary fix was made to Jpsonic so that when IgnoreTimestamp is enabled, all ID3 Artist and Album fields are deleted and then inserted. The downside of this approach is that if you run a full scan with IgnoreTimestamp, the Star with Id3 in the external reference will be removed. 

From a user perspective, the removal of stars with Full-scan is a terrible feature and frankly seems like a bug. That's true, but data duplication is a much bigger nightmare. The data duplication could develop into a very obscure and unknown problem, and it is difficult to predict the extent of the impact.


 - As you know, Subsonic has two Star systems: FileStructure and Id3. There are fewer Subsonic apps actively adopting Id3 Star than there are apps adopting FileStructure Star. Of course, this is a matter of degree.
 - If Id3 Star experiences some temporary functionality restrictions, it doesn't mean that all users will be affected.
 - Data CRUD bugs as Duplicates affect all users.
 - Data CRUD bugs affects all features. Developing new features is completely pointless as long as this bug exists. You will only be bothered by unknown bugs more often.

In other words, the purpose behind the temporary feature degradation was to recover from more serious data corruption. While this poison was being put into place, the registration and updating of Jpsonic data was improved to prevent unintended data duplication. This commit reverts Star's persistence to its expected use, preventing it from being removed by a full scan.

## Additional Note

This commit will update the Mediafile version and Index version and will force a full scan on the next scan. There are no changes to the database schema, but the contents of the Genre data have been partially revised due to the fix in #2662.



