### PR TITLE
Abandoned

### DIFF
--- a/jpsonic-java17/src/main/java/com/tesshu/jpsonic/util/concurrent/ExecutorConfiguration.java
+++ b/jpsonic-java17/src/main/java/com/tesshu/jpsonic/util/concurrent/ExecutorConfiguration.java
@@ -87,7 +87,7 @@ public class ExecutorConfiguration {
      * task).
      */
     @Bean
-    @DependsOn({ "legacyDaoHelper", "cacheDisposer" })
+    @DependsOn("legacyDaoHelper")
     public AsyncTaskExecutor shortExecutor() {
 
         final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
@@ -112,7 +112,7 @@ public class ExecutorConfiguration {
      * shutdown.
      */
     @Bean
-    @DependsOn({ "legacyDaoHelper", "cacheDisposer" })
+    @DependsOn("legacyDaoHelper")
     public ThreadPoolTaskExecutor podcastDownloadExecutor() {
         final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setWaitForTasksToCompleteOnShutdown(true); // To handle IO
@@ -132,7 +132,7 @@ public class ExecutorConfiguration {
      * shutdown.
      */
     @Bean
-    @DependsOn({ "legacyDaoHelper", "cacheDisposer", "podcastDownloadExecutor" })
+    @DependsOn({ "legacyDaoHelper", "podcastDownloadExecutor" })
     public ThreadPoolTaskExecutor podcastRefreshExecutor() {
         final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setWaitForTasksToCompleteOnShutdown(true); // To call download
@@ -151,7 +151,7 @@ public class ExecutorConfiguration {
      * Scan thread executor. All tasks must be successfully canceled at shutdown.
      */
     @Bean
-    @DependsOn({ "legacyDaoHelper", "cacheDisposer", "podcastRefreshExecutor" })
+    @DependsOn({ "legacyDaoHelper", "podcastRefreshExecutor" })
     public ThreadPoolTaskExecutor scanExecutor() {
         final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setWaitForTasksToCompleteOnShutdown(true); // To handle IO

--- a/jpsonic-java21/src/main/java/com/tesshu/jpsonic/util/concurrent/ExecutorConfiguration.java
+++ b/jpsonic-java21/src/main/java/com/tesshu/jpsonic/util/concurrent/ExecutorConfiguration.java
@@ -74,7 +74,7 @@ public class ExecutorConfiguration {
     }
 
     @Bean
-    @DependsOn({ "legacyDaoHelper", "cacheDisposer" })
+	@DependsOn("legacyDaoHelper")
     public AsyncTaskExecutor shortExecutor() {
         // @see TaskExecutorConfigurations
         // shortExecutor(SimpleAsyncTaskExecutorBuilder builder)
@@ -88,7 +88,7 @@ public class ExecutorConfiguration {
      * Podcast download executor. All tasks must be successfully canceled at shutdown.
      */
     @Bean
-    @DependsOn({ "legacyDaoHelper", "cacheDisposer" })
+    @DependsOn("legacyDaoHelper")
     public ThreadPoolTaskExecutor podcastDownloadExecutor() {
         final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setWaitForTasksToCompleteOnShutdown(true); // To handle IO
@@ -105,7 +105,7 @@ public class ExecutorConfiguration {
      * Podcast refresh executor. All tasks must be successfully canceled at shutdown.
      */
     @Bean
-    @DependsOn({ "legacyDaoHelper", "cacheDisposer", "podcastDownloadExecutor" })
+    @DependsOn({ "legacyDaoHelper", "podcastDownloadExecutor" })
     public ThreadPoolTaskExecutor podcastRefreshExecutor() {
         final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setWaitForTasksToCompleteOnShutdown(true); // To call download
@@ -122,7 +122,7 @@ public class ExecutorConfiguration {
      * Scan thread executor. All tasks must be successfully canceled at shutdown.
      */
     @Bean
-    @DependsOn({ "legacyDaoHelper", "cacheDisposer", "podcastRefreshExecutor" })
+    @DependsOn({ "legacyDaoHelper", "podcastRefreshExecutor" })
     public ThreadPoolTaskExecutor scanExecutor() {
         final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setWaitForTasksToCompleteOnShutdown(true); // To handle IO

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/spring/EhcacheConfiguration.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/spring/EhcacheConfiguration.java
@@ -32,11 +32,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 
 @Configuration
 public class EhcacheConfiguration {
 
     @Bean
+    @DependsOn("mediaScannerService")
     public CacheDisposer cacheDisposer() {
         return new CacheDisposer();
     }


### PR DESCRIPTION

### Summary

Although it did not cause any adverse effects such as data corruption, there was a flaw in the shutdown flow. Will be fixed.

### Probrem Description

Although it is very rare, if you shut down during a scan, the following log may be recorded:

```
2025-11-09 08:49:33.032  WARN --- o.s.s.c.ThreadPoolTaskExecutor           : Timed out while waiting for executor 'scanExecutor' to terminate
2025-11-09 08:49:33.045 ERROR --- jps-scan-task-pool-1                     : An error occurred in the pooling thread.

java.lang.IllegalStateException: The mediaFileMemoryCache Cache is not alive (STATUS_SHUTDOWN)
	at net.sf.ehcache.Cache$CacheStatus.checkAlive(Cache.java:4267) ~[ehcache-core-2.6.11.jar:na]
	at net.sf.ehcache.Cache.checkStatus(Cache.java:2701) ~[ehcache-core-2.6.11.jar:na]
	at net.sf.ehcache.Cache.removeInternal(Cache.java:2320) ~[ehcache-core-2.6.11.jar:na]
	at net.sf.ehcache.Cache.remove(Cache.java:2247) ~[ehcache-core-2.6.11.jar:na]
	at net.sf.ehcache.Cache.remove(Cache.java:2172) ~[ehcache-core-2.6.11.jar:na]
	at com.tesshu.jpsonic.service.MediaFileCache.remove(MediaFileCache.java:75) ~[classes/:114.3.0-SNAPSHOT]
	at com.tesshu.jpsonic.service.scanner.WritableMediaFileService.refreshMediaFile(WritableMediaFileService.java:597) ~[classes/:114.3.0-SNAPSHOT]
	at com.tesshu.jpsonic.service.scanner.WritableMediaFileService.checkLastModified(WritableMediaFileService.java:382) ~[classes/:114.3.0-SNAPSHOT]
	at com.tesshu.jpsonic.service.scanner.WritableMediaFileService.createOrUpdateChild(WritableMediaFileService.java:333) ~[classes/:114.3.0-SNAPSHOT]
	at com.tesshu.jpsonic.service.scanner.WritableMediaFileService.updateChildren(WritableMediaFileService.java:271) ~[classes/:114.3.0-SNAPSHOT]
	at com.tesshu.jpsonic.service.scanner.WritableMediaFileService.getChildrenOf(WritableMediaFileService.java:344) ~[classes/:114.3.0-SNAPSHOT]
	at com.tesshu.jpsonic.service.scanner.DirectoryScanProcedure.scanFile(DirectoryScanProcedure.java:179) ~[classes/:114.3.0-SNAPSHOT]
	at com.tesshu.jpsonic.service.scanner.DirectoryScanProcedure.scanFile(DirectoryScanProcedure.java:185) ~[classes/:114.3.0-SNAPSHOT]
	at com.tesshu.jpsonic.service.scanner.DirectoryScanProcedure.scanFile(DirectoryScanProcedure.java:185) ~[classes/:114.3.0-SNAPSHOT]
	at com.tesshu.jpsonic.service.scanner.DirectoryScanProcedure.lambda$parseFileStructure$0(DirectoryScanProcedure.java:115) ~[classes/:114.3.0-SNAPSHOT]
	at java.base/java.util.Optional.ifPresent(Optional.java:178) ~[na:na]
	at com.tesshu.jpsonic.service.scanner.DirectoryScanProcedure.parseFileStructure(DirectoryScanProcedure.java:115) ~[classes/:114.3.0-SNAPSHOT]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[na:na]
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:360) ~[spring-aop-6.2.12.jar:6.2.12]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:724) ~[spring-aop-6.2.12.jar:6.2.12]
	at com.tesshu.jpsonic.service.scanner.DirectoryScanProcedure$$SpringCGLIB$$0.parseFileStructure(<generated>) ~[classes/:114.3.0-SNAPSHOT]
	at com.tesshu.jpsonic.service.scanner.MediaScannerServiceImpl.doScanLibrary(MediaScannerServiceImpl.java:201) ~[classes/:114.3.0-SNAPSHOT]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[na:na]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[na:na]

2025-11-09 08:49:33.636  INFO --- c.t.j.d.base.LegacyHsqlDaoHelper         : Embedded database shutdown complete.
```
### Description

The expected Shutdown Event Flow is as follows:

```
[Docker container stop signal (SIGTERM)]
│
▼
Spring Boot application shutdown begins
│
▼
ApplicationContext.close() invoked
│
▼
Beans are destroyed in reverse initialization order
│
▼
MediaScannerServiceImpl waits for running tasks
└→ scanExecutor.shutdown() + waitForTasksToCompleteOnShutdown = true
│
▼
MediaScannerServiceImpl destroy completes
│
▼
CacheDisposer @PreDestroy is called
└→ Shuts down Ehcache managers (mediaFileMemoryCache, genreCache, fontCache, randomCache)
│
▼
Remaining beans are destroyed
│
▼
ApplicationContext fully closed
│
▼
Docker container stops
```

Supports Docker's graceful shutdown, and the above process is usually completed within 30 seconds. The current issue is that the timing of CacheDisposer disposal is incorrect due to insufficient dependency specification. As a result, the cache is disposed before the scanning thread has completely stopped, and the log shown at the beginning may be recorded.
