### PR TITLE
Bump lucene from 9.11.1 to 9.12.0

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
@@ -107,7 +107,7 @@ public class IndexManager implements ReadWriteLockSupport {
      * of AnalyzerFactory, DocumentFactory or the class that they use.
      *
      */
-    private static final int INDEX_VERSION = 28;
+    private static final int INDEX_VERSION = 29;
 
     /**
      * Literal name of index top directory.

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <versions.liquibase-slf4j>5.0.0</versions.liquibase-slf4j>
     <versions.log4j>2.22.1</versions.log4j>
     <versions.logback>1.5.8</versions.logback>
-    <versions.lucene>9.11.1</versions.lucene>
+    <versions.lucene>9.12.0</versions.lucene>
     <versions.maven-artifact>3.9.9</versions.maven-artifact>
     <versions.mockito-junit-jupiter>5.13.0</versions.mockito-junit-jupiter>
     <versions.moxy>4.0.4</versions.moxy>


### PR DESCRIPTION
## Overview

Lucene will be updated.  This will clear the search index, which will require a full scan.

## Details

Lucene occasionally updates its codec version, and this is one such update. There is a way to add legacy codec libs to ensure backward compatibility, but Airsonic and Jpsonic have traditionally not done this to avoid bloat. It has a generational replacement mechanism. Previous data is deleted and can be restored by full scan. 

The generation of such indexes is managed by IndexManager#INDEX_VERSION. (This is the same number as the suffix of the index directory in the data directory.) Subsonic has equivalent numbers, but the Lucene major number was used. In practice, index generation updates are triggered by schema changes or codec updates. Therefore, the meaning of this management number (suffix) is different for Subsonic and Airsonic and later servers.

This commit includes an increment to IndexManager#INDEX_VERSION. (On server startup, the data directory will be deleted and an empty directory will be created. A full scan will re-register the data so there are no codec conflicts.) This commit alone will not automatically be full-scan. IgnoreTimestamp should be enabled.






