### PR TITLE
Fix a bug causing the arm/v7 Docker build to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,22 +469,20 @@ jobs:
           echo "DOCKER_TAG=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
       - name: Copy artifact
         run: |
-          mkdir -p install/docker/noble/target/dependency
-          mv jpsonic.war install/docker/noble/target/dependency
+          mkdir -p install/docker/armv7/target/dependency
+          mv jpsonic.war install/docker/armv7/target/dependency
       - name: Release with Version Tag
         if: "(github.ref == 'refs/heads/master')"
         run: |
           if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            cd install/docker/noble
-            sed -i -e "s/21-jdk-noble/17-jre-noble/g" Dockerfile
-            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
-            mvn -DdockerTag=${{ env.DOCKER_TAG }}-noble package
+            cd install/docker/armv7
+            mvn -DdockerTag=${{ env.DOCKER_TAG }}-noble-v7 package
             docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
             docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-noble-v7 .
-            mvn -DdockerTag=${DOCKER_TAG%.*}-noble package
+            mvn -DdockerTag=${DOCKER_TAG%.*}-noble-v7 package
             docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
             docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${DOCKER_TAG%.*}-noble-v7 .
-            mvn -DdockerTag=${DOCKER_TAG%.*.*}-noble package
+            mvn -DdockerTag=${DOCKER_TAG%.*.*}-noble-v7 package
             docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
             docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${DOCKER_TAG%.*.*}-noble-v7 .
           fi
@@ -492,10 +490,8 @@ jobs:
         if: github.ref == 'refs/heads/master'
         run: |
           if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            cd install/docker/noble
-            sed -i -e "s/21-jdk-noble/17-jre-noble/g" Dockerfile
-            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
-            mvn -DdockerTag=latest-noble package
+            cd install/docker/armv7
+            mvn -DdockerTag=latest-noble-v7 package
             docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
             docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:latest-noble-v7 .
           fi
@@ -503,10 +499,8 @@ jobs:
         if: github.ref == 'refs/heads/master'
         run: |
           if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.(alpha|beta)\.[0-9]+\.[0-9]+$ ]]; then
-            cd install/docker/noble
-            sed -i -e "s/21-jdk-noble/17-jre-noble/g" Dockerfile
-            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
-            mvn -DdockerTag=latest-noble package
+            cd install/docker/armv7
+            mvn -DdockerTag=latest-noble-v7 package
             docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
             docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-noble-v7 .
           fi
@@ -616,22 +610,21 @@ jobs:
           echo "DOCKER_TAG=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
       - name: Copy artifact
         run: |
-          mkdir -p install/docker/jammy/target/dependency
-          mv jpsonic.war install/docker/jammy/target/dependency
+          mkdir -p install/docker/armv7/target/dependency
+          mv jpsonic.war install/docker/armv7/target/dependency
       - name: Release with Version Tag
         if: "(github.ref == 'refs/heads/master')"
         run: |
           if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            cd install/docker/jammy
-            sed -i -e "s/21-jdk-jammy/17-jre-jammy/g" Dockerfile
-            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
-            mvn -DdockerTag=${{ env.DOCKER_TAG }}-jammy package
+            cd install/docker/armv7
+            sed -i -e "s/17-jre-noble/17-jre-jammy/g" Dockerfile
+            mvn -DdockerTag=${{ env.DOCKER_TAG }}-jammy-v7 package
             docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
             docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-jammy-v7 .
-            mvn -DdockerTag=${DOCKER_TAG%.*}-jammy package
+            mvn -DdockerTag=${DOCKER_TAG%.*}-jammy-v7 package
             docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
             docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${DOCKER_TAG%.*}-jammy-v7 .
-            mvn -DdockerTag=${DOCKER_TAG%.*.*}-jammy package
+            mvn -DdockerTag=${DOCKER_TAG%.*.*}-jammy-v7 package
             docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
             docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${DOCKER_TAG%.*.*}-jammy-v7 .
           fi
@@ -639,10 +632,9 @@ jobs:
         if: github.ref == 'refs/heads/master'
         run: |
           if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            cd install/docker/jammy
-            sed -i -e "s/21-jdk-jammy/17-jre-jammy/g" Dockerfile
-            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
-            mvn -DdockerTag=latest-jammy package
+            cd install/docker/armv7
+            sed -i -e "s/17-jre-noble/17-jre-jammy/g" Dockerfile
+            mvn -DdockerTag=latest-jammy-v7 package
             docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
             docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:latest-jammy-v7 .
           fi
@@ -650,10 +642,9 @@ jobs:
         if: github.ref == 'refs/heads/master'
         run: |
           if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.(alpha|beta)\.[0-9]+\.[0-9]+$ ]]; then
-            cd install/docker/jammy
-            sed -i -e "s/21-jdk-jammy/17-jre-jammy/g" Dockerfile
-            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
-            mvn -DdockerTag=latest-jammy package
+            cd install/docker/armv7
+            sed -i -e "s/17-jre-noble/17-jre-jammy/g" Dockerfile
+            mvn -DdockerTag=latest-jammy-v7 package
             docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
             docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-jammy-v7 .
           fi

--- a/install/docker/alpine/Dockerfile
+++ b/install/docker/alpine/Dockerfile
@@ -60,9 +60,9 @@ COPY entry-point.sh /usr/local/bin/entry-point.sh
 RUN chmod +x /usr/local/bin/entry-point.sh
 
 COPY target/dependency/jpsonic.war jpsonic.war
-RUN unzip -q jpsonic.war \
+RUN java -Djarmode=tools -jar jpsonic.war extract --launcher --destination app \
     && rm jpsonic.war \
-    && mkdir -p /opt/jpsonic \
-    && java -Dspring.context.exit=onRefresh -XX:ArchiveClassesAtExit=/opt/jpsonic/jpsonic.jsa org.springframework.boot.loader.launch.WarLauncher
+    && cd app \
+    && java -Dspring.context.exit=onRefresh -XX:ArchiveClassesAtExit=../jpsonic.jsa org.springframework.boot.loader.launch.WarLauncher
 
 ENTRYPOINT ["tini", "-e", "143", "--", "entry-point.sh"]

--- a/install/docker/alpine/entry-point.sh
+++ b/install/docker/alpine/entry-point.sh
@@ -35,6 +35,7 @@ if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
 
     # su-exec and sudo may obscure exit codes.
     # Use set to enable graceful shutdown.
+    cd "$JPSONIC_DIR"/app
     set -- su-exec "$username":"$groupname" java \
      -Dserver.host=0.0.0.0 \
      -Dserver.port="$JPSONIC_PORT" \
@@ -60,7 +61,7 @@ if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
      -Dlogging.level.com.tesshu.jpsonic="$LOG_LEVEL" \
      -Djava.awt.headless=true \
      -Duser.timezone="$TIME_ZONE" \
-     -XX:SharedArchiveFile=/opt/jpsonic/jpsonic.jsa \
+     -XX:SharedArchiveFile="$JPSONIC_DIR"/jpsonic.jsa \
      "${java_opts_array[@]}" \
      org.springframework.boot.loader.launch.WarLauncher "$@"
 fi

--- a/install/docker/armv7/.dockerignore
+++ b/install/docker/armv7/.dockerignore
@@ -1,0 +1,5 @@
+.gitignore
+pom.xml
+production.yml
+target/
+!target/dependency/*

--- a/install/docker/armv7/Dockerfile
+++ b/install/docker/armv7/Dockerfile
@@ -1,0 +1,63 @@
+FROM eclipse-temurin:17-jre-noble
+
+LABEL description="Jpsonic is a free, web-based media streamer, providing ubiquitious access to your music." \
+      url="https://github.com/jpsonic/jpsonic"
+
+ENV JPSONIC_DIR=/jpsonic \
+    CONTEXT_PATH=/ \
+    JPSONIC_PORT=4040 \
+    UPNP_PORT=4041 \
+    UPNP_IDLE_INTERVAL=30 \
+    UPNP_MAX_CONNECTIONS=50 \
+    UPNP_MAX_IDLE_CONNECTIONS=30 \
+    UPNP_DRAIN_AMOUNT=65536 \
+    UPNP_MAX_REQ_HEADERS=200 \
+    UPNP_MAX_REQ_TIME=500 \
+    UPNP_MAX_RSP_TIME=500 \
+    UPNP_NODELAY=true \
+    SHOW_DATA_DIR=true \
+    USER_ID=1000 \
+    GROUP_ID=1000 \
+    TIME_ZONE=GB \
+    BANNER_MODE=OFF \
+    LOG_LEVEL=WARN \
+    SCAN_ON_BOOT=false \
+    EMBEDDED_FONT=false \
+    MIME_DSF=audio/x-dsd \
+    MIME_DFF=audio/x-dsd \
+    JAVA_OPTS="-Xms512m -Xmx512m -XX:+UseG1GC -XX:MaxGCPauseMillis=500"
+
+WORKDIR $JPSONIC_DIR
+
+COPY local.conf /etc/fonts
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    software-properties-common \
+    gosu \
+    tini \
+    fonts-noto-cjk \
+    ffmpeg \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm /usr/share/fonts/opentype/noto/NotoSansCJK-Bold.ttc \
+    && rm /usr/share/fonts/opentype/noto/NotoSerifCJK-Bold.ttc \
+    && rm /usr/share/fonts/opentype/noto/NotoSerifCJK-Regular.ttc \
+    && fc-cache -vf
+
+EXPOSE $JPSONIC_PORT
+EXPOSE $UPNP_PORT
+EXPOSE 1900/udp
+
+VOLUME \
+    $JPSONIC_DIR/data \
+    $JPSONIC_DIR/music \
+    $JPSONIC_DIR/playlists \
+    $JPSONIC_DIR/podcasts
+
+HEALTHCHECK --interval=30s --timeout=2s CMD export HEALTHCHECK_QUERY=$(echo localhost:"$JPSONIC_PORT""$CONTEXT_PATH"/rest/ping | tr -s /);wget -q http://"$HEALTHCHECK_QUERY" -O /dev/null || exit 1
+
+COPY entry-point.sh /usr/local/bin/entry-point.sh
+RUN chmod +x /usr/local/bin/entry-point.sh
+COPY target/dependency/jpsonic.war jpsonic.war
+
+ENTRYPOINT ["tini", "-e", "143", "--", "entry-point.sh"]

--- a/install/docker/armv7/entry-point.sh
+++ b/install/docker/armv7/entry-point.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+groupname=$(getent group "$GROUP_ID" | cut -d":" -f1)
+if [ -z "$groupname" ]; then
+    groupname=jpsonic
+    addgroup -g "$GROUP_ID" -S $groupname
+fi
+
+username=$(getent passwd "$USER_ID" | cut -d":" -f1)
+if [ -z "$username" ]; then
+    username=jpsonic
+	adduser \
+	    -u "$USER_ID" \
+	    --disabled-password \
+	    --gecos "" \
+	    --home "$JPSONIC_DIR" \
+	    --ingroup "$groupname" \
+	    jpsonic
+fi
+
+addgroup "$username" "$groupname"
+
+gosu "$username":"$groupname" mkdir -p "$JPSONIC_DIR"/data/transcode
+rm -f "$JPSONIC_DIR"/data/transcode/ffmpeg
+gosu "$username":"$groupname" ln -fs /usr/bin/ffmpeg "$JPSONIC_DIR"/data/transcode/ffmpeg
+rm -f "$JPSONIC_DIR"/data/transcode/ffprobe
+gosu "$username":"$groupname" ln -fs /usr/bin/ffprobe "$JPSONIC_DIR"/data/transcode/ffprobe
+
+if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
+
+    java_opts_array=()
+    while IFS= read -r -d '' item; do
+        java_opts_array+=( "$item" )
+    done < <([[ $JAVA_OPTS ]] && xargs printf '%s\0' <<<"$JAVA_OPTS")
+
+    # su-exec and gosu may obscure exit codes.
+    # Use set to enable graceful shutdown.
+    set -- gosu "$username":"$groupname" java \
+     -Dserver.host=0.0.0.0 \
+     -Dserver.port="$JPSONIC_PORT" \
+     -Dserver.servlet.context-path="$CONTEXT_PATH" \
+     -Djpsonic.home="$JPSONIC_DIR"/data \
+     -Djpsonic.defaultMusicFolder="$JPSONIC_DIR"/music \
+     -Djpsonic.defaultPodcastFolder="$JPSONIC_DIR"/podcasts \
+     -Djpsonic.defaultPlaylistFolder="$JPSONIC_DIR"/playlists \
+     -Djpsonic.scan.onboot="$SCAN_ON_BOOT" \
+     -Djpsonic.embeddedfont="$EMBEDDED_FONT" \
+     -Djpsonic.mime.dsf="$MIME_DSF" \
+     -Djpsonic.mime.dff="$MIME_DFF" \
+     -DUPNP_PORT="$UPNP_PORT" \
+     -Dsun.net.httpserver.idleInterval="$UPNP_IDLE_INTERVAL" \
+     -Djdk.httpserver.maxConnections="$UPNP_MAX_CONNECTIONS" \
+     -Dsun.net.httpserver.maxIdleConnections="$UPNP_MAX_IDLE_CONNECTIONS" \
+     -Dsun.net.httpserver.drainAmount="$UPNP_DRAIN_AMOUNT" \
+     -Dsun.net.httpserver.maxReqHeaders="$UPNP_MAX_REQ_HEADERS" \
+     -Dsun.net.httpserver.maxReqTime="$UPNP_MAX_REQ_TIME" \
+     -Dsun.net.httpserver.maxRspTime="$UPNP_MAX_RSP_TIME" \
+     -Dsun.net.httpserver.nodelay="$UPNP_NODELAY" \
+     -Dspring.main.banner-mode="$BANNER_MODE" \
+     -Dlogging.level.com.tesshu.jpsonic="$LOG_LEVEL" \
+     -Djava.awt.headless=true \
+     -Duser.timezone="$TIME_ZONE" \
+     "${java_opts_array[@]}" \
+     -jar jpsonic.war "$@"
+fi
+
+exec "$@"

--- a/install/docker/armv7/local.conf
+++ b/install/docker/armv7/local.conf
@@ -1,0 +1,12 @@
+<?xml version='1.0'?>
+<!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
+<fontconfig>
+    <match target="pattern">
+        <test qual="any" name="family">
+            <string>sans-serif</string>
+        </test>
+        <edit name="family" mode="prepend" binding="same">
+            <string>Noto Sans CJK JP</string>
+        </edit>
+    </match>
+</fontconfig>

--- a/install/docker/armv7/pom.xml
+++ b/install/docker/armv7/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <relativePath>../../../pom.xml</relativePath>
+        <artifactId>jpsonic</artifactId>
+        <version>114.2.0</version>
+        <groupId>com.tesshu.jpsonic.player</groupId>
+    </parent>
+    <packaging>pom</packaging>
+    <artifactId>jpsonic-docker-armv7</artifactId>
+    <name>Jpsonic Docker Image</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.40.1</version>
+                <executions>
+                    <execution>
+                        <id>build-image</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <name>${docker.container.repo}</name>
+                                    <build>
+                                        <dockerFile>${project.basedir}/Dockerfile</dockerFile>
+                                        <tags>${dockerTag}</tags>
+                                    </build>
+                                </image>
+                            </images>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <configuration>
+                    <stripClassifier>true</stripClassifier>
+                    <stripVersion>true</stripVersion>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/install/docker/jammy/Dockerfile
+++ b/install/docker/jammy/Dockerfile
@@ -35,7 +35,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     software-properties-common \
     gosu \
     tini \
-    unzip \
     fonts-noto-cjk \
     ffmpeg \
     && apt-get clean \
@@ -62,9 +61,9 @@ COPY entry-point.sh /usr/local/bin/entry-point.sh
 RUN chmod +x /usr/local/bin/entry-point.sh
 
 COPY target/dependency/jpsonic.war jpsonic.war
-RUN unzip -q jpsonic.war \
+RUN java -Djarmode=tools -jar jpsonic.war extract --launcher --destination app \
     && rm jpsonic.war \
-    && mkdir -p /opt/jpsonic \
-    && java -Dspring.context.exit=onRefresh -XX:ArchiveClassesAtExit=/opt/jpsonic/jpsonic.jsa org.springframework.boot.loader.launch.WarLauncher
+    && cd app \
+    && java -Dspring.context.exit=onRefresh -XX:ArchiveClassesAtExit=../jpsonic.jsa org.springframework.boot.loader.launch.WarLauncher
 
 ENTRYPOINT ["tini", "-e", "143", "--", "entry-point.sh"]

--- a/install/docker/jammy/entry-point.sh
+++ b/install/docker/jammy/entry-point.sh
@@ -35,6 +35,7 @@ if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
 
     # su-exec and gosu may obscure exit codes.
     # Use set to enable graceful shutdown.
+    cd "$JPSONIC_DIR"/app
     set -- gosu "$username":"$groupname" java \
      -Dserver.host=0.0.0.0 \
      -Dserver.port="$JPSONIC_PORT" \
@@ -60,7 +61,7 @@ if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
      -Dlogging.level.com.tesshu.jpsonic="$LOG_LEVEL" \
      -Djava.awt.headless=true \
      -Duser.timezone="$TIME_ZONE" \
-     -XX:SharedArchiveFile=/opt/jpsonic/jpsonic.jsa \
+     -XX:SharedArchiveFile="$JPSONIC_DIR"/jpsonic.jsa \
      "${java_opts_array[@]}" \
      org.springframework.boot.loader.launch.WarLauncher "$@"
 fi

--- a/install/docker/noble/Dockerfile
+++ b/install/docker/noble/Dockerfile
@@ -35,7 +35,6 @@ RUN apt-get update && apt-get -q install -y --no-install-recommends \
     software-properties-common \
     gosu \
     tini \
-    unzip \
     fonts-noto-cjk \
     ffmpeg \
     && apt-get clean \
@@ -62,9 +61,9 @@ COPY entry-point.sh /usr/local/bin/entry-point.sh
 RUN chmod +x /usr/local/bin/entry-point.sh
 
 COPY target/dependency/jpsonic.war jpsonic.war
-RUN unzip -q jpsonic.war \
+RUN java -Djarmode=tools -jar jpsonic.war extract --launcher --destination app \
     && rm jpsonic.war \
-    && mkdir -p /opt/jpsonic \
-    && java -Dspring.context.exit=onRefresh -XX:ArchiveClassesAtExit=/opt/jpsonic/jpsonic.jsa org.springframework.boot.loader.launch.WarLauncher
+    && cd app \
+    && java -Dspring.context.exit=onRefresh -XX:ArchiveClassesAtExit=../jpsonic.jsa org.springframework.boot.loader.launch.WarLauncher
 
 ENTRYPOINT ["tini", "-e", "143", "--", "entry-point.sh"]

--- a/install/docker/noble/entry-point.sh
+++ b/install/docker/noble/entry-point.sh
@@ -35,6 +35,7 @@ if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
 
     # su-exec and gosu may obscure exit codes.
     # Use set to enable graceful shutdown.
+    cd "$JPSONIC_DIR"/app
     set -- gosu "$username":"$groupname" java \
      -Dserver.host=0.0.0.0 \
      -Dserver.port="$JPSONIC_PORT" \
@@ -60,7 +61,7 @@ if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
      -Dlogging.level.com.tesshu.jpsonic="$LOG_LEVEL" \
      -Djava.awt.headless=true \
      -Duser.timezone="$TIME_ZONE" \
-     -XX:SharedArchiveFile=/opt/jpsonic/jpsonic.jsa \
+     -XX:SharedArchiveFile="$JPSONIC_DIR"/jpsonic.jsa \
      "${java_opts_array[@]}" \
      org.springframework.boot.loader.launch.WarLauncher "$@"
 fi

--- a/install/docker/ubi9/Dockerfile
+++ b/install/docker/ubi9/Dockerfile
@@ -60,9 +60,9 @@ COPY entry-point.sh /usr/local/bin/entry-point.sh
 RUN chmod +x /usr/local/bin/entry-point.sh
 
 COPY target/dependency/jpsonic.war jpsonic.war
-RUN unzip -q jpsonic.war \
+RUN java -Djarmode=tools -jar jpsonic.war extract --launcher --destination app \
     && rm jpsonic.war \
-    && mkdir -p /opt/jpsonic \
-    && java -Dspring.context.exit=onRefresh -XX:ArchiveClassesAtExit=/opt/jpsonic/jpsonic.jsa org.springframework.boot.loader.launch.WarLauncher
+    && cd app \
+    && java -Dspring.context.exit=onRefresh -XX:ArchiveClassesAtExit=../jpsonic.jsa org.springframework.boot.loader.launch.WarLauncher
 
 ENTRYPOINT ["tini", "-e", "143", "--", "entry-point.sh"]

--- a/install/docker/ubi9/entry-point.sh
+++ b/install/docker/ubi9/entry-point.sh
@@ -35,6 +35,7 @@ if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
         java_opts_array+=( "$item" )
     done < <([[ $JAVA_OPTS ]] && xargs printf '%s\0' <<<"$JAVA_OPTS")
 
+    cd "$JPSONIC_DIR"/app
     set -- java \
      -Dserver.host=0.0.0.0 \
      -Dserver.port="$JPSONIC_PORT" \
@@ -60,7 +61,7 @@ if [[ $# -lt 1 ]] || [[ ! "$1" == "java"* ]]; then
      -Dlogging.level.com.tesshu.jpsonic="$LOG_LEVEL" \
      -Djava.awt.headless=true \
      -Duser.timezone="$TIME_ZONE" \
-     -XX:SharedArchiveFile=/opt/jpsonic/jpsonic.jsa \
+     -XX:SharedArchiveFile="$JPSONIC_DIR"/jpsonic.jsa \
      "${java_opts_array[@]}" \
      org.springframework.boot.loader.launch.WarLauncher "$@"
 fi


### PR DESCRIPTION
Prerequisites: #2702

___

## Problem description

The arm/v7 Docker build is failing in CI. However, there are no problems other than the arm/v7 build, so shipping to Dockerhub was successful. As a workaround, we will revert the arm/v7 build to the previous version and the arm/v7 Docker Image will be fixed so that CDS is not used. 

The problem is that the Main Class cannot be recognized when creating a CDS shared class file. The war unpacks normally, and the WarLancher searches for the main class via the Manifest, but then gets ClassNotFound. Docker images for arm/v7 use Java 17. To isolate the problem, we tested using Java 17 on amd64/armv8, and CDS was able to be used without any problems.

It looks like there might be something arm/v7 specific in Spring's WarLancher, but I haven't done any further validation on it. (We won't know until debug it on an actual device. Incidentally, there have been class loading bugs in JarLancher before.) The top priority for arm/v7 images is to maintain the current state.

## System information

 * **Jpsonic version**: v114.1
 * **Operating system**: arm/v7 of Ubunts Jammy/Noble
 * **Java version**: 17

## Details

This commit includes improvements to the process of creating shared class files for CDS. The end result is the same, but where Unzip was used before, standard Java tools are now used in a manner consistent with Spring's recommended procedures. The verification was carried out on this basis. 

The Java version (21/17) is not relevant to this issue, only arm/v7 has this issue. Therefore, the previous Dockerfile was reverted and changed to use it in arm/v7.




