### PR TITLE
Fix bug in UPnP Recent Album that returned results exceeding the server limit

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/RandomSongProc.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/RandomSongProc.java
@@ -20,14 +20,11 @@
 package com.tesshu.jpsonic.service.upnp.processor;
 
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 
 import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.service.MediaFileService;
 import com.tesshu.jpsonic.service.SearchService;
 import com.tesshu.jpsonic.service.SettingsService;
-import org.jupnp.support.model.BrowseResult;
-import org.jupnp.support.model.DIDLContent;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -48,13 +45,6 @@ public class RandomSongProc extends MediaFileByFolderProc implements CountLimitP
     @Override
     public ProcId getProcId() {
         return ProcId.RANDOM_SONG;
-    }
-
-    @Override
-    public BrowseResult browseRoot(String filter, long offset, long count) throws ExecutionException {
-        DIDLContent content = new DIDLContent();
-        getDirectChildren(offset, count).forEach(song -> addDirectChild(content, song));
-        return createBrowseResult(content, (int) content.getCount(), getDirectChildrenCount());
     }
 
     @Override

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumId3Proc.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumId3Proc.java
@@ -19,14 +19,12 @@
 
 package com.tesshu.jpsonic.service.upnp.processor;
 
+import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 
 import com.tesshu.jpsonic.dao.AlbumDao;
 import com.tesshu.jpsonic.domain.Album;
 import com.tesshu.jpsonic.service.MediaFileService;
-import org.jupnp.support.model.BrowseResult;
-import org.jupnp.support.model.DIDLContent;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -50,18 +48,14 @@ public class RecentAlbumId3Proc extends AlbumId3Proc implements CountLimitProc {
     }
 
     @Override
-    public BrowseResult browseRoot(String filter, long firstResult, long maxResults) throws ExecutionException {
-        DIDLContent parent = new DIDLContent();
+    public List<Album> getDirectChildren(long firstResult, long maxResults) {
         int offset = (int) firstResult;
         int directChildrenCount = getDirectChildrenCount();
         int count = toCount(firstResult, maxResults, directChildrenCount);
-        getDirectChildren(offset, count).forEach(a -> addDirectChild(parent, a));
-        return createBrowseResult(parent, (int) parent.getCount(), directChildrenCount);
-    }
-
-    @Override
-    public List<Album> getDirectChildren(long offset, long max) {
-        return albumDao.getNewestAlbums((int) offset, (int) max, util.getGuestFolders());
+        if (count == 0) {
+            return Collections.emptyList();
+        }
+        return albumDao.getNewestAlbums(offset, count, util.getGuestFolders());
     }
 
     @Override

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumProc.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumProc.java
@@ -19,13 +19,11 @@
 
 package com.tesshu.jpsonic.service.upnp.processor;
 
+import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 
 import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.service.MediaFileService;
-import org.jupnp.support.model.BrowseResult;
-import org.jupnp.support.model.DIDLContent;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -48,17 +46,14 @@ public class RecentAlbumProc extends MediaFileByFolderProc implements CountLimit
     }
 
     @Override
-    public BrowseResult browseRoot(String filter, long firstResult, long maxResults) throws ExecutionException {
-        DIDLContent parent = new DIDLContent();
+    public List<MediaFile> getDirectChildren(long firstResult, long maxResults) {
         int offset = (int) firstResult;
-        int count = toCount(firstResult, maxResults, RECENT_COUNT);
-        getDirectChildren(offset, count).forEach(a -> addDirectChild(parent, a));
-        return createBrowseResult(parent, (int) parent.getCount(), getDirectChildrenCount());
-    }
-
-    @Override
-    public List<MediaFile> getDirectChildren(long count, long offset) {
-        return mediaFileService.getNewestAlbums((int) count, (int) offset, util.getGuestFolders());
+        int max = getDirectChildrenCount();
+        int count = toCount(firstResult, maxResults, max);
+        if (count == 0) {
+            return Collections.emptyList();
+        }
+        return mediaFileService.getNewestAlbums(offset, count, util.getGuestFolders());
     }
 
     @Override

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MediaFileDaoTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/MediaFileDaoTest.java
@@ -43,6 +43,7 @@ import com.tesshu.jpsonic.dao.base.TemplateWrapper;
 import com.tesshu.jpsonic.dao.dialect.DialectMediaFileDao;
 import com.tesshu.jpsonic.domain.ArtistSortCandidate;
 import com.tesshu.jpsonic.domain.ArtistSortCandidate.TargetField;
+import com.tesshu.jpsonic.domain.MediaFile;
 import com.tesshu.jpsonic.domain.MediaFile.MediaType;
 import com.tesshu.jpsonic.domain.MusicFolder;
 import com.tesshu.jpsonic.domain.RandomSearchCriteria;
@@ -786,6 +787,39 @@ class MediaFileDaoTest {
                 default -> throw new IllegalArgumentException("Unexpected value: " + index.index());
                 }
             });
+        }
+
+        /**
+         * SQL: Boundary value testing for count. NewestAlbums is the only place within Apps where count can be 0
+         * (UPnP's View-Paging). Please note that in the current Dao implementation, a count of 0 is treated as having
+         * no condition.
+         */
+        @Test
+        void testGetNewestAlbums() {
+
+            // There are 4 test data albums in total.
+            List<MediaFile> albums = mediaFileDao.getNewestAlbums(0, Integer.MAX_VALUE, getMusicFolders());
+            assertEquals(4, albums.size());
+
+            albums = mediaFileDao.getNewestAlbums(0, 1, getMusicFolders());
+            assertEquals(1, albums.size());
+
+            albums = mediaFileDao.getNewestAlbums(0, 2, getMusicFolders());
+            assertEquals(2, albums.size());
+
+            albums = mediaFileDao.getNewestAlbums(0, 3, getMusicFolders());
+            assertEquals(3, albums.size());
+
+            albums = mediaFileDao.getNewestAlbums(0, 4, getMusicFolders());
+            assertEquals(4, albums.size());
+
+            // Up until this point, everything has gone as expected...
+            albums = mediaFileDao.getNewestAlbums(0, 5, getMusicFolders());
+            assertEquals(4, albums.size());
+
+            // Please note that even if we specify 0, it will not return 0.
+            albums = mediaFileDao.getNewestAlbums(0, 0, getMusicFolders());
+            assertEquals(4, albums.size());
         }
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumId3ProcTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/upnp/processor/RecentAlbumId3ProcTest.java
@@ -26,6 +26,8 @@ import static com.tesshu.jpsonic.util.PlayerUtils.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -45,6 +47,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.jupnp.support.model.BrowseResult;
+import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @SuppressWarnings("PMD.TooManyStaticImports")
@@ -75,16 +78,29 @@ class RecentAlbumId3ProcTest {
             when(albumDao.getNewestAlbums(anyInt(), anyInt(), anyList())).thenReturn(List.of(new Album()));
             when(albumDao.getAlbumCount(anyList())).thenReturn(99);
             BrowseResult result = proc.browseRoot(null, 0, 0);
+            assertEquals(0, result.getCountLong());
+            assertEquals(50, result.getTotalMatches().getValue()); // RECENT_COUNT
+            verify(albumDao, never()).getNewestAlbums(anyInt(), anyInt(), anyList());
+            verify(albumDao, times(2)).getAlbumCount(anyList());
+
+            clearInvocations(albumDao);
+            result = proc.browseRoot(null, 0, 1);
             assertEquals(1, result.getCountLong());
             assertEquals(50, result.getTotalMatches().getValue()); // RECENT_COUNT
             verify(albumDao, times(1)).getNewestAlbums(anyInt(), anyInt(), anyList());
-            verify(albumDao, times(1)).getAlbumCount(anyList());
+            verify(albumDao, times(2)).getAlbumCount(anyList());
         }
 
         @Test
         void testGetDirectChildren() {
+            when(albumDao.getAlbumCount(ArgumentMatchers.<MusicFolder> anyList())).thenReturn(50);
+
             assertEquals(0, proc.getDirectChildren(0, 0).size());
-            verify(albumDao, times(1)).getNewestAlbums(anyInt(), anyInt(), anyList());
+            verify(albumDao, never()).getNewestAlbums(anyInt(), anyInt(), ArgumentMatchers.<MusicFolder> anyList());
+
+            clearInvocations(albumDao);
+            assertEquals(0, proc.getDirectChildren(0, 1).size());
+            verify(albumDao, times(1)).getNewestAlbums(anyInt(), anyInt(), ArgumentMatchers.<MusicFolder> anyList());
         }
 
         @Test


### PR DESCRIPTION
## Problem description

When using certain UPnP Apps, the server-side limit of 50 Recent Albums may be exceeded and all Albums may be returned. 


### Steps to reproduce

This is a rare case. The conditions are a bit special. During UPnP paging communication, it is limited to Client Apps that specify an offset that exceeds `the total matches` value of the server result that has been obtained in advance. Currently only Media Monkey 5 has been confirmed.

## Additional notes

This case was anticipated (including the possibility of a bug in the client implementation). A process that uses both paging and count limits implements an interface called CountLimitProc. In subclasses that inherit this interface, the count value is corrected, even when a request outside the range is received. For example, if an offset of 50 or more is specified for a search function with a 50 result limit, the count will be corrected to 0.

What was not anticipated was the subsequent processing. There is a problem with the SQL search for count 0. In the current Dao implementation, if count 0 is specified, it is treated as '**no condition**'. As a result, the value to be changed is not 0 but all items after offset. (This commit adds boundary tests.) I think normally it's 0 🙃  I hadn't test that case 🙃

I think there are lots of ways to avoid this. For example, specifying restrictions in a SpringJdbc query object. (Maybe that implementation is what it's there for, but I've never used it and don't want to.)

## Fixes

The easiest way to solve it. If the server receives more requests than the limit, it will not search and will return an empty result set. This is because the cases where the problem occurs are rare and the implementations where it can occur are easily identifiable. (CountLimitProc subclasses only)