### PR TITLE
Fix bug that caused UPnP transcoding settings to be reset

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DLNASettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DLNASettingsController.java
@@ -125,7 +125,7 @@ public class DLNASettingsController {
         command.setAllowedMusicFolderIds(musicFolderService.getMusicFoldersForUser(guestUser.getUsername()).stream()
                 .mapToInt(MusicFolder::getId).toArray());
         command.setAllTranscodings(transcodingService.getAllTranscodings());
-        Player guestPlayer = playerService.getGuestPlayer(null);
+        Player guestPlayer = playerService.getUPnPPlayer();
         command.setActiveTranscodingIds(transcodingService.getTranscodingsForPlayer(guestPlayer).stream()
                 .mapToInt(Transcoding::getId).toArray());
         command.setTranscodingSupported(transcodingService.isTranscodingSupported(null));
@@ -218,7 +218,7 @@ public class DLNASettingsController {
         UserSettings userSettings = securityService.getUserSettings(guestUser.getUsername());
         userSettings.setTranscodeScheme(command.getTranscodeScheme());
         userSettings.setChanged(now());
-        Player guestPlayer = playerService.getGuestPlayer(null);
+        Player guestPlayer = playerService.getUPnPPlayer();
         transcodingService.setTranscodingsForPlayer(guestPlayer, command.getActiveTranscodingIds());
         if (command.getActiveTranscodingIds().length == 0) {
             guestPlayer.setTranscodeScheme(TranscodeScheme.OFF);

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PlayerService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PlayerService.java
@@ -69,7 +69,7 @@ public class PlayerService implements ReadWriteLockSupport {
 
     private static final String COOKIE_NAME = "player";
     private static final String ATTRIBUTE_SESSION_KEY = "player";
-    private static final String GUEST_PLAYER_TYPE = "UPnP Processor";
+    private static final String UPNP_PLAYER_ID = "Jpsonic UPnP Player";
     private static final int COOKIE_EXPIRY = 360 * 24 * 3600; // About One year
 
     private final PlayerDao playerDao;
@@ -486,10 +486,27 @@ public class PlayerService implements ReadWriteLockSupport {
             player.setIpAddress(request.getRemoteAddr());
         }
         player.setUsername(user.getUsername());
-        player.setType(GUEST_PLAYER_TYPE);
         player.setLastSeen(now());
         createPlayer(player, false);
+        return player;
+    }
 
+    public Player getUPnPPlayer() {
+        User user = securityService.getGuestUser();
+        Player player = getPlayersForUserAndClientId(user.getUsername(), UPNP_PLAYER_ID).stream().findFirst()
+                .orElseGet(() -> {
+                    Player p = new Player();
+                    p.setUsername(User.USERNAME_GUEST);
+                    p.setClientId(UPNP_PLAYER_ID);
+                    p.setLastSeen(now());
+                    createPlayer(p, false);
+                    return p;
+                });
+        Instant now = now();
+        if (player.getLastSeen().plus(1, ChronoUnit.DAYS).isBefore(now)) {
+            player.setLastSeen(now);
+            updatePlayer(player);
+        }
         return player;
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PlayerService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/PlayerService.java
@@ -93,6 +93,10 @@ public class PlayerService implements ReadWriteLockSupport {
         writeLock(playerLock);
         try {
             playerDao.deleteOldPlayers(60);
+            Player upnpPlayer = getUPnPPlayer();
+            User guestUser = securityService.getGuestUser();
+            getPlayersForUserAndClientId(guestUser.getUsername(), null).stream()
+                    .filter(p -> p.getId().equals(upnpPlayer.getId())).forEach(p -> playerDao.deletePlayer(p.getId()));
         } finally {
             writeUnlock(playerLock);
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/SecurityService.java
@@ -260,7 +260,7 @@ public class SecurityService implements UserDetailsService {
         // Create guest user if necessary.
         User user = getUserByName(User.USERNAME_GUEST);
         if (user == null) {
-            user = new User(User.USERNAME_GUEST, RandomStringUtils.randomAlphanumeric(30), null);
+            user = new User(User.USERNAME_GUEST, RandomStringUtils.secure().nextAlphanumeric(30), null);
             user.setStreamRole(true);
             createUser(user);
         }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/UpnpDIDLFactory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/UpnpDIDLFactory.java
@@ -114,7 +114,7 @@ public class UpnpDIDLFactory implements CoverArtPresentation {
     String createURIStringWithToken(UriComponentsBuilder builder, MediaFile song) {
         String token = addJWTToken(builder).toUriString();
         if (settingsService.isUriWithFileExtensions() && !StringUtils.isEmpty(song.getFormat())) {
-            Player player = playerService.getGuestPlayer(null);
+            Player player = playerService.getUPnPPlayer();
             String fmt = transcodingService.getSuffix(player, song, null);
             token = token.concat(".").concat(fmt);
         }
@@ -373,7 +373,7 @@ public class UpnpDIDLFactory implements CoverArtPresentation {
     }
 
     Res toRes(MediaFile file) {
-        Player player = playerService.getGuestPlayer(null);
+        Player player = playerService.getUPnPPlayer();
         MimeType mimeType = getMimeType(file, player);
         Res res = new Res(mimeType, null, createStreamURI(file, player));
         res.setDuration(formatDuration(file.getDurationSeconds()));

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/status.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/status.jsp
@@ -10,7 +10,7 @@
 <body class="mainframe status">
 
 <c:import url="helpHeader.jsp">
-	<c:param name="cat" value="status"/>
+    <c:param name="cat" value="status"/>
     <c:param name="isAdmin" value="${model.admin}"/>
 </c:import>
 
@@ -88,7 +88,12 @@
                         <dl>
                             <dt><fmt:message key="status.user" /></dt><dd>${user}</dd>
                             <dt><fmt:message key="status.type" /></dt><dd>${transferType}</dd>
-                            <dt><fmt:message key="status.player" /></dt><dd title="${status.player} ... ${type}">${status.player}<br>${type}</dd>
+                            <dt>
+                                <fmt:message key="status.player" /></dt><dd title="${status.player} ... ${type}">${status.player}
+                                <c:if test="${user ne 'guest'}">
+                                    <br>${type}
+                                </c:if>
+                            </dd>
                             <dt><fmt:message key="status.current" /></dt><dd title="${current}">${current}</dd>
                             <dt><fmt:message key="status.transmitted" /></dt><dd>${status.bytes}</dd>
                         </dl>

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/ServiceMockUtils.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/ServiceMockUtils.java
@@ -84,6 +84,11 @@ public final class ServiceMockUtils {
             player.setId(99);
             player.setUsername(User.USERNAME_GUEST);
             Mockito.when(playerService.getGuestPlayer(Mockito.nullable(HttpServletRequest.class))).thenReturn(player);
+            Player upnpPlayer = new Player();
+            upnpPlayer.setId(999);
+            upnpPlayer.setUsername(User.USERNAME_GUEST);
+            upnpPlayer.setClientId("Jpsonic UPnP Player");
+            Mockito.when(playerService.getUPnPPlayer()).thenReturn(upnpPlayer);
             mock = playerService;
         } else if (SettingsService.class == classToMock) {
             SettingsService settingsService = Mockito.mock(SettingsService.class);


### PR DESCRIPTION
## Problem description

When you set up UPnP transcoding on a web page, it will work as expected for a while, but after a while the transcoding will stop working. If you check the transcoding settings on the web page again, the settings will be initialized.

### Steps to reproduce

In the UPnP settings page, assign some transcoding and Bitrate.

![image](https://github.com/user-attachments/assets/477363c0-88e4-47aa-aef7-914b52f680b1)

After that, communication is performed via UPnP. A bug is causing the transcoding settings to be reset when a player reference occurs within the server. This depends on UPnP Apps, but for example, when you browse an album and start playing it, transcoding may appear to be working, but when you browse another album and start playing it, transcoding will be disabled. 

## System information

UPnP only. Does not affect Subsonic Apps or Web Player.

## Additional notes

This is due to a bug in the Player assignment implementation on the Jpsonic side. 

 - The UPnP implementations of Subsonic and Airsonic will automatically create a Player for each communicating Client App (or requests). You can reference this on your server's configuration page to assign your own transcoding settings. At first glance it looks like a flexible structure, but as a specification it's no good. Some UPnP apps may work with this, but there are also devices that refer to the UPnP message format rather than the binary header when determining the transcoder to use during playback. In the latter case, playback may fail.
   - For this reason, Jpsonic has been redesigned so that the transcoding settings configured on the web page match the file format property in the UPnP message and the format of the binary data sent.
 - Although the basic design policy has been changed in Jpsonic, the player creation logic still repurposed the logic assumed for the conventional external player, and was insufficient to handle unified format specifications. This pull request will improve that.

There are some related changes involved.

 - Previously used internally (incorrect) UPnP Player records will be automatically clean up on startup. If you use transcoding with UPnP Player, please try allocating again.
 - The network usage page will be modified to not show the agent for UPnP client apps. Originally, Subsonic's communication history was designed to be summarized on a per-player basis.　(Only one UPnP communication status will be displayed)
   - This could be changed, but it doesn't seem worth the effort... It is possible to summarize communication history by source IP and Agent, but that's all. There are many cases where providing such information would not make sense (e.g. in a WAN with dynamically assigned IPs). It would be sad if the only thing we could get in exchange for complex implementation and lots of unnecessary records was a less useful history.
