### PR TITLE
Fix bug that UPnP:By Folder(ID3) did not work

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/DispatchingContentDirectory.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/upnp/processor/DispatchingContentDirectory.java
@@ -89,8 +89,9 @@ public class DispatchingContentDirectory extends CustomContentDirectory
 
     public DispatchingContentDirectory(RootUpnpProc rp, @Qualifier("mediaFileProc") MediaFileProc mfp,
             @Lazy @Qualifier("mediaFileByFolderProc") MediaFileByFolderProc mfbfp, @Lazy PlaylistProc playp,
-            @Lazy @Qualifier("albumId3Proc") AlbumId3Proc aid3p, @Lazy AlbumId3ByFolderProc alid3bfp,
-            @Lazy AlbumProc alp, @Lazy AlbumByFolderProc albfp, @Lazy @Qualifier("recentAlbumProc") RecentAlbumProc rap,
+            @Lazy @Qualifier("albumId3Proc") AlbumId3Proc aid3p,
+            @Lazy @Qualifier("albumId3ByFolderProc") AlbumId3ByFolderProc alid3bfp, @Lazy AlbumProc alp,
+            @Lazy AlbumByFolderProc albfp, @Lazy @Qualifier("recentAlbumProc") RecentAlbumProc rap,
             @Lazy @Qualifier("recentAlbumByFolderProc") RecentAlbumByFolderProc rabfp,
             @Lazy @Qualifier("recentAlbumId3Proc") RecentAlbumId3Proc raip,
             @Lazy @Qualifier("recentAlbumId3ByFolderProc") RecentAlbumId3ByFolderProc raigfp, @Lazy ArtistProc arP,


### PR DESCRIPTION

## Problem description

 - UPnP's "By Folder (ID3)" cannot be used.
 - If you enable this item, other album items will also be unavailable.

### Steps to reproduce

Check the "By Folder(ID3)" box and save.

![image](https://github.com/user-attachments/assets/f2bd604e-6779-40ed-b5a8-466e7c513a10)

## System information

 * **Jpsonic version**: v114.2.0

## Additional notes

This is not a fatal error that affects data integrity or the like.

A required  `@Qualifier` of Spring FW was missing, which caused the bean to not be initialized correctly. Maybe I just didn't check it enough 🤨 
