### PR TITLE
Remove NoOpPasswordEncoder

### DIFF
--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/security/GlobalSecurityConfig.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/security/GlobalSecurityConfig.java
@@ -24,14 +24,12 @@ package com.tesshu.jpsonic.security;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.EnumSet;
-import java.util.Map;
 import java.util.Random;
 
 import com.tesshu.jpsonic.controller.Attributes;
 import com.tesshu.jpsonic.service.JWTSecurityService;
 import com.tesshu.jpsonic.service.SecurityService;
 import com.tesshu.jpsonic.service.SettingsService;
-import com.tesshu.jpsonic.util.LegacyMap;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.SessionTrackingMode;
 import org.apache.commons.lang3.StringUtils;
@@ -55,8 +53,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
-import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -78,14 +74,8 @@ public class GlobalSecurityConfig extends GlobalAuthenticationConfigurerAdapter 
     }
 
     @Bean
-    public PasswordEncoder delegatingPasswordEncoder() {
-        PasswordEncoder defaultEncoder = NoOpPasswordEncoder.getInstance();
-        String defaultIdForEncode = "noop";
-        Map<String, PasswordEncoder> encoders = LegacyMap.of(defaultIdForEncode, defaultEncoder);
-        DelegatingPasswordEncoder passworEncoder = new DelegatingPasswordEncoder(defaultIdForEncode,
-                encoders);
-        passworEncoder.setDefaultPasswordEncoderForMatches(defaultEncoder);
-        return passworEncoder;
+    public PasswordEncoder passwordEncoder() {
+        return new PlainTextPasswordEncoder();
     }
 
     @EnableWebSecurity

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/security/PlainTextPasswordEncoder.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/security/PlainTextPasswordEncoder.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Jpsonic.
+ *
+ * Jpsonic is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Jpsonic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * (C) 2025 tesshucom
+ */
+
+package com.tesshu.jpsonic.security;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public class PlainTextPasswordEncoder implements PasswordEncoder {
+
+    @Override
+    public String encode(CharSequence rawPassword) {
+        return rawPassword.toString();
+    }
+
+    @Override
+    public boolean matches(CharSequence rawPassword, String encodedPassword) {
+        return rawPassword.toString().equals(encodedPassword);
+    }
+}


### PR DESCRIPTION
## Summary
- Replaced the legacy `DelegatingPasswordEncoder` with a simple `PlainTextPasswordEncoder` to maintain backward compatibility for existing users.
- Updated `GlobalSecurityConfig` to use the new password encoder.
- Removed unnecessary Airsonic-derived code related to `DelegatingPasswordEncoder`.
- Preserves existing Subsonic ecosystem compatibility while preparing for Spring Boot 4 migration.

## Rationale
- `NoOpPasswordEncoder` is being removed in Spring Security 6 / Boot4.
- Existing passwords in the database must remain valid without introducing Spring-specific encoding.

## Impact
- No functional changes for users.
- Security-wise, passwords remain in plain text, consistent with previous behavior.
- Removes dead / legacy code paths.

## Note

Jpsonic's development policy regarding password strength is as follows:

・The PlainTextPasswordEncoder will be maintained for the time being.
・Measures to improve password strength may be implemented in the future.
・Maintaining an implementation that does not deviate from the Subsonic ecosystem is currently the highest priority.
・Security-related issues are addressed efficiently, focusing on those with the highest importance first.

If you are a user who is not deeply familiar with practical security measures, you might ask an AI a question like the following:

> Please make a judgment at the level of a top security administrator without any speculation:
> 
> (1) Introduce a mechanism to replace NoOpPasswordEncoder with another encoder of higher cryptographic strength.
> (2) Keep the CVE warnings for the entire product, including Docker images, at zero.
> 
> Which has higher value, or which should be prioritized first?

The answer is clear.

Key points for the user's judgment are:

・Enhancing encryption strength improves theoretical security but increases operational and compatibility risks.
・Measures that directly eliminate vulnerabilities have immediate and clear defensive effects.
・Best practice is to prioritize protection of components that are likely to be attacked and affect a wide range of systems.

The current status of Jpsonic is as follows:

・Jpsonic has already achieved zero CVE warnings for Alpine, UBI9, and Ubunts images.
・The password strength issue is deferred, but this ensures zero operational or compatibility risk.
・Jpsonic is currently in a transitional phase for its frameworks and major products. To perform a major upgrade to Spring Boot, it is necessary to remove the NoOpPasswordEncoder, which handles plain-text passwords. However, as a practical solution, Jpsonic continues to maintain a password implementation that does not deviate from the Subsonic ecosystem, prioritizing the transition of the major products.
・Rotating all major product versions simultaneously would be a high-cost change. Many media server development communities cannot perform such updates. Not performing this rotation would not only prevent taking advantage of new technologies, but also significantly increase the risk of CVE warnings due to vulnerabilities.

Taking all these conditions into account, Jpsonic positions encryption-related issues as comparatively low priority.
While the password strength problem is currently deferred, users can take responsibility for improving security as needed.
At the same time, Jpsonic proactively addresses more troublesome issues in advance, ensuring no operational or compatibility risks arise.



