### PR TITLE
Improve URL validation for DlnaBaseLANURL

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/UPnPSubnet.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/service/UPnPSubnet.java
@@ -40,9 +40,10 @@ public class UPnPSubnet {
                         : InetAddress.getByName(url.getHost()).getHostAddress()).concat("/24");
                 subnetInfo = new SubnetUtils(cidrNotation).getInfo();
             } catch (MalformedURLException | UnknownHostException e) {
-                if (LOG.isInfoEnabled()) {
-                    LOG.info("Unable to get subnet from the dlna base lan URL.");
+                if (LOG.isWarnEnabled()) {
+                    LOG.warn("Unable to get subnet from the dlna base lan URL.");
                 }
+                return false;
             }
         }
         return subnetInfo.isInRange(address);

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/UPnPSubnetTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/UPnPSubnetTest.java
@@ -93,13 +93,22 @@ class UPnPSubnetTest {
         assertFalse(subnet.isInUPnPRange("dummy"));
     }
 
+    @SubnetDecisions.Conditions.DlnaBaseLANURL.NotNull.WithHostName.InValid
+    @SubnetDecisions.Conditions.Address.NotInRange
+    @SubnetDecisions.Results.False
+    @Test
+    void c021() {
+        subnet.setDlnaBaseLANURL("http://sjhbfdkljhf.com");
+        assertFalse(subnet.isInUPnPRange("20.27.178.1"));
+    }
+
     @SubnetDecisions.Conditions.DlnaBaseLANURL.NotNull.WithHostName.Valid
     @SubnetDecisions.Conditions.Address.NotInRange
     @SubnetDecisions.Results.False
     @Test
     void c03() {
-        subnet.setDlnaBaseLANURL("http://tesshu.com"); // 157.7.140.239
-        assertFalse(subnet.isInUPnPRange("157.7.141.1"));
+        subnet.setDlnaBaseLANURL("http://20.27.177.113");
+        assertFalse(subnet.isInUPnPRange("20.27.178.1"));
     }
 
     @SubnetDecisions.Conditions.DlnaBaseLANURL.NotNull.WithHostName.Valid
@@ -107,8 +116,8 @@ class UPnPSubnetTest {
     @SubnetDecisions.Results.True
     @Test
     void c04() {
-        subnet.setDlnaBaseLANURL("http://tesshu.com");
-        assertTrue(subnet.isInUPnPRange("157.7.140.1"));
+        subnet.setDlnaBaseLANURL("http://20.27.177.113");
+        assertTrue(subnet.isInUPnPRange("20.27.177.1"));
     }
 
     @SubnetDecisions.Conditions.DlnaBaseLANURL.NotNull.WithIp


### PR DESCRIPTION
## Problem description

Minor fix for error handling of DlnaBaseLANURL.

Jpsonic uses the player name and the network segment to which it is connected to determine whether the player used by the user is UPnP. In this case, the address obtained by DlnaBaseLANURL is used. Currently, a Null Pointer will occur in cases where host information cannot be obtained (e.g. if there is a network problem).

> What was originally envisioned was...
> 
> 1. The message "Unable to get subnet from the dlna base lan URL." is displayed.
> 2. If the conditions are not met, the player will not be treated as a UPnP Player.

This bug fix will allow the expected processing to be performed instead of a NullPointer when host information cannot be obtained. Also, the output message for when there is a problem was specified as INFO, but it has been changed to WARN.

### Steps to reproduce

1. Specify a URL for which host information cannot be obtained in DlnaBaseLANURL.
2. Access with UPnP Player

## System information

 * **Jpsonic version**: Before 114.2.8
