### PR TITLE
Fix to filter unknown menus (2)

### DIFF
--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MenuItemServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MenuItemServiceTest.java
@@ -19,6 +19,7 @@
 
 package com.tesshu.jpsonic.service;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -44,6 +45,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.NoSuchMessageException;
 
 @SpringBootTest
 @ExtendWith(NeedsHome.class)
@@ -454,6 +456,28 @@ class MenuItemServiceTest {
             assertEquals(6,
                     menuItemDao.getChildlenOf(ViewType.UPNP, MenuItemId.GENRE, false, 0, Integer.MAX_VALUE).size());
             assertEquals(subMenuItemsSize, menuItemDao.getSubMenuItems(ViewType.UPNP).size());
+        }
+
+        /*
+         * #2660 This does not happen only in release versions, it is a glitch that can occur when sharing release and
+         * development branches. An exception occurs if a definition already exists for MenuItemId, the record exists in
+         * the DB, and the name is not defined in the message resource.
+         */
+        @Test
+        void testUnknownMessage() {
+            // Add a dummy menu
+            templateWrapper.update("""
+                    insert into menu_item
+                    (view_type, id, parent, name, enabled, menu_item_order)
+                    values(?, ?, ?, ?, ?, ?);
+                    """, ViewType.UPNP.value(), 130, MenuItemId.ROOT.value(), "dummy", true, 99);
+
+            assertThatExceptionOfType(NoSuchMessageException.class)
+                    .isThrownBy(() -> menuItemService.getTopMenuItems(ViewType.UPNP));
+
+            templateWrapper.update("""
+                    delete from menu_item where id = 130
+                    """);
         }
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MenuItemServiceTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/service/MenuItemServiceTest.java
@@ -19,7 +19,7 @@
 
 package com.tesshu.jpsonic.service;
 
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -45,7 +45,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.NoSuchMessageException;
 
 @SpringBootTest
 @ExtendWith(NeedsHome.class)
@@ -471,10 +470,10 @@ class MenuItemServiceTest {
                     (view_type, id, parent, name, enabled, menu_item_order)
                     values(?, ?, ?, ?, ?, ?);
                     """, ViewType.UPNP.value(), 130, MenuItemId.ROOT.value(), "dummy", true, 99);
-
-            assertThatExceptionOfType(NoSuchMessageException.class)
-                    .isThrownBy(() -> menuItemService.getTopMenuItems(ViewType.UPNP));
-
+            for (MenuItemWithDefaultName menuItem : menuItemService.getTopMenuItems(ViewType.UPNP)) {
+                assertNotNull(menuItem.getDefaultName());
+            }
+            menuItemService.ensureUPnPSubMenuEnabled();
             templateWrapper.update("""
                     delete from menu_item where id = 130
                     """);


### PR DESCRIPTION
Prerequisites: #2660

___

This bug fix is ​​a non-functional requirement. If you are not using the development version, you will not experience any issues. This will eliminate glitches that may occur when sharing data between release and development versions.

## Problem description

Problem with the edit function of the menu. If you use the development version and then the release version with the same data, the UPnP menu may not be available. This was fixed in the previous version #2660, but there were some cases that were not taken into consideration.

### Details

UPnP menu items will be added gradually as new versions of Jpsonic are released. In the source code, adding a menu is done in the following steps:

 - A definition is added to the Enum
 - A menu record is added to the DB.
 - The default menu name is added to the resource message

These are not necessarily done at the same time. For example, when trying out a new menu feature in a development branch, records are automatically added to the DB, but if a previous version of Jpsonic is used with the same data later, the previous menu structure needs to be restored.

This pull request is to fix a feature regarding differences in menu behavior between different versions. There was a case where processing was missing for non-existent message resources, but this will be fixed.


