### PR TITLE
Remove player type detection from JSP

### DIFF
--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/search.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/search.jsp
@@ -164,7 +164,7 @@ $(document).ready(function(){
 	                    <c:param name="id" value="${match.id}"/>
 	                    <c:param name="playEnabled" value="${command.user.streamRole and not command.partyModeEnabled}"/>
 	                    <c:param name="addEnabled" value="${command.user.streamRole and (not command.partyModeEnabled or not match.directory)}"/>
-	                    <c:param name="video" value="${match.video and command.player.web}"/>
+	                    <c:param name="video" value="${match.video}"/>
 	                    <c:param name="asTable" value="true"/>
 	                </c:import>
                     <td class="song"><span>${fn:escapeXml(match.title)}</span></td>

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/starred.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/starred.jsp
@@ -275,7 +275,7 @@ function onPlayAll() {
                             <c:param name="addEnabled" value="${model.user.streamRole and not model.partyModeEnabled}"/>
                             <c:param name="starEnabled" value="true"/>
                             <c:param name="starred" value="${not empty video.starredDate}"/>
-                            <c:param name="video" value="${model.player.web}"/>
+                            <c:param name="video" value="true"/>
                             <c:param name="asTable" value="true"/>
                         </c:import>
                         <td><a href="javascript:top.onOpenDialogVideoPlayer('${videoUrl}')">${fn:escapeXml(video.name)}</a></td>


### PR DESCRIPTION
## Problem description

An error occurs on the web page when the content displayed on the search or star page includes video in addition to music.

<img width="982" height="772" alt="image" src="https://github.com/user-attachments/assets/4c2a8fb4-c308-4f66-bab0-10eabbc5a733" />





### Steps to reproduce

Execute a search on the web page that includes videos, or mark a video as a favorite and view it on the star page.

## System information

 * **Jpsonic version**: Since 114.2.0
 * **Client**: Browser 

## Additional notes

This issue was caused by an oversight during a previous functional fix.

In Jpsonic, we are gradually removing outdated implementations to consolidate efforts around improving overall quality. One such obsolete element was the concept of "player type" in the web player.

While most of the player-type-related logic was already removed in earlier updates, part of the web page (JSP) still contained logic that depended on the player type.

Specifically, this related to the play button behavior. In the case of video and music content, the actions triggered by the play button differ. As a result, different buttons were implemented in the JSP depending on the media type.
Previously, the button displayed was determined based on the media type and the selected player type.

However, since the JSP logic was still referencing a player type property that had already been removed, this resulted in a malfunction when video content was involved.


