### PR TITLE
Fix production.windows.yml

### DIFF
--- a/install/docker/production.windows.yml
+++ b/install/docker/production.windows.yml
@@ -1,50 +1,91 @@
-# 
-# This is a JPSONIC boot configuration sample in Windows or in Mac or in Linux without UPnP.
+#
+# This is a JPSONIC boot configuration sample in Windows.
 # You can easily start Jpsonic by changing the volume, port and so on.
 #
-# usege: 
+# usage: 
+#   docker compose -f production.windows.yml up -d
+#   or
 #   docker-compose -f production.windows.yml up -d
 #
+# Please note that the commands may differ
+# depending on the version of Docker you are using.
+# https://docs.docker.com/compose/migrate/
+#
+# [Note for Windows Users]
+# 1. Path: Docker can't interpret UNC paths directly.
+#    NAS mounting is technically possible but impractical for most users.
+# 2. I/O: Desperately slow due to the 9P protocol overhead on Windows.
+# 3. Network: Host mode is unavailable. UDP/UPnP features will not work.
+#
+# @since 114.2.0
+#
 
-version: '3.9'
 services:
   app:
     image: 'jpsonic/jpsonic:latest'
     container_name: 'jpsonic'
 
-    # The host networking driver only works on Linux hosts,
-    # and is not supported on Docker Desktop for Mac Docker Desktop for Windows,
-    # or Docker EE for Windows Server.
-    # https://docs.docker.com/network/host/
-    network_mode: 'bridge'
-    hostname: 'jpsonic'
+    # Not required. However, if you specify, please specify the correct name.
+    # hostname: 'WinLocal'
 
-    # <host>:<internal>
-    # Please set "the port of host" properly.
-    ports:
+    # This image is automatically updated by watchtower.
+    # See docker-compose.watchtower.yml
+    labels:
+     - "com.centurylinklabs.watchtower.enable=true"
 
-     # Port for Jpsonic. 
-     - '8080:4040'
-
-     # Port for JMX. The "ea" tag image is required to use JMX.
-     # - 3333:3333
-
-    pid: host
     volumes:
      # <host>:<internal>
      # Please rewrite "the path of host" appropriately.
-     - '/c/tmp/jpsonic/data:/jpsonic/data'
-     - '/c/tmp/jpsonic/music:/jpsonic/music'
-     - '/c/tmp/jpsonic/podcasts:/jpsonic/podcasts'
-     - '/c/tmp/jpsonic/playlists:/jpsonic/playlists'
+     - 'C:/jpsonic:/jpsonic/data'
+     - 'C:/Music:/jpsonic/music'
+     - 'C:/Podcasts:/jpsonic/podcasts'
+     - 'C:/Playlists:/jpsonic/playlists'
 
-    # If the UID/GUI is not correct, Jpsonic will not start.
-    # If you need to check the permissions of the data directory,
-    # rewrite the entrypoint and check it.
-    # 
-    # entrypoint: ls -n /jpsonic/data
+    # If you want to add a large number of music folders, add more volumes.
+    # Please add <internal> from Settings pages as Music foldres after login.
+    #
+    # - 'C:/Music2:/jpsonic/music2'
+    # - 'C:/Music3:/jpsonic/music3'
+
+    # If you use Audiobook,
+    # we recommend that you include the audiobook string in the entry path.
+    # In Subsonic's direct lineage servers, it is used for shuffle exclusion, etc.
+    # In Jpsonic, you can separate music and audiobook genres (with UPnP).
+    #
+    # - 'C:/SomeDir:/jpsonic/audiobook'
+
+    # Jpsonic container is limited to 1Gb so that it can run on DS220+'s standard memory.
+    # Please change this depending on the number of songs in your library.
+    # Note that you need to change both Java and Docker memory settings.
+    #
+    # ---------------------------------------------------------
+    # Songs count    Java(Xms, Xmx)  Docker(mem_limit)
+    # 70K            512m            896m
+    # 100K           640m            1024m
+    # 130K           768m            1152m
+    # 200K           1024m           1.5g
+    # 300K           1280m           1.75g
+    # 400K           1536m           2g
+    # ---------------------------------------------------------
+    mem_limit: 1024m
 
     environment:
+     # Specify the appropriate Java options.
+     #
+     # When using a CPU with lower performance than DS220+(Intel Celeron J4025),
+     # please remove the -XX:+UseG1GC Option. Or specify -XX:+UseSerialGC.
+     # Jpsonic has been tested for both Serial GC and G1 GC.
+
+     JAVA_OPTS: >
+       -Xms640m
+       -Xmx640m
+       -XX:+UseG1GC
+       -XX:MaxGCPauseMillis=500
+
+     # Set the jpsonic and upnp ports.
+     # Containers share the host networking name space,
+     # so be careful not to overlap with existing ports.
+     JPSONIC_PORT: &port "4040"
 
      # Set the appropriate UID/GID.
      USER_ID: '0'
@@ -56,41 +97,63 @@ services:
      # Jpsonic context path.
      CONTEXT_PATH: '/'
 
+     # Advanced Options ###############################################
+
      # Whether to log the logo at startup. [OFF|CONSOLE|LOG]
-     BANNER_MODE: 'OFF'
+     #
+     #BANNER_MODE: 'OFF'
 
      # Granularity of output logs. [ERROR|WARN|INFO|DEBUG|TRACE]
-     LOG_LEVEL: 'WARN'
+     #
+     #LOG_LEVEL: 'WARN'
 
      # Whether to scan at startup. False is recommended for Docker.
-     SCAN_ON_BOOT: 'false'
+     #
+     #SCAN_ON_BOOT: 'false'
 
      # If false, use the logical font of JRE (JDK) for Cover Art.
      # If true, preferentially use embedded fonts.
-     EMBEDDED_FONT: 'false'
+     #
+     #EMBEDDED_FONT: 'false'
 
      # You can override the MIME of DSD according to your device.
-     MIME_DSF: 'audio/x-dsd'
-     MIME_DFF: 'audio/x-dsd'
+     #
+     #MIME_DSF: 'audio/x-dsd'
+     #MIME_DFF: 'audio/x-dsd'
 
-     # Specify the appropriate Java options.
-     # Currently, Jpsonic will not require extremely large memory.
-     # If you are using 32 bit OS please specify -Xmx256m
-     JAVA_OPTS: '-Xmx512m'
-
-     #　Option example when using JMX. The "ea" tag image is required to use JMX.
-     #　For VisualVM, you need to specify the port in File-Add JMX Connection.
-     #　e.g. localhost:3333
-     #　
+     # Option example when using JMX. The "ea" tag image is required to use JMX.
+     # Note that port 3333 is free on "ea" !!
+     # For VisualVM, you need to specify the port in File-Add JMX Connection.
+     # e.g. localhost:3333
+     #
      #JAVA_OPTS: >
+     #  -Xms512m
      #  -Xmx512m
-     #  -Dcom.sun.management.jmxremote
+     #  -XX:+UseG1GC
+     #  -XX:MaxGCPauseMillis=500
+     #  -Dcom.sun.management.jmxremote=true
      #  -Dcom.sun.management.jmxremote.port=3333
      #  -Dcom.sun.management.jmxremote.rmi.port=3333
      #  -Dcom.sun.management.jmxremote.local.only=false
      #  -Dcom.sun.management.jmxremote.ssl=false
      #  -Dcom.sun.management.jmxremote.authenticate=false
-     #  -Djava.rmi.server.hostname=localhost
+     #  -Djava.rmi.server.hostname=SynologyNAS
+
+     # It is possible to override some of the UPnP server parameters.
+     # Synology DS220+ and general network spec are assumed.
+     # If Timout occurs during UPnP Browsing, consider increasing these values.
+     # https://docs.oracle.com/en/java/javase/21/docs/api/jdk.httpserver/module-summary.html
+     # Please note that these apply only to UPnP communication.
+     # Communication of images and media files is not controlled.
+     #
+     #UPNP_IDLE_INTERVAL: '30'
+     #UPNP_MAX_CONNECTIONS: '50'
+     #UPNP_MAX_IDLE_CONNECTIONS: '30'
+     #UPNP_DRAIN_AMOUNT: '65536'
+     #UPNP_MAX_REQ_HEADERS: '200'
+     #UPNP_MAX_REQ_TIME: '500'
+     #UPNP_MAX_RSP_TIME: '500'
+     #UPNP_NODELAY: 'true'
 
     # Usually no need to change.
     # Unlike other Sonic servers, Jpsonic has a graceful shutdown implemented.
@@ -99,3 +162,8 @@ services:
     # there may be a wait time of up to 30 seconds to protect data.
      TINI_SUBREAPER: 'true'
     stop_grace_period: '30s'
+
+    # Please do not change it.
+    ports:
+      - target: *port
+        published: *port

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DLNASettingsController.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/DLNASettingsController.java
@@ -126,6 +126,7 @@ public class DLNASettingsController {
         // UPnP basic settings
 
         command.setDlnaEnabled(settingsFacade.get(UPnPSKeys.basic.enabled));
+        command.setWsl(EnvironmentProvider.getInstance().isWsl());
         command.setDlnaServerName(settingsFacade.get(UPnPSKeys.basic.serverName));
         command.setDlnaBaseLANURL(settingsFacade.get(UPnPSKeys.basic.baseLanUrl));
         command.setAllMusicFolders(musicFolderService.getAllMusicFolders());

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/form/DLNASettingsCommand.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/controller/form/DLNASettingsCommand.java
@@ -35,6 +35,7 @@ public class DLNASettingsCommand extends SettingsPageCommons {
 
     // UPnP basic settings
     private boolean dlnaEnabled;
+    private boolean wsl;
     private String dlnaServerName;
     private String dlnaBaseLANURL;
     private List<MusicFolder> allMusicFolders;
@@ -73,6 +74,14 @@ public class DLNASettingsCommand extends SettingsPageCommons {
 
     public void setDlnaEnabled(boolean dlnaEnabled) {
         this.dlnaEnabled = dlnaEnabled;
+    }
+
+    public boolean isWsl() {
+        return wsl;
+    }
+
+    public void setWsl(boolean wsl) {
+        this.wsl = wsl;
     }
 
     public String getDlnaServerName() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/infrastructure/core/EnvironmentProvider.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/infrastructure/core/EnvironmentProvider.java
@@ -27,6 +27,7 @@ import java.nio.charset.Charset;
 import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Locale;
@@ -120,6 +121,21 @@ public class EnvironmentProvider {
 
     public boolean isWindows() {
         return SystemUtils.IS_OS_WINDOWS;
+    }
+
+    public boolean isWsl() {
+        // 1. Fast check: WSL-specific runtime directory
+        if (Files.exists(Path.of("/run/WSL"))) {
+            return true;
+        }
+
+        // 2. Fallback: Parse kernel version string
+        try {
+            String version = Files.readString(Paths.get("/proc/version")).toLowerCase(Locale.ROOT);
+            return version.contains("microsoft") || version.contains("wsl");
+        } catch (IOException e) {
+            return false;
+        }
     }
 
     public String getOsName() {

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/infrastructure/filesystem/FileNameSanitizer.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/infrastructure/filesystem/FileNameSanitizer.java
@@ -46,9 +46,16 @@ public class FileNameSanitizer {
      *         are removed or replaced.
      */
     public static String sanitize(final String filename) {
-        String result = filename;
+        // Trim trailing dots
+        int end = filename.length();
+        while (end > 0 && filename.charAt(end - 1) == '.') {
+            end--;
+        }
+        String result = (end == filename.length()) ? filename : filename.substring(0, end);
+
+        // replace all unsafe characters
         for (String s : FILE_SYSTEM_UNSAFE) {
-            result = result.replaceAll("\\.$", "").replace(s, "-");
+            result = result.replace(s, "-");
         }
         return result;
     }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/infrastructure/filesystem/MediaTypeDetector.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/infrastructure/filesystem/MediaTypeDetector.java
@@ -19,7 +19,12 @@
 
 package com.tesshu.jpsonic.infrastructure.filesystem;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.tesshu.jpsonic.infrastructure.core.EnvironmentProvider;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Utility for mapping file extensions to MIME types and vice versa.
@@ -29,24 +34,67 @@ import com.tesshu.jpsonic.infrastructure.core.EnvironmentProvider;
  * image formats.
  * </p>
  */
+@SuppressWarnings("PMD.UseConcurrentHashMap")
 public final class MediaTypeDetector {
 
-    private static final String MIME_MP4 = "audio/mp4";
-    private static final String[][] MIME_TYPES = { { "mp3", "audio/mpeg" }, { "ogg", "audio/ogg" },
-            { "oga", "audio/ogg" }, { "opus", "audio/ogg" }, { "ogx", "application/ogg" },
-            { "aac", MIME_MP4 }, { "m4a", MIME_MP4 }, { "m4b", MIME_MP4 }, { "flac", "audio/flac" },
-            { "wav", "audio/x-wav" }, { "wma", "audio/x-ms-wma" },
-            { "ape", "audio/x-monkeys-audio" }, { "mpc", "audio/x-musepack" },
-            { "shn", "audio/x-shn" }, { "dsf", EnvironmentProvider.getInstance().getMemeDsf() },
-            { "dff", EnvironmentProvider.getInstance().getMemeDff() }, { "flv", "video/x-flv" },
-            { "avi", "video/avi" }, { "mpg", "video/mpeg" }, { "mpeg", "video/mpeg" },
-            { "mp4", "video/mp4" }, { "m4v", "video/x-m4v" }, { "mkv", "video/x-matroska" },
-            { "mov", "video/quicktime" }, { "wmv", "video/x-ms-wmv" }, { "ogv", "video/ogg" },
-            { "divx", "video/divx" }, { "m2ts", "video/MP2T" }, { "ts", "video/MP2T" },
-            { "webm", "video/webm" },
+    private static final Map<String, String> EXT_TO_MIME;
+    private static final Map<String, String> MIME_TO_EXT;
 
-            { "gif", "image/gif" }, { "jpg", "image/jpeg" }, { "jpeg", "image/jpeg" },
-            { "png", "image/png" }, { "bmp", "image/bmp" }, };
+    static {
+
+        final String mimeMp4 = "audio/mp4";
+        final String[][] rawData = {
+                // spotless:off
+                { "mp3", "audio/mpeg" },
+                { "ogg", "audio/ogg" },
+                { "oga", "audio/ogg" },
+                { "opus", "audio/ogg" },
+                { "ogx", "application/ogg" },
+                { "aac", mimeMp4 },
+                { "m4a", mimeMp4 },
+                { "m4b", mimeMp4 },
+                { "flac", "audio/flac" },
+                { "wav", "audio/x-wav" }, 
+                { "wma", "audio/x-ms-wma" },
+                { "ape", "audio/x-monkeys-audio" },
+                { "mpc", "audio/x-musepack" },
+                { "shn", "audio/x-shn" },
+                { "dsf", EnvironmentProvider.getInstance().getMemeDsf() },
+                { "dff", EnvironmentProvider.getInstance().getMemeDff() },
+                { "flv", "video/x-flv" },
+                { "avi", "video/avi" },
+                { "mpg", "video/mpeg" },
+                { "mpeg", "video/mpeg" },
+                { "mp4", "video/mp4" },
+                { "m4v", "video/x-m4v" },
+                { "mkv", "video/x-matroska" },
+                { "mov", "video/quicktime" },
+                { "wmv", "video/x-ms-wmv" },
+                { "ogv", "video/ogg" },
+                { "divx", "video/divx" },
+                { "m2ts", "video/MP2T" },
+                { "ts", "video/MP2T" },
+                { "webm", "video/webm" },
+        
+                { "gif", "image/gif" },
+                { "jpg", "image/jpeg" },
+                { "jpeg", "image/jpeg" },
+                { "png", "image/png" },
+                { "bmp", "image/bmp" }
+                };
+                // spotless:on
+
+        Map<String, String> e2m = new HashMap<>(rawData.length * 2);
+        Map<String, String> m2e = new HashMap<>(rawData.length * 2);
+        for (String[] entry : rawData) {
+            String ext = entry[0];
+            String mime = entry[1];
+            e2m.put(ext, mime);
+            m2e.putIfAbsent(mime, ext);
+        }
+        EXT_TO_MIME = Map.copyOf(e2m);
+        MIME_TO_EXT = Map.copyOf(m2e);
+    }
 
     private MediaTypeDetector() {
         // no-op
@@ -63,20 +111,13 @@ public final class MediaTypeDetector {
      * @return The corresponding MIME type, or "application/octet-stream" if no
      *         match is found.
      */
-    public static String getMimeType(String suffix) {
-        for (String[] typeAndValue : MIME_TYPES) {
-            String type = typeAndValue[0];
-            String value = typeAndValue[1];
-            if (type.equalsIgnoreCase(suffix)) {
-                return value;
-            } else {
-                String typeWithDot = '.' + type;
-                if (typeWithDot.equalsIgnoreCase(suffix)) {
-                    return typeAndValue[1];
-                }
-            }
+    public static @NonNull String getMimeType(String suffix) {
+        if (suffix == null) {
+            return "application/octet-stream";
         }
-        return "application/octet-stream";
+        // Pure O(1) lookup. No allocation, no casing logic, no redundancy.
+        String mime = EXT_TO_MIME.get(suffix);
+        return (mime != null) ? mime : "application/octet-stream";
     }
 
     /**
@@ -86,12 +127,10 @@ public final class MediaTypeDetector {
      * @return The canonical extension without a dot (e.g., "mp3"), or null if
      *         unknown.
      */
-    public static String getSuffix(String mimeType) {
-        for (String[] map : MIME_TYPES) {
-            if (map[1].equalsIgnoreCase(mimeType)) {
-                return map[0];
-            }
+    public static @Nullable String getSuffix(String mimeType) {
+        if (mimeType == null) {
+            return null;
         }
-        return null;
+        return MIME_TO_EXT.get(mimeType);
     }
 }

--- a/jpsonic-main/src/main/java/com/tesshu/jpsonic/infrastructure/filesystem/ScanningExclusionPolicy.java
+++ b/jpsonic-main/src/main/java/com/tesshu/jpsonic/infrastructure/filesystem/ScanningExclusionPolicy.java
@@ -21,7 +21,9 @@ package com.tesshu.jpsonic.infrastructure.filesystem;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import com.tesshu.jpsonic.infrastructure.settings.SettingsFacade;
@@ -51,9 +53,15 @@ public class ScanningExclusionPolicy {
      *      "https://kb.synology.com/en-in/DSM/help/FileStation/connect?version=7">Synology
      *      Knowledge Base:Remote Connection</a>
      */
-    private static final List<String> SYNOLOGY_RESERVED_WORDS = List
-        .of("._", ".SYNOPPSDB", ".DS_Store", "@eaDir", "@sharebin", "@tmp",
-                ".SynologyWorkingDirectory");
+    private static final Set<String> SYNOLOGY_SET;
+
+    static {
+        final List<String> synologyReservedWords = List
+            .of("._", ".SYNOPPSDB", ".DS_Store", "@eaDir", "@sharebin", "@tmp",
+                    ".SynologyWorkingDirectory");
+        Set<String> set = new HashSet<>(synologyReservedWords);
+        SYNOLOGY_SET = Set.copyOf(set);
+    }
 
     private final SettingsFacade settingsFacade;
 
@@ -80,33 +88,24 @@ public class ScanningExclusionPolicy {
      */
     @SuppressWarnings("PMD.SimplifyBooleanReturns")
     public boolean isExcluded(Path path) {
-        if (settingsFacade.get(FileSystemSKeys.ignoreSymlinks) && Files.isSymbolicLink(path)) {
-            LOG.info("Excluding symbolic link %s".formatted(path));
-            return true;
-        }
-
         Path fileName = path.getFileName();
         if (fileName == null) {
             return true;
         }
-
-        // Exclude those that match a user-specified pattern
         String name = fileName.toString();
-        Pattern excludePattern = settingsFacade
-            .getCachedPattern(FileSystemSKeys.excludePatternString);
-        if (excludePattern != null && excludePattern.matcher(name).matches()) {
-            LOG
-                .info("Excluding file which matches exclude pattern %s : %s"
-                    .formatted(settingsFacade.get(FileSystemSKeys.excludePatternString), path));
-            return true;
-        }
 
-        // Exclude all hidden files starting with a single "."
         if (name.charAt(0) == '.' && !name.startsWith("..")) {
             return true;
         }
 
-        // Exclude files end with a dot (Windows prohibitions)
+        if ("Thumbs.db".equals(name)) {
+            return true;
+        }
+
+        if (SYNOLOGY_SET.contains(name)) {
+            return true;
+        }
+
         if (name.endsWith(".")) {
             LOG.warn("""
                     Excluding files ending with Dot. \
@@ -116,12 +115,20 @@ public class ScanningExclusionPolicy {
             return true;
         }
 
-        // Exclude Thumbnail on Windows
-        if ("Thumbs.db".equals(name)) {
+        Pattern excludePattern = settingsFacade
+            .getCachedPattern(FileSystemSKeys.excludePatternString);
+        if (excludePattern != null && excludePattern.matcher(name).matches()) {
+            LOG
+                .info("Excluding file which matches exclude pattern %s : %s"
+                    .formatted(settingsFacade.get(FileSystemSKeys.excludePatternString), path));
             return true;
         }
 
-        // Exclude files or dir created on Synology devices
-        return SYNOLOGY_RESERVED_WORDS.stream().anyMatch(name::equals);
+        if (settingsFacade.get(FileSystemSKeys.ignoreSymlinks) && Files.isSymbolicLink(path)) {
+            LOG.info("Excluding symbolic link %s".formatted(path));
+            return true;
+        }
+
+        return false;
     }
 }

--- a/jpsonic-main/src/main/resources/com/tesshu/jpsonic/feature/i18n/ResourceBundle_en.properties
+++ b/jpsonic-main/src/main/resources/com/tesshu/jpsonic/feature/i18n/ResourceBundle_en.properties
@@ -186,6 +186,7 @@ dlnasettings.submenuoutline                     = You can change what is display
 dlnasettings.uriwithfileextensions              = Add extension to the address of the song
 dlnasettings.view                               = Items to display
 dlnasettings.viewopt                            = Display options
+dlnasettings.wsl                                = UPnP is unavailable in your current environment.
 
 edittags.album         = Album
 edittags.artist        = Artist

--- a/jpsonic-main/src/main/resources/com/tesshu/jpsonic/feature/i18n/ResourceBundle_ja_JP.properties
+++ b/jpsonic-main/src/main/resources/com/tesshu/jpsonic/feature/i18n/ResourceBundle_ja_JP.properties
@@ -187,6 +187,7 @@ dlnasettings.submenuoutline                     = \u30E1\u30CB\u30E5\u30FC\u306B
 dlnasettings.uriwithfileextensions              = \u697D\u66F2\u306E\u30A2\u30C9\u30EC\u30B9\u306B\u62E1\u5F35\u5B50\u3092\u4ED8\u4E0E
 dlnasettings.view                               = \u8868\u793A\u3059\u308B\u9805\u76EE
 dlnasettings.viewopt                            = \u8868\u793A\u306E\u30AA\u30D7\u30B7\u30E7\u30F3
+dlnasettings.wsl                                = \u3054\u4F7F\u7528\u4E2D\u306E\u74B0\u5883\u3067\u306FUPnP\u306F\u4ED5\u69D8\u3067\u304D\u307E\u305B\u3093
 
 edittags.album         = \u30A2\u30EB\u30D0\u30E0
 edittags.artist        = \u30A2\u30FC\u30C6\u30A3\u30B9\u30C8

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/dlnaSettings.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/dlnaSettings.jsp
@@ -96,6 +96,9 @@
                 <form:checkbox path="dlnaEnabled" id="dlnaEnabled"/>
                 <label for="dlnaEnabled"><fmt:message key="dlnasettings.enabled"/></label>
                 <c:import url="helpToolTip.jsp"><c:param name="topic" value="dlnaenable"/></c:import>
+                <c:if test="${command.wsl}">
+                    <strong><fmt:message key="dlnasettings.wsl"/></strong>
+                </c:if>
             </dd>
             <dt><fmt:message key="dlnasettings.servername"/></dt>
             <dd>

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/infrastructure/filesystem/FileNameSanitizerTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/infrastructure/filesystem/FileNameSanitizerTest.java
@@ -34,4 +34,27 @@ class FileNameSanitizerTest {
         assertEquals("foo-bar", FileNameSanitizer.sanitize("foo\\bar"));
         assertEquals("foo-bar", FileNameSanitizer.sanitize("foo:bar"));
     }
+
+    @Test
+    void sanitizeShouldEnsureCrossPlatformCompatibility() {
+        // [Case 1] Standard replacement of OS-unsafe characters (e.g., Colon)
+        assertEquals("Artist-Album", FileNameSanitizer.sanitize("Artist:Album"),
+                "Should replace colons with hyphens for cross-platform safety.");
+
+        // [Case 2] Multiple different unsafe characters in a single name
+        assertEquals("What-s-Next-", FileNameSanitizer.sanitize("What?s*Next|"),
+                "Should handle multiple different unsafe characters.");
+
+        // [Case 3] Single trailing dot removal
+        assertEquals("Space Oddity", FileNameSanitizer.sanitize("Space Oddity."),
+                "Should remove a single trailing dot.");
+
+        // [Case 4] Multiple trailing dots removal (New implementation check)
+        assertEquals("Extreme-Condition", FileNameSanitizer.sanitize("Extreme:Condition..."),
+                "Should remove all consecutive trailing dots in one pass.");
+
+        // [Case 5] Internal dots should be preserved
+        assertEquals("Track.01", FileNameSanitizer.sanitize("Track.01"),
+                "Should preserve dots that are not at the end of the filename.");
+    }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/infrastructure/filesystem/MediaTypeDetectorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/infrastructure/filesystem/MediaTypeDetectorTest.java
@@ -20,9 +20,11 @@
 package com.tesshu.jpsonic.infrastructure.filesystem;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class MediaTypeDetectorTest {
 
     @Test
@@ -33,5 +35,26 @@ class MediaTypeDetectorTest {
         assertEquals("application/octet-stream", MediaTypeDetector.getMimeType("koko"));
         assertEquals("application/octet-stream", MediaTypeDetector.getMimeType(""));
         assertEquals("application/octet-stream", MediaTypeDetector.getMimeType(null));
+    }
+
+    @Test
+    void testGetMimeTypeShouldResolveCorrectly() {
+        // Test for MediaTypeDetector to ensure O(1) lookups and G1GC-friendly behavior.
+        assertEquals("audio/mpeg", MediaTypeDetector.getMimeType("mp3"));
+        assertEquals("audio/flac", MediaTypeDetector.getMimeType("flac"));
+        assertEquals("video/mp4", MediaTypeDetector.getMimeType("mp4"));
+        assertEquals("video/x-matroska", MediaTypeDetector.getMimeType("mkv"));
+        assertEquals("image/jpeg", MediaTypeDetector.getMimeType("jpg"));
+        assertEquals("application/octet-stream", MediaTypeDetector.getMimeType("unknown"));
+        assertEquals("application/octet-stream", MediaTypeDetector.getMimeType(""));
+        assertEquals("application/octet-stream", MediaTypeDetector.getMimeType(null));
+    }
+
+    @Test
+    void testGetSuffixShouldResolveCanonicalExtension() {
+        assertEquals("mp3", MediaTypeDetector.getSuffix("audio/mpeg"));
+        assertEquals("aac", MediaTypeDetector.getSuffix("audio/mp4"));
+        assertNull(MediaTypeDetector.getSuffix("application/pdf"));
+        assertNull(MediaTypeDetector.getSuffix(null));
     }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/infrastructure/filesystem/MediaTypeDetectorTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/infrastructure/filesystem/MediaTypeDetectorTest.java
@@ -20,6 +20,7 @@
 package com.tesshu.jpsonic.infrastructure.filesystem;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
@@ -30,11 +31,13 @@ class MediaTypeDetectorTest {
     @Test
     void testGetMimeType() {
         assertEquals("audio/mpeg", MediaTypeDetector.getMimeType("mp3"));
-        assertEquals("audio/mpeg", MediaTypeDetector.getMimeType(".mp3"));
-        assertEquals("audio/mpeg", MediaTypeDetector.getMimeType(".MP3"));
         assertEquals("application/octet-stream", MediaTypeDetector.getMimeType("koko"));
         assertEquals("application/octet-stream", MediaTypeDetector.getMimeType(""));
         assertEquals("application/octet-stream", MediaTypeDetector.getMimeType(null));
+
+        // The only input value is the return value of PathInspector#getExtension.
+        assertNotEquals("audio/mpeg", MediaTypeDetector.getMimeType(".MP3"));
+        assertNotEquals("audio/mpeg", MediaTypeDetector.getMimeType(".mp3"));
     }
 
     @Test

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/infrastructure/filesystem/RootPathEntryGuardTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/infrastructure/filesystem/RootPathEntryGuardTest.java
@@ -149,4 +149,38 @@ class RootPathEntryGuardTest {
             assertTrue(RootPathEntryGuard.validateFolderPath("\\\\192.168.1.1\\shared").isEmpty());
         }
     }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    void validateFolderPathShouldStrictlyRejectRelativeAndRootOnlyPathsOnWin() {
+        // [Case 1] Drive letter only (considered as a relative path in NIO)
+        assertFalse(RootPathEntryGuard.validateFolderPath("C:").isPresent(),
+                "Should reject relative drive-letter-only paths.");
+
+        // [Case 2] Single root only (getFileName() returns null)
+        assertFalse(RootPathEntryGuard.validateFolderPath("C:\\").isPresent(),
+                "Should reject root-only paths to enforce directory-level management.");
+
+        // [Case 3] Valid absolute directory path
+        assertTrue(RootPathEntryGuard.validateFolderPath("C:\\Music").isPresent(),
+                "Should accept valid absolute Windows paths.");
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void validateFolderPathShouldStrictlyRejectRelativeAndRootOnlyPathsOnLinux() {
+        // [Case 1] Simple relative path
+        assertTrue(RootPathEntryGuard.validateFolderPath("music/rock").isPresent(), """
+                Relative paths are not explicitly prohibited at this stage;
+                verification is deferred to downstream physical existence checks.
+                """);
+
+        // [Case 2] POSIX Root only (getFileName() returns null)
+        assertFalse(RootPathEntryGuard.validateFolderPath("/").isPresent(),
+                "Should reject root-only paths.");
+
+        // [Case 3] Valid absolute directory path
+        assertTrue(RootPathEntryGuard.validateFolderPath("/home/user/music").isPresent(),
+                "Should accept valid absolute POSIX paths.");
+    }
 }

--- a/jpsonic-main/src/test/java/com/tesshu/jpsonic/infrastructure/filesystem/ScanningExclusionPolicyTest.java
+++ b/jpsonic-main/src/test/java/com/tesshu/jpsonic/infrastructure/filesystem/ScanningExclusionPolicyTest.java
@@ -28,7 +28,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import com.tesshu.jpsonic.infrastructure.settings.SKeys;
 import com.tesshu.jpsonic.infrastructure.settings.SettingsFacade;
 import com.tesshu.jpsonic.infrastructure.settings.SettingsFacadeBuilder;
 import org.junit.Ignore;
@@ -135,6 +134,59 @@ class ScanningExclusionPolicyTest {
         assertTrue(exclusionPolicy.isExcluded(Path.of("@sharebin")));
         assertTrue(exclusionPolicy.isExcluded(Path.of("@tmp")));
         assertTrue(exclusionPolicy.isExcluded(Path.of(".SynologyWorkingDirectory")));
+    }
+
+    @Test
+    void isExcludedShouldExcludeHiddenFiles() {
+        // [Case] Standard hidden files (dot-prefix)
+        assertTrue(exclusionPolicy.isExcluded(Path.of("/music/.hidden_folder")));
+        assertTrue(exclusionPolicy.isExcluded(Path.of("/music/.DSStore")));
+
+        // [Case] Normal files should NOT be excluded
+        assertFalse(exclusionPolicy.isExcluded(Path.of("/music/album/song.mp3")));
+    }
+
+    @Test
+    void isExcludedShouldExcludeReservedNames() {
+        // [Case] Windows specific thumbnail
+        assertTrue(exclusionPolicy.isExcluded(Path.of("/music/Thumbs.db")));
+
+        // [Case] Synology specific metadata
+        assertTrue(exclusionPolicy.isExcluded(Path.of("/music/@eaDir")));
+        assertTrue(exclusionPolicy.isExcluded(Path.of("/music/@tmp")));
+        assertTrue(exclusionPolicy.isExcluded(Path.of("/music/.SYNOPPSDB")));
+    }
+
+    @Test
+    void isExcludedShouldExcludeTrailingDotFiles() {
+        // [Case] Windows-prohibited trailing dots
+        assertTrue(exclusionPolicy.isExcluded(Path.of("/music/InvalidName.")));
+    }
+
+    @Test
+    void isExcludedShouldExcludeByUserDefinedPattern() {
+        // [Setup] Mock a custom exclusion pattern (e.g., exclude all 'temp' files)
+        String patternStr = ".*temp.*";
+        settingsFacade = SettingsFacadeBuilder
+            .create()
+            .withString(FileSystemSKeys.excludePatternString, patternStr)
+            .buildWithDefault();
+        init();
+
+        // [Case] Matches user pattern
+        assertTrue(exclusionPolicy.isExcluded(Path.of("/music/my_temp_recording.mp3")));
+
+        // [Case] Does NOT match user pattern
+        assertFalse(exclusionPolicy.isExcluded(Path.of("/music/permanent_track.mp3")));
+    }
+
+    @Test
+    void isExcludedShouldHandleEdgeCases() {
+        // [Case] Root path (fileName is null)
+        assertTrue(exclusionPolicy.isExcluded(Path.of("/")));
+
+        // [Case] Directory with dot in name (but not at start) should NOT be excluded
+        assertFalse(exclusionPolicy.isExcluded(Path.of("/music/album.2023/song.mp3")));
     }
 
 }


### PR DESCRIPTION
## Overview

The `production.windows.yml` has been updated to make the Jpsonic Docker image easily accessible on Windows. This allows for an operational experience nearly identical to `production.synology.yml`, hiding as much setup complexity as possible.

However, due to the significant limitations of the Docker environment on Windows, it cannot support the full range of features available on native Linux machines or NAS devices. Accordingly, the UPnP configuration page has been updated to display a warning when such limitations are detected.

## Details

Will UPnP eventually become usable in Docker on Windows? The likely answer is "No."

The backend for Docker on Windows has evolved as follows:

1. **VirtualBox (Docker Toolbox)**: Supported Bridge Adapters, allowing direct network access.
2. **Hyper-V**: Permitted direct interaction with the NIC.
3. **WSL2 (Current)**: Fixed to NAT; network management is tightly confined within the Windows OS layer.

As long as Microsoft prioritizes security and stability as their primary justification, the convenience of the past is unlikely to return.

If Docker Desktop is installed on Windows, Jpsonic can now be easily launched using `production.windows.yml`. However, this is provided strictly for "quick verification" purposes. For those who wish to perform serious music management and build an environment for 24/7 listening via a UPnP server, a NAS remains the most powerful and recommended choice.
