### PR TITLE
Update Libs

### DIFF
--- a/airsonic-taglibs/pom.xml
+++ b/airsonic-taglibs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.2.27</version>
+    <version>114.2.28</version>
   </parent>
   <artifactId>airsonic-taglibs</artifactId>
   <name>Airsonic Tag Libs</name>

--- a/install/docker/alpine/pom.xml
+++ b/install/docker/alpine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.2.27</version>
+        <version>114.2.28</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/armv7/pom.xml
+++ b/install/docker/armv7/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.2.27</version>
+        <version>114.2.28</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/jammy/pom.xml
+++ b/install/docker/jammy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.2.27</version>
+        <version>114.2.28</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/noble/pom.xml
+++ b/install/docker/noble/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.2.27</version>
+        <version>114.2.28</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/ubi9/pom.xml
+++ b/install/docker/ubi9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>114.2.27</version>
+        <version>114.2.28</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/jpsonic-concurent17/pom.xml
+++ b/jpsonic-concurent17/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.2.27</version>
+    <version>114.2.28</version>
   </parent>
   <artifactId>jpsonic-concurent17</artifactId>
   <name>Concurent Config for Java17</name>

--- a/jpsonic-concurent21/pom.xml
+++ b/jpsonic-concurent21/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.2.27</version>
+    <version>114.2.28</version>
   </parent>
   <artifactId>jpsonic-concurent21</artifactId>
   <name>Concurent Config for Java21</name>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -627,7 +627,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>3.5.13</version>
+        <version>3.5.14</version>
         <configuration>
           <mainClass>com.tesshu.jpsonic.Application</mainClass>
           <layout>WAR</layout>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.2.27</version>
+    <version>114.2.28</version>
   </parent>
   <artifactId>jpsonic-main</artifactId>
   <packaging>war</packaging>

--- a/jpsonic-upnp-template/pom.xml
+++ b/jpsonic-upnp-template/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.2.27</version>
+    <version>114.2.28</version>
   </parent>
   <artifactId>jpsonic-upnp-template</artifactId>
   <name>Upnp Template</name>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <versions.java-jwt>4.5.1</versions.java-jwt>
     <versions.jaxb-runtime>4.0.7</versions.jaxb-runtime>
     <versions.jdom2>2.0.6.1</versions.jdom2>
-    <versions.jetty>12.0.33</versions.jetty>
+    <versions.jetty>12.0.34</versions.jetty>
     <versions.jfreechart>1.5.6</versions.jfreechart>
     <versions.junit-jupiter-api>5.13.4</versions.junit-jupiter-api>
     <versions.junit-jupiter-engine>5.7.1</versions.junit-jupiter-engine>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <versions.log4j>2.25.4</versions.log4j>
     <versions.logback>1.5.32</versions.logback>
     <versions.lucene>9.11.1</versions.lucene>
-    <versions.maven-artifact>3.9.14</versions.maven-artifact>
+    <versions.maven-artifact>3.9.15</versions.maven-artifact>
     <versions.mockito-junit-jupiter>5.20.0</versions.mockito-junit-jupiter>
     <versions.moxy>4.0.9</versions.moxy>
     <versions.mysql-connector-j>9.6.0</versions.mysql-connector-j>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tesshu.jpsonic.player</groupId>
   <artifactId>jpsonic</artifactId>
-  <version>114.2.27</version>
+  <version>114.2.28</version>
   <packaging>pom</packaging>
   <name>Jpsonic</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,9 +80,9 @@
     <versions.postgresql>42.7.10</versions.postgresql>
     <versions.recaptcha>1.0.4</versions.recaptcha>
     <versions.spotbugs>4.9.8</versions.spotbugs>
-    <versions.spring-boot>3.5.13</versions.spring-boot>
-    <versions.spring-framework>6.2.17</versions.spring-framework>
-    <versions.spring-security>6.5.9</versions.spring-security>
+    <versions.spring-boot>3.5.14</versions.spring-boot>
+    <versions.spring-framework>6.2.18</versions.spring-framework>
+    <versions.spring-security>6.5.10</versions.spring-security>
     <versions.stax-ex>2.1.0</versions.stax-ex>
     <versions.tika>3.3.0</versions.tika>
     <versions.tomcat>10.1.54</versions.tomcat>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <versions.maven-artifact>3.9.14</versions.maven-artifact>
     <versions.mockito-junit-jupiter>5.20.0</versions.mockito-junit-jupiter>
     <versions.moxy>4.0.9</versions.moxy>
-    <versions.mysql-connector-j>9.6.0</versions.mysql-connector-j>
+    <versions.mysql-connector-j>9.7.0</versions.mysql-connector-j>
     <versions.netty>4.1.127.Final</versions.netty>
     <versions.os-platform-finder>1.1</versions.os-platform-finder>
     <versions.pgjdbc-ng>0.8.9</versions.pgjdbc-ng>

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>114.2.27</version>
+    <version>114.2.28</version>
   </parent>
   <artifactId>subsonic-rest-api</artifactId>
   <name>Subsonic REST API</name>


### PR DESCRIPTION
Regular patch updates for libraries and Docker images.

## 🐥 Maintenance

No Jpsonic‑related security issues were found. 

However, [CVE-2026-22020](https://bugzilla.redhat.com/show_bug.cgi?id=2460045) has been reported in the latest-ubi-9 (Red Hat) Docker image. Details of CVE-2026-22020 have not been publicly disclosed. It is already marked as fixed in Java 21.0.11 and 25.0.3, so a fix is expected to be available soon. It is recommended to use the **latest** (Alpine) or **latest-noble** (Ubuntu) images instead.

## 🛡️ Vulnerabilities

<img width="492" height="745" alt="image" src="https://github.com/user-attachments/assets/a23d3178-40d5-4fbb-a5fb-a4e106a0f036" />





