### PR TITLE
Refactor WebServerFactoryCustomizer for Spring Boot 4.x to Maintain Universal Portability

### DIFF
--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -189,6 +189,10 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-web-server</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -696,12 +700,12 @@
             <goals>
               <goal>run</goal>
             </goals>
-            <phase>package</phase>
+            <phase>prepare-package</phase>
             <configuration>
               <target>
                 <delete>
                   <!--This is because *ApplicationHelper may depend on a particular vendor class.　-->
-                  <fileset dir="${project.build.directory}/classes/com/tesshu/jpsonic" includes="${helper.excludes}"></fileset>
+                  <fileset dir="${project.build.directory}/classes/com/tesshu/jpsonic/infrastructure/bootstrap" includes="${helper.excludes}"></fileset>
                 </delete>
               </target>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,11 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-web-server</artifactId>
+        <version>${versions.spring-boot}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.checkerframework</groupId>


### PR DESCRIPTION

### Overview
This PR addresses the modularization changes in Spring Boot 4.x regarding web server customization. It ensures that Jpsonic maintains its core identity: a **"Universal WAR"** that can either run as a standalone executable or be deployed to external containers (Tomcat/Jetty) using a single artifact.

### The "Pitfall" in Spring Boot 4.x
In Spring Boot 4.x, the `WebServerFactoryCustomizer` interface was moved to the separate `spring-boot-web-server` module. This reorganization introduced a critical issue for external WAR deployments:

1.  **Forced Type Introspection**: During the startup process, Spring's `BeanPostProcessor` performs an unconditional type check on all beans. If the interface definition (the JAR) is missing from the classpath, it triggers a `NoClassDefFoundError`, even if the bean is not used in that specific environment.
2.  **Modularization Conflict**: While the framework intends to exclude unused server modules, the internal auto-configuration still expects these types to be present for classpath scanning.

### The Strategy: A Three-Layer Solution

To overcome these framework-level constraints while keeping Jpsonic's deployment "clean," the following measures were implemented:

#### 1. Physical Layer: Promotion of `spring-boot-web-server` to `compile` scope
- Promoted the module from `provided` to `compile` scope.
- This ensures the "Common Dictionary" of web types is always available during runtime, satisfying Spring's introspection and preventing startup failures in external containers.

#### 2. Logic Layer: "Safe Bypass" via Reflection
- Refactored the `Customizer` implementation to use Reflection (`Class.forName`) instead of direct static references for vendor-specific classes (Tomcat/Jetty).
- This allows the code to gracefully skip server-specific logic when those classes are absent, enabling a "safe bypass" without class-loading errors.

#### 3. Build Layer: Relocating Cleanup to `prepare-package` Phase
- Moved the `maven-antrun-plugin` execution (which deletes unnecessary Helper classes) from the `package` phase to the `prepare-package` phase.
- This resolves a race condition—particularly prevalent in WSL/CI environments—where the WAR was being packaged before the physical deletion was completed.

### Conclusion
While this approach involves some tactical "tricks," it is the optimal engineering solution to bridge the gap between Spring Boot 4.x's rigid modularization and Jpsonic's flexible deployment philosophy. It guarantees that Jpsonic remains a truly portable, single-binary solution.

### Technical Notes (Verification Results)

#### 1. Why not use `@ConditionalOnClass`?
While the Logic Layer (Reflection) and Build Layer (Cleanup) could technically be replaced by Spring's `@ConditionalOnClass`, we have intentionally chosen to maintain our current approach. This is to ensure that vendor-specific classes (Tomcat/Jetty) are strictly excluded from the final binary depending on the profile, adhering to Jpsonic's long-standing build philosophy.

#### 2. Behavior in WAR Deployment
It has been confirmed that even when the `Customizer` is executed in a WAR deployment, Spring Boot gracefully ignores any "Embedded Server" specific configurations. Therefore, having the Customizer run in an external container does not cause any functional side effects; it simply "idles" safely.
