### PR TITLE
Change for faster startup with CDS

### DIFF
--- a/install/docker/alpine/Dockerfile
+++ b/install/docker/alpine/Dockerfile
@@ -58,6 +58,11 @@ HEALTHCHECK --interval=30s --timeout=2s CMD export HEALTHCHECK_QUERY=$(echo loca
 
 COPY entry-point.sh /usr/local/bin/entry-point.sh
 RUN chmod +x /usr/local/bin/entry-point.sh
+
 COPY target/dependency/jpsonic.war jpsonic.war
+RUN unzip -q jpsonic.war \
+    && rm jpsonic.war \
+    && mkdir -p /opt/jpsonic \
+    && java -Dspring.context.exit=onRefresh -XX:ArchiveClassesAtExit=/opt/jpsonic/jpsonic.jsa org.springframework.boot.loader.launch.WarLauncher
 
 ENTRYPOINT ["tini", "-e", "143", "--", "entry-point.sh"]

--- a/install/docker/alpine/entry-point.sh
+++ b/install/docker/alpine/entry-point.sh
@@ -60,8 +60,9 @@ if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
      -Dlogging.level.com.tesshu.jpsonic="$LOG_LEVEL" \
      -Djava.awt.headless=true \
      -Duser.timezone="$TIME_ZONE" \
+     -XX:SharedArchiveFile=/opt/jpsonic/jpsonic.jsa \
      "${java_opts_array[@]}" \
-     -jar jpsonic.war "$@"
+     org.springframework.boot.loader.launch.WarLauncher "$@"
 fi
 
 exec "$@"

--- a/install/docker/jammy/Dockerfile
+++ b/install/docker/jammy/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     software-properties-common \
     gosu \
     tini \
+    unzip \
     fonts-noto-cjk \
     ffmpeg \
     && apt-get clean \
@@ -59,6 +60,11 @@ HEALTHCHECK --interval=30s --timeout=2s CMD export HEALTHCHECK_QUERY=$(echo loca
 
 COPY entry-point.sh /usr/local/bin/entry-point.sh
 RUN chmod +x /usr/local/bin/entry-point.sh
+
 COPY target/dependency/jpsonic.war jpsonic.war
+RUN unzip -q jpsonic.war \
+    && rm jpsonic.war \
+    && mkdir -p /opt/jpsonic \
+    && java -Dspring.context.exit=onRefresh -XX:ArchiveClassesAtExit=/opt/jpsonic/jpsonic.jsa org.springframework.boot.loader.launch.WarLauncher
 
 ENTRYPOINT ["tini", "-e", "143", "--", "entry-point.sh"]

--- a/install/docker/jammy/entry-point.sh
+++ b/install/docker/jammy/entry-point.sh
@@ -60,8 +60,9 @@ if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
      -Dlogging.level.com.tesshu.jpsonic="$LOG_LEVEL" \
      -Djava.awt.headless=true \
      -Duser.timezone="$TIME_ZONE" \
+     -XX:SharedArchiveFile=/opt/jpsonic/jpsonic.jsa \
      "${java_opts_array[@]}" \
-     -jar jpsonic.war "$@"
+     org.springframework.boot.loader.launch.WarLauncher "$@"
 fi
 
 exec "$@"

--- a/install/docker/noble/Dockerfile
+++ b/install/docker/noble/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update && apt-get -q install -y --no-install-recommends \
     software-properties-common \
     gosu \
     tini \
+    unzip \
     fonts-noto-cjk \
     ffmpeg \
     && apt-get clean \
@@ -59,6 +60,11 @@ HEALTHCHECK --interval=30s --timeout=2s CMD export HEALTHCHECK_QUERY=$(echo loca
 
 COPY entry-point.sh /usr/local/bin/entry-point.sh
 RUN chmod +x /usr/local/bin/entry-point.sh
+
 COPY target/dependency/jpsonic.war jpsonic.war
+RUN unzip -q jpsonic.war \
+    && rm jpsonic.war \
+    && mkdir -p /opt/jpsonic \
+    && java -Dspring.context.exit=onRefresh -XX:ArchiveClassesAtExit=/opt/jpsonic/jpsonic.jsa org.springframework.boot.loader.launch.WarLauncher
 
 ENTRYPOINT ["tini", "-e", "143", "--", "entry-point.sh"]

--- a/install/docker/noble/entry-point.sh
+++ b/install/docker/noble/entry-point.sh
@@ -60,8 +60,9 @@ if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
      -Dlogging.level.com.tesshu.jpsonic="$LOG_LEVEL" \
      -Djava.awt.headless=true \
      -Duser.timezone="$TIME_ZONE" \
+     -XX:SharedArchiveFile=/opt/jpsonic/jpsonic.jsa \
      "${java_opts_array[@]}" \
-     -jar jpsonic.war "$@"
+     org.springframework.boot.loader.launch.WarLauncher "$@"
 fi
 
 exec "$@"

--- a/install/docker/ubi9/Dockerfile
+++ b/install/docker/ubi9/Dockerfile
@@ -58,6 +58,11 @@ HEALTHCHECK --interval=30s --timeout=2s CMD export HEALTHCHECK_QUERY=$(echo loca
 
 COPY entry-point.sh /usr/local/bin/entry-point.sh
 RUN chmod +x /usr/local/bin/entry-point.sh
+
 COPY target/dependency/jpsonic.war jpsonic.war
+RUN unzip -q jpsonic.war \
+    && rm jpsonic.war \
+    && mkdir -p /opt/jpsonic \
+    && java -Dspring.context.exit=onRefresh -XX:ArchiveClassesAtExit=/opt/jpsonic/jpsonic.jsa org.springframework.boot.loader.launch.WarLauncher
 
 ENTRYPOINT ["tini", "-e", "143", "--", "entry-point.sh"]

--- a/install/docker/ubi9/entry-point.sh
+++ b/install/docker/ubi9/entry-point.sh
@@ -60,9 +60,9 @@ if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
      -Dlogging.level.com.tesshu.jpsonic="$LOG_LEVEL" \
      -Djava.awt.headless=true \
      -Duser.timezone="$TIME_ZONE" \
+     -XX:SharedArchiveFile=/opt/jpsonic/jpsonic.jsa \
      "${java_opts_array[@]}" \
-     -jar jpsonic.war "$@"
+     org.springframework.boot.loader.launch.WarLauncher "$@"
 fi
 
 exec "$@"
-exit


### PR DESCRIPTION

## Overview 

CDS will be introduced to speed up the startup of Jpsonic on Docker Images. 

[CDS with Spring Framework 6.1](https://spring.io/blog/2023/12/04/cds-with-spring-framework-6-1)

In a DS220+ environment, this will reduce the time by about 10 seconds. In some cases, Docker can be faster than starting just the war file.

## Details

Jpsonic's Docker Layer processing will change as follows

 - Unpack and deploy the war
 - Create a Class Data Sharing archive file
 - The archive file is used at startup.

The actual time-saving benefits come from the unpacking portion (80%) and the CDS portion (20%).. Unpack itself is a trick that has been around for several decades, but since war files also have advantages such as easier signature management, they had not been actively adopted by Jpsonic. The trigger for this was the increase in startup times due to the recent increased functionality and robustness of various frameworks and application servers. (Of course, this should be welcomed. Even if there’s a slight delay in startup, there are often more important factors for a server that's always running.) Nonetheless, a gradually slowing trend was observed.

If we're just comparing startup times, it's of course about 10 seconds faster than the previous version. Note however that this does not mean that it is 10 seconds faster than the Jpsonic from a few years ago, the Airsonic or Subsonic. (Of course, the latest Jpsonic has the most robust product configuration.)


