### PR TITLE
Fix to temporarily exclude Ubuntu Jammy from the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Create coverage
         id: create-coverage
         if: contains(matrix.os, 'ubuntu-latest')
-        run: mvn -Punit-test -Psend-coverage -Ptomcat-embed -DfailIfNoTests=false -DtranscodePath="${{ steps.ffmpeg.outputs.path }}" clean test jacoco:report
+        run: mvn -Punit-test -Psend-coverage -Ptomcat-embed -DfailIfNoTests=false -DtranscodePath="${{ steps.ffmpeg.outputs.path }}" -Prelease17 clean test jacoco:report
       - name: Archive code coverage
         if: "(steps.create-coverage.conclusion == 'success' && contains(matrix.os, 'ubuntu-latest')) && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop')"
         uses: actions/upload-artifact@v4
@@ -103,7 +103,7 @@ jobs:
         if: contains(matrix.os, 'windows-latest')
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-        run: mvn -DnvdApiKey=${{ env.NVD_API_KEY }} -DnvdApiDelay=3000 -DnvdMaxRetryCount=10 -DfailIfNoTests=false -DtranscodePath="${{ steps.ffmpeg.outputs.path }}" clean verify -B -Ptomcat-embed -Punit-test
+        run: mvn -DnvdApiKey=${{ env.NVD_API_KEY }} -DnvdApiDelay=3000 -DnvdMaxRetryCount=10 -DfailIfNoTests=false -DtranscodePath="${{ steps.ffmpeg.outputs.path }}" -Prelease17 clean verify -B -Ptomcat-embed -Punit-test
   ##########################################################################
   verify-Java21-or-later:
     needs: pre_job
@@ -507,158 +507,163 @@ jobs:
             docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-noble-v7 .
           fi
   ##########################################################################
-  ship-docker-image-jammy:
-    name: Docker(jammy-amd,arm)
-    needs: ship-war
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 21
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASS }}
-      - name: Get current date
-        id: date
-        run: echo "current=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
-      - name: Download package
-        uses: actions/download-artifact@v4
-        with:
-          name: jpsonic-jetty-embedded-for-jdk21-${{ steps.date.outputs.current }}
-      - name: Create Tag
-        run: |
-          echo "DOCKER_TAG=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
-      - name: Copy artifact
-        run: |
-          mkdir -p install/docker/jammy/target/dependency
-          mv jpsonic.war install/docker/jammy/target/dependency
-      - name: Release with Version Tag
-        if: "(github.ref == 'refs/heads/master')"
-        run: |
-          if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            cd install/docker/jammy
-            sed -i -e "s/21-jdk-jammy/21-jre-jammy/g" Dockerfile
-            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
-            mvn -DdockerTag=${{ env.DOCKER_TAG }}-jammy package
-            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
-            docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-jammy .
-            mvn -DdockerTag=${DOCKER_TAG%.*}-jammy package
-            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
-            docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t jpsonic/jpsonic:${DOCKER_TAG%.*}-jammy .
-            mvn -DdockerTag=${DOCKER_TAG%.*.*}-jammy package
-            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
-            docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t jpsonic/jpsonic:${DOCKER_TAG%.*.*}-jammy .
-          fi
-      - name: Release with Latest Tag
-        if: github.ref == 'refs/heads/master'
-        run: |
-          if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            cd install/docker/jammy
-            sed -i -e "s/21-jdk-jammy/21-jre-jammy/g" Dockerfile
-            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
-            mvn -DdockerTag=latest-jammy package
-            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
-            docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t jpsonic/jpsonic:latest-jammy .
-          fi
-      - name: Release with Alpha/Beta Tag
-        if: github.ref == 'refs/heads/master'
-        run: |
-          if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.(alpha|beta)\.[0-9]+\.[0-9]+$ ]]; then
-            cd install/docker/jammy
-            sed -i -e "s/21-jdk-jammy/21-jre-jammy/g" Dockerfile
-            sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
-            mvn -DdockerTag=latest-jammy package
-            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
-            docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-jammy .
-          fi
-      - name: Release with Early-Access Tag
-        if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/feature/docker'
-        run: |
-          cd install/docker/jammy
-          mvn -DdockerTag=ea-jammy package
-          docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
-          docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t jpsonic/jpsonic:ea-jammy .
+#
+# https://github.com/tesshucom/jpsonic/pull/2741
+#
+# ship-docker-image-jammy:
+#   name: Docker(jammy-amd,arm)
+#   needs: ship-war
+#   runs-on: ubuntu-latest
+#   steps:
+#     - uses: actions/checkout@v4
+#     - uses: actions/setup-java@v4
+#       with:
+#         distribution: 'temurin'
+#         java-version: 21
+#     - uses: docker/setup-qemu-action@v3
+#     - uses: docker/setup-buildx-action@v3
+#     - uses: docker/login-action@v3
+#       with:
+#         username: ${{ secrets.DOCKER_USER }}
+#         password: ${{ secrets.DOCKER_PASS }}
+#     - name: Get current date
+#       id: date
+#       run: echo "current=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+#     - name: Download package
+#       uses: actions/download-artifact@v4
+#       with:
+#         name: jpsonic-jetty-embedded-for-jdk21-${{ steps.date.outputs.current }}
+#     - name: Create Tag
+#       run: |
+#         echo "DOCKER_TAG=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
+#     - name: Copy artifact
+#       run: |
+#         mkdir -p install/docker/jammy/target/dependency
+#         mv jpsonic.war install/docker/jammy/target/dependency
+#     - name: Release with Version Tag
+#       if: "(github.ref == 'refs/heads/master')"
+#       run: |
+#         if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+#           cd install/docker/jammy
+#           sed -i -e "s/21-jdk-jammy/21-jre-jammy/g" Dockerfile
+#           sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
+#           mvn -DdockerTag=${{ env.DOCKER_TAG }}-jammy package
+#           docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+#           docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-jammy .
+#           mvn -DdockerTag=${DOCKER_TAG%.*}-jammy package
+#           docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+#           docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t jpsonic/jpsonic:${DOCKER_TAG%.*}-jammy .
+#           mvn -DdockerTag=${DOCKER_TAG%.*.*}-jammy package
+#           docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+#           docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t jpsonic/jpsonic:${DOCKER_TAG%.*.*}-jammy .
+#         fi
+#     - name: Release with Latest Tag
+#       if: github.ref == 'refs/heads/master'
+#       run: |
+#         if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+#           cd install/docker/jammy
+#           sed -i -e "s/21-jdk-jammy/21-jre-jammy/g" Dockerfile
+#           sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
+#           mvn -DdockerTag=latest-jammy package
+#           docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+#           docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t jpsonic/jpsonic:latest-jammy .
+#         fi
+#     - name: Release with Alpha/Beta Tag
+#       if: github.ref == 'refs/heads/master'
+#       run: |
+#         if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.(alpha|beta)\.[0-9]+\.[0-9]+$ ]]; then
+#           cd install/docker/jammy
+#           sed -i -e "s/21-jdk-jammy/21-jre-jammy/g" Dockerfile
+#           sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
+#           mvn -DdockerTag=latest-jammy package
+#           docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+#           docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-jammy .
+#         fi
+#     - name: Release with Early-Access Tag
+#       if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/feature/docker'
+#       run: |
+#         cd install/docker/jammy
+#         mvn -DdockerTag=ea-jammy package
+#         docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+#         docker buildx build --push --platform linux/amd64,linux/arm64/v8 -t jpsonic/jpsonic:ea-jammy .
   ##########################################################################
-  ship-docker-image-jammy-v7:
-    name: Docker(jammy-arm/v7)
-    needs: ship-war
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 17
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASS }}
-      - name: Get current date
-        id: date
-        run: echo "current=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
-      - name: Download package
-        uses: actions/download-artifact@v4
-        with:
-          name: jpsonic-jetty-embedded-for-jdk17-${{ steps.date.outputs.current }}
-      - name: Create Tag
-        run: |
-          echo "DOCKER_TAG=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
-      - name: Copy artifact
-        run: |
-          mkdir -p install/docker/armv7/target/dependency
-          mv jpsonic.war install/docker/armv7/target/dependency
-      - name: Release with Version Tag
-        if: "(github.ref == 'refs/heads/master')"
-        run: |
-          if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            cd install/docker/armv7
-            sed -i -e "s/17-jre-noble/17-jre-jammy/g" Dockerfile
-            mvn -DdockerTag=${{ env.DOCKER_TAG }}-jammy-v7 package
-            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
-            docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-jammy-v7 .
-            mvn -DdockerTag=${DOCKER_TAG%.*}-jammy-v7 package
-            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
-            docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${DOCKER_TAG%.*}-jammy-v7 .
-            mvn -DdockerTag=${DOCKER_TAG%.*.*}-jammy-v7 package
-            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
-            docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${DOCKER_TAG%.*.*}-jammy-v7 .
-          fi
-      - name: Release with Latest Tag
-        if: github.ref == 'refs/heads/master'
-        run: |
-          if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            cd install/docker/armv7
-            sed -i -e "s/17-jre-noble/17-jre-jammy/g" Dockerfile
-            mvn -DdockerTag=latest-jammy-v7 package
-            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
-            docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:latest-jammy-v7 .
-          fi
-      - name: Release with Alpha/Beta Tag
-        if: github.ref == 'refs/heads/master'
-        run: |
-          if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.(alpha|beta)\.[0-9]+\.[0-9]+$ ]]; then
-            cd install/docker/armv7
-            sed -i -e "s/17-jre-noble/17-jre-jammy/g" Dockerfile
-            mvn -DdockerTag=latest-jammy-v7 package
-            docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
-            docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-jammy-v7 .
-          fi
+# ship-docker-image-jammy-v7:
+#   name: Docker(jammy-arm/v7)
+#   needs: ship-war
+#   runs-on: ubuntu-latest
+#   steps:
+#     - uses: actions/checkout@v4
+#     - uses: actions/setup-java@v4
+#       with:
+#         distribution: 'temurin'
+#         java-version: 17
+#     - uses: docker/setup-qemu-action@v3
+#     - uses: docker/setup-buildx-action@v3
+#     - uses: docker/login-action@v3
+#       with:
+#         username: ${{ secrets.DOCKER_USER }}
+#         password: ${{ secrets.DOCKER_PASS }}
+#     - name: Get current date
+#       id: date
+#       run: echo "current=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+#     - name: Download package
+#       uses: actions/download-artifact@v4
+#       with:
+#         name: jpsonic-jetty-embedded-for-jdk17-${{ steps.date.outputs.current }}
+#     - name: Create Tag
+#       run: |
+#         echo "DOCKER_TAG=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
+#     - name: Copy artifact
+#       run: |
+#         mkdir -p install/docker/armv7/target/dependency
+#         mv jpsonic.war install/docker/armv7/target/dependency
+#     - name: Release with Version Tag
+#       if: "(github.ref == 'refs/heads/master')"
+#       run: |
+#         if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+#           cd install/docker/armv7
+#           sed -i -e "s/17-jre-noble/17-jre-jammy/g" Dockerfile
+#           mvn -DdockerTag=${{ env.DOCKER_TAG }}-jammy-v7 package
+#           docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+#           docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-jammy-v7 .
+#          mvn -DdockerTag=${DOCKER_TAG%.*}-jammy-v7 package
+#           docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+#           docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${DOCKER_TAG%.*}-jammy-v7 .
+#           mvn -DdockerTag=${DOCKER_TAG%.*.*}-jammy-v7 package
+#           docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+#           docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${DOCKER_TAG%.*.*}-jammy-v7 .
+#         fi
+#     - name: Release with Latest Tag
+#       if: github.ref == 'refs/heads/master'
+#       run: |
+#         if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+#           cd install/docker/armv7
+#           sed -i -e "s/17-jre-noble/17-jre-jammy/g" Dockerfile
+#           mvn -DdockerTag=latest-jammy-v7 package
+#           docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+#           docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:latest-jammy-v7 .
+#         fi
+#     - name: Release with Alpha/Beta Tag
+#       if: github.ref == 'refs/heads/master'
+#       run: |
+#         if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.(alpha|beta)\.[0-9]+\.[0-9]+$ ]]; then
+#           cd install/docker/armv7
+#           sed -i -e "s/17-jre-noble/17-jre-jammy/g" Dockerfile
+#           mvn -DdockerTag=latest-jammy-v7 package
+#           docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
+#           docker buildx build --push --platform linux/arm/v7 -t jpsonic/jpsonic:${{ env.DOCKER_TAG }}-jammy-v7 .
+#         fi
   ##########################################################################
   run-docker4latest:
     name: Run ${{ matrix.tag }}
-    needs: [ ship-docker-image, ship-docker-image-ubi9, ship-docker-image-noble, ship-docker-image-noble-v7, ship-docker-image-jammy, ship-docker-image-jammy-v7 ]
+#   needs: [ ship-docker-image, ship-docker-image-ubi9, ship-docker-image-noble, ship-docker-image-noble-v7, ship-docker-image-jammy, ship-docker-image-jammy-v7 ]
+    needs: [ ship-docker-image, ship-docker-image-ubi9, ship-docker-image-noble, ship-docker-image-noble-v7 ]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tag: [ latest, latest-ubi9, latest-noble, latest-jammy ]
+#       tag: [ latest, latest-ubi9, latest-noble, latest-jammy ]
+        tag: [ latest, latest-ubi9, latest-noble ]
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -683,12 +688,14 @@ jobs:
   ##########################################################################
   run-docker4ea:
     name: Run ${{ matrix.tag }}
-    needs: [ ship-docker-image, ship-docker-image-ubi9, ship-docker-image-noble, ship-docker-image-noble-v7, ship-docker-image-jammy, ship-docker-image-jammy-v7 ]
+#   needs: [ ship-docker-image, ship-docker-image-ubi9, ship-docker-image-noble, ship-docker-image-noble-v7, ship-docker-image-jammy, ship-docker-image-jammy-v7 ]
+    needs: [ ship-docker-image, ship-docker-image-ubi9, ship-docker-image-noble, ship-docker-image-noble-v7 ]
     if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/feature/docker'
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tag: [ ea, ea-ubi9, ea-noble, ea-jammy ]
+#       tag: [ ea, ea-ubi9, ea-noble, ea-jammy ]
+        tag: [ ea, ea-ubi9, ea-noble ]
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
## Problem description - February 2025

There is currently a problem with apt-get on Ubuntu Jammy, and 'update' cannot be performed on Github Action. Therefore, the release of Docker Images for the Ubuntu Jammy version will be suspended for the time being.

 - arm-v7 users are encouraged to try the Ubuntu Noble Image.
 - For amd64 users, we recommend trying the Ubuntu Noble Image, or considering the more secure Alpine or Red Hat Image.

## System information

 * **Jpsonic version**: v114.2.6
 * **Operating system**: Docker Image : Ubuntu Jammy

## Additional notes

My personal preference is to continue releasing Jammy as long as LTS Support is provided. 

On the other hand, I know how hacky and tedious apt-get hacks can be. I don't want to spend too much time here. I vaguely suspect that the problem is occurring with Temurin, which provides the upstream image, or with Github Actions. (By the way, there are no problems building the image on local Windows.) Hopefully, it will resolve naturally over time 🙃

 - Previous versions of Jammy images will not be deleted (you can continue to use them) However, I would also suggest trying other images.
 - This issue will be observed in the medium to long term. If the issue is resolved or a workaround is found, Jammy image releases will resume.






