### PR TITLE
Update Libs

### DIFF
--- a/airsonic-taglibs/pom.xml
+++ b/airsonic-taglibs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.8</version>
+    <version>114.1.9</version>
   </parent>
   <artifactId>airsonic-taglibs</artifactId>
   <name>Airsonic Tag Libs</name>

--- a/airsonic-taglibs/pom.xml
+++ b/airsonic-taglibs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.7</version>
+    <version>114.1.8</version>
   </parent>
   <artifactId>airsonic-taglibs</artifactId>
   <name>Airsonic Tag Libs</name>

--- a/airsonic-taglibs/pom.xml
+++ b/airsonic-taglibs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.10</version>
+    <version>114.1.11</version>
   </parent>
   <artifactId>airsonic-taglibs</artifactId>
   <name>Airsonic Tag Libs</name>

--- a/airsonic-taglibs/pom.xml
+++ b/airsonic-taglibs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.6</version>
+    <version>114.1.7</version>
   </parent>
   <artifactId>airsonic-taglibs</artifactId>
   <name>Airsonic Tag Libs</name>

--- a/airsonic-taglibs/pom.xml
+++ b/airsonic-taglibs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.9</version>
+    <version>114.1.10</version>
   </parent>
   <artifactId>airsonic-taglibs</artifactId>
   <name>Airsonic Tag Libs</name>

--- a/install/docker/alpine/pom.xml
+++ b/install/docker/alpine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.8</version>
+        <version>114.1.9</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/alpine/pom.xml
+++ b/install/docker/alpine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.7</version>
+        <version>114.1.8</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/alpine/pom.xml
+++ b/install/docker/alpine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.9</version>
+        <version>114.1.10</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/alpine/pom.xml
+++ b/install/docker/alpine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.10</version>
+        <version>114.1.11</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/alpine/pom.xml
+++ b/install/docker/alpine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.6</version>
+        <version>114.1.7</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/jammy/pom.xml
+++ b/install/docker/jammy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.8</version>
+        <version>114.1.9</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/jammy/pom.xml
+++ b/install/docker/jammy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.7</version>
+        <version>114.1.8</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/jammy/pom.xml
+++ b/install/docker/jammy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.9</version>
+        <version>114.1.10</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/jammy/pom.xml
+++ b/install/docker/jammy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.10</version>
+        <version>114.1.11</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/jammy/pom.xml
+++ b/install/docker/jammy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.6</version>
+        <version>114.1.7</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/noble/pom.xml
+++ b/install/docker/noble/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.0</version>
+        <version>114.1.9</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/noble/pom.xml
+++ b/install/docker/noble/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.9</version>
+        <version>114.1.10</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/noble/pom.xml
+++ b/install/docker/noble/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.10</version>
+        <version>114.1.11</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/ubi9/pom.xml
+++ b/install/docker/ubi9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.8</version>
+        <version>114.1.9</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/ubi9/pom.xml
+++ b/install/docker/ubi9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.7</version>
+        <version>114.1.8</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/ubi9/pom.xml
+++ b/install/docker/ubi9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.9</version>
+        <version>114.1.10</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/ubi9/pom.xml
+++ b/install/docker/ubi9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.10</version>
+        <version>114.1.11</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/ubi9/pom.xml
+++ b/install/docker/ubi9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.1.6</version>
+        <version>114.1.7</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/jpsonic-concurent17/pom.xml
+++ b/jpsonic-concurent17/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.10</version>
+    <version>114.1.11</version>
   </parent>
   <artifactId>jpsonic-concurent17</artifactId>
   <name>Concurent Config for Java17</name>

--- a/jpsonic-concurent17/pom.xml
+++ b/jpsonic-concurent17/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.9</version>
+    <version>114.1.10</version>
   </parent>
   <artifactId>jpsonic-concurent17</artifactId>
   <name>Concurent Config for Java17</name>

--- a/jpsonic-concurent17/pom.xml
+++ b/jpsonic-concurent17/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.6</version>
+    <version>114.1.7</version>
   </parent>
   <artifactId>jpsonic-concurent17</artifactId>
   <name>Concurent Config for Java17</name>

--- a/jpsonic-concurent17/pom.xml
+++ b/jpsonic-concurent17/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.7</version>
+    <version>114.1.8</version>
   </parent>
   <artifactId>jpsonic-concurent17</artifactId>
   <name>Concurent Config for Java17</name>

--- a/jpsonic-concurent17/pom.xml
+++ b/jpsonic-concurent17/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.8</version>
+    <version>114.1.9</version>
   </parent>
   <artifactId>jpsonic-concurent17</artifactId>
   <name>Concurent Config for Java17</name>

--- a/jpsonic-concurent21/pom.xml
+++ b/jpsonic-concurent21/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.8</version>
+    <version>114.1.9</version>
   </parent>
   <artifactId>jpsonic-concurent21</artifactId>
   <name>Concurent Config for Java21</name>

--- a/jpsonic-concurent21/pom.xml
+++ b/jpsonic-concurent21/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.10</version>
+    <version>114.1.11</version>
   </parent>
   <artifactId>jpsonic-concurent21</artifactId>
   <name>Concurent Config for Java21</name>

--- a/jpsonic-concurent21/pom.xml
+++ b/jpsonic-concurent21/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.9</version>
+    <version>114.1.10</version>
   </parent>
   <artifactId>jpsonic-concurent21</artifactId>
   <name>Concurent Config for Java21</name>

--- a/jpsonic-concurent21/pom.xml
+++ b/jpsonic-concurent21/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.6</version>
+    <version>114.1.7</version>
   </parent>
   <artifactId>jpsonic-concurent21</artifactId>
   <name>Concurent Config for Java21</name>

--- a/jpsonic-concurent21/pom.xml
+++ b/jpsonic-concurent21/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.7</version>
+    <version>114.1.8</version>
   </parent>
   <artifactId>jpsonic-concurent21</artifactId>
   <name>Concurent Config for Java21</name>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.7</version>
+    <version>114.1.8</version>
   </parent>
   <artifactId>jpsonic-main</artifactId>
   <packaging>war</packaging>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.8</version>
+    <version>114.1.9</version>
   </parent>
   <artifactId>jpsonic-main</artifactId>
   <packaging>war</packaging>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.6</version>
+    <version>114.1.7</version>
   </parent>
   <artifactId>jpsonic-main</artifactId>
   <packaging>war</packaging>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.9</version>
+    <version>114.1.10</version>
   </parent>
   <artifactId>jpsonic-main</artifactId>
   <packaging>war</packaging>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.10</version>
+    <version>114.1.11</version>
   </parent>
   <artifactId>jpsonic-main</artifactId>
   <packaging>war</packaging>

--- a/jpsonic-upnp-template/pom.xml
+++ b/jpsonic-upnp-template/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.9</version>
+    <version>114.1.10</version>
   </parent>
   <artifactId>jpsonic-upnp-template</artifactId>
   <name>Upnp Template</name>

--- a/jpsonic-upnp-template/pom.xml
+++ b/jpsonic-upnp-template/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.6</version>
+    <version>114.1.7</version>
   </parent>
   <artifactId>jpsonic-upnp-template</artifactId>
   <name>Upnp Template</name>

--- a/jpsonic-upnp-template/pom.xml
+++ b/jpsonic-upnp-template/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.7</version>
+    <version>114.1.8</version>
   </parent>
   <artifactId>jpsonic-upnp-template</artifactId>
   <name>Upnp Template</name>

--- a/jpsonic-upnp-template/pom.xml
+++ b/jpsonic-upnp-template/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.8</version>
+    <version>114.1.9</version>
   </parent>
   <artifactId>jpsonic-upnp-template</artifactId>
   <name>Upnp Template</name>

--- a/jpsonic-upnp-template/pom.xml
+++ b/jpsonic-upnp-template/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.10</version>
+    <version>114.1.11</version>
   </parent>
   <artifactId>jpsonic-upnp-template</artifactId>
   <name>Upnp Template</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tesshu.jpsonic.player</groupId>
   <artifactId>jpsonic</artifactId>
-  <version>114.1.10</version>
+  <version>114.1.11</version>
   <packaging>pom</packaging>
   <name>Jpsonic</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tesshu.jpsonic.player</groupId>
   <artifactId>jpsonic</artifactId>
-  <version>114.1.7</version>
+  <version>114.1.8</version>
   <packaging>pom</packaging>
   <name>Jpsonic</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tesshu.jpsonic.player</groupId>
   <artifactId>jpsonic</artifactId>
-  <version>114.1.6</version>
+  <version>114.1.7</version>
   <packaging>pom</packaging>
   <name>Jpsonic</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tesshu.jpsonic.player</groupId>
   <artifactId>jpsonic</artifactId>
-  <version>114.1.9</version>
+  <version>114.1.10</version>
   <packaging>pom</packaging>
   <name>Jpsonic</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tesshu.jpsonic.player</groupId>
   <artifactId>jpsonic</artifactId>
-  <version>114.1.8</version>
+  <version>114.1.9</version>
   <packaging>pom</packaging>
   <name>Jpsonic</name>
 

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.7</version>
+    <version>114.1.8</version>
   </parent>
   <artifactId>subsonic-rest-api</artifactId>
   <name>Subsonic REST API</name>

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.10</version>
+    <version>114.1.11</version>
   </parent>
   <artifactId>subsonic-rest-api</artifactId>
   <name>Subsonic REST API</name>

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.6</version>
+    <version>114.1.7</version>
   </parent>
   <artifactId>subsonic-rest-api</artifactId>
   <name>Subsonic REST API</name>

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.8</version>
+    <version>114.1.9</version>
   </parent>
   <artifactId>subsonic-rest-api</artifactId>
   <name>Subsonic REST API</name>

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.1.9</version>
+    <version>114.1.10</version>
   </parent>
   <artifactId>subsonic-rest-api</artifactId>
   <name>Subsonic REST API</name>


### PR DESCRIPTION
Regular updates of libs and Docker images. Jpsonic itself does not include security fixes. The following CVE warnings are preventing development and will be suppressed or updated:

 - CVE-2024-42469, CVE-2024-42470, CVE-2024-42468 -> [Suppressed.](https://github.com/tesshucom/jpsonic/commit/429804c265f3d37b1978d788d2f09ee5a0df242e)
   - Jupnp is also published on Openhub. This is a false positive for the tool used to release Jupnp to Openhub. Of course, It is not used by Jpsonic. 

## Vulnerabilities

`latest` or `latest-ubi9` are recommended. Alpine and Red Hat have almost always been fine.
