### PR TITLE
Fix bug regarding ID3 album stars (2)

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AlbumDao.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/dao/AlbumDao.java
@@ -343,10 +343,6 @@ public class AlbumDao {
                 """, scanDate);
     }
 
-    public void deleteAll() {
-        template.update("delete from album");
-    }
-
     public void starAlbum(int albumId, String username) {
         unstarAlbum(albumId, username);
         template.update("""

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/search/IndexManager.java
@@ -44,7 +44,6 @@ import java.util.stream.Stream;
 
 import com.tesshu.jpsonic.SuppressFBWarnings;
 import com.tesshu.jpsonic.ThreadSafe;
-import com.tesshu.jpsonic.dao.AlbumDao;
 import com.tesshu.jpsonic.dao.ArtistDao;
 import com.tesshu.jpsonic.domain.Album;
 import com.tesshu.jpsonic.domain.Artist;
@@ -124,7 +123,6 @@ public class IndexManager implements ReadWriteLockSupport {
     private final SettingsService settingsService;
     private final ScannerStateServiceImpl scannerState;
     private final ArtistDao artistDao;
-    private final AlbumDao albumDao;
     private final Executor shortExecutor;
 
     private final Map<IndexType, SearcherManager> searchers;
@@ -142,7 +140,7 @@ public class IndexManager implements ReadWriteLockSupport {
 
     public IndexManager(AnalyzerFactory analyzerFactory, DocumentFactory documentFactory, QueryFactory queryFactory,
             SearchServiceUtilities util, JpsonicComparators comparators, SettingsService settingsService,
-            ScannerStateServiceImpl scannerState, ArtistDao artistDao, AlbumDao albumDao,
+            ScannerStateServiceImpl scannerState, ArtistDao artistDao,
             @Qualifier("shortExecutor") Executor shortExecutor) {
         super();
         this.analyzerFactory = analyzerFactory;
@@ -153,7 +151,6 @@ public class IndexManager implements ReadWriteLockSupport {
         this.settingsService = settingsService;
         this.scannerState = scannerState;
         this.artistDao = artistDao;
-        this.albumDao = albumDao;
         this.shortExecutor = shortExecutor;
         searchers = new ConcurrentHashMap<>();
         writers = new ConcurrentHashMap<>();
@@ -542,7 +539,6 @@ public class IndexManager implements ReadWriteLockSupport {
         }
 
         artistDao.deleteAll();
-        albumDao.deleteAll();
         if (FileUtil.createDirectories(getRootIndexDirectory()) == null) {
             LOG.warn("Failed to create index directory :  (index version {}). ", INDEX_VERSION);
         }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/DaoUnitTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/dao/DaoUnitTest.java
@@ -106,7 +106,6 @@ class DaoUnitTest {
 
         albumDao.starAlbum(album.getId(), USER_NAME);
         albumDao.unstarAlbum(album.getId(), USER_NAME);
-        albumDao.deleteAll();
         mediaFileDao.deleteMediaFile(file.getId());
     }
 

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/search/IndexManagerTest.java
@@ -38,7 +38,6 @@ import java.util.concurrent.ExecutionException;
 
 import com.tesshu.jpsonic.AbstractNeedsScan;
 import com.tesshu.jpsonic.NeedsHome;
-import com.tesshu.jpsonic.dao.AlbumDao;
 import com.tesshu.jpsonic.dao.ArtistDao;
 import com.tesshu.jpsonic.dao.MediaFileDao;
 import com.tesshu.jpsonic.dao.RatingDao;
@@ -151,7 +150,7 @@ class IndexManagerTest {
             JapaneseReadingUtils readingUtils = new JapaneseReadingUtils(settingsService);
             JpsonicComparators comparators = new JpsonicComparators(settingsService, readingUtils);
             indexManager = new IndexManager(null, null, queryFactory, utils, comparators, settingsService, null, null,
-                    null, null);
+                    null);
         }
 
         @GetGenresDecisions.Conditions.Settings.IsSortGenresByAlphabet.FALSE
@@ -477,16 +476,13 @@ class IndexManagerTest {
     class UnitTest {
 
         private ArtistDao artistDao;
-        private AlbumDao albumDao;
         private IndexManager indexManager;
 
         @BeforeEach
         public void setup() {
             SettingsService settingsService = Mockito.mock(SettingsService.class);
             artistDao = mock(ArtistDao.class);
-            albumDao = mock(AlbumDao.class);
-            indexManager = new IndexManager(null, null, null, null, null, settingsService, null, artistDao, albumDao,
-                    null);
+            indexManager = new IndexManager(null, null, null, null, null, settingsService, null, artistDao, null);
         }
 
         @AfterEach
@@ -500,7 +496,6 @@ class IndexManagerTest {
             Files.createDirectories(indexManager.getRootIndexDirectory());
             indexManager.initializeIndexDirectory();
             Mockito.verify(artistDao, Mockito.never()).deleteAll();
-            Mockito.verify(albumDao, Mockito.never()).deleteAll();
         }
 
         @Test
@@ -508,7 +503,6 @@ class IndexManagerTest {
             System.setProperty("jpsonic.home", tempDir.toString());
             indexManager.initializeIndexDirectory();
             Mockito.verify(artistDao, Mockito.times(1)).deleteAll();
-            Mockito.verify(albumDao, Mockito.times(1)).deleteAll();
         }
     }
 


### PR DESCRIPTION
Prerequisites: #2683
___

## Problem description

In v114.2.0, a fix was made so that the Star in AlbumId3 is not deleted when performing a full scan with Ignoretimestamp enabled. 

In the Jpsonic released in the master branch, the Star of AlbumId3 is not deleted during normal scan operations. However, there is a special case where the Star in AlbumId3 is deleted.

### Steps to reproduce

The trigger for this bug is deleting the search index directory (index-JP**) that exists in the data directory.

This data deletion was originally introduced temporarily as a necessary process. This was made unnecessary by the fix in #2683 and was supposed to be fixed at the same time. (Correction missed!)

#### Case 1

1. Shutdown Jpsonic.
2. Manually delete the search index directory (index-JP**)
3. Start Jpsonic.

#### Case 2

1. Switch to Jpsonic with a different search index version and start it.

This is because the index is automatically deleted when the generation is replaced. In other words, the principle is the same as in Case 1.


## System information

 * **Jpsonic version**: v114.2.0 or earlier than v114.2.0


## Impact

This is not a problem that occurs during normal use and is not fatal. But, if we do not apply this fix, the issue may occur under the following conditions:

 - When a user intentionally and manually deletes the search index directory (index-JP**)
 - When using the Jpsonic image of the development branch
   - Due to the Lucene codec update, indexes will be precessed to be deleted/regenerated in the next release. Lucene bump has already been completed in the development branch.
     - #2707
     - #2709

If this fix is ​​included in the next minor version (v114.3) release, there will be no problem. However, if a user executes the above case without knowing this specification, a problem will occur. Therefore, the bug fix will be applied as a hotfix.





