### PR TITLE
Bump java from 25 to 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,13 +106,13 @@ jobs:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: mvn -DnvdApiKey=${{ env.NVD_API_KEY }} -DnvdApiDelay=3000 -DnvdMaxRetryCount=10 -DfailIfNoTests=false -Djpsonic-transcodePath="${{ steps.ffmpeg.outputs.path }}" -Prelease21 clean verify -B -Ptomcat-embed -Punit-test
   ##########################################################################
-  verify-Java25-or-later:
+  verify-Java26:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     name: JDK${{ matrix.java }} on ubuntu-latest
     strategy:
       matrix:
-        java: [ 25 ]
+        java: [ 26 ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -163,11 +163,11 @@ jobs:
   ##########################################################################
   ship-war:
     if: "(github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/feature/docker') && github.event_name != 'schedule'"
-    needs: [ verify-Java21, verify-Java25-or-later ]
+    needs: [ verify-Java21, verify-Java26 ]
     name: Package with JDK ${{ matrix.java }} on ubuntu
     strategy:
       matrix:
-        java: [ 21, 24, 25 ]
+        java: [ 21, 24, 26 ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -235,7 +235,7 @@ jobs:
       - name: Download package
         uses: actions/download-artifact@v4
         with:
-          name: jpsonic-jetty-embedded-for-jdk25-${{ steps.date.outputs.current }}
+          name: jpsonic-jetty-embedded-for-jdk26-${{ steps.date.outputs.current }}
       - name: Create Tag
         run: |
           echo "DOCKER_TAG=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
@@ -248,7 +248,7 @@ jobs:
         run: |
           if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             cd install/docker/alpine
-            sed -i -e "s/25-jdk-alpine/25-jre-alpine/g" Dockerfile
+            sed -i -e "s/26-jdk-alpine/26-jre-alpine/g" Dockerfile
             sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
             mvn -DdockerTag=${{ env.DOCKER_TAG }} package
             docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
@@ -265,7 +265,7 @@ jobs:
         run: |
           if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             cd install/docker/alpine
-            sed -i -e "s/25-jdk-alpine/25-jre-alpine/g" Dockerfile
+            sed -i -e "s/26-jdk-alpine/26-jre-alpine/g" Dockerfile
             sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
             mvn -DdockerTag=latest package
             docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
@@ -276,7 +276,7 @@ jobs:
         run: |
           if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.(alpha|beta)\.[0-9]+\.[0-9]+$ ]]; then
             cd install/docker/alpine
-            sed -i -e "s/25-jdk-alpine/25-jre-alpine/g" Dockerfile
+            sed -i -e "s/26-jdk-alpine/26-jre-alpine/g" Dockerfile
             sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
             mvn -DdockerTag=latest package
             docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
@@ -389,7 +389,7 @@ jobs:
       - name: Download package
         uses: actions/download-artifact@v4
         with:
-          name: jpsonic-jetty-embedded-for-jdk25-${{ steps.date.outputs.current }}
+          name: jpsonic-jetty-embedded-for-jdk26-${{ steps.date.outputs.current }}
       - name: Create Tag
         run: |
           echo "DOCKER_TAG=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
@@ -402,7 +402,7 @@ jobs:
         run: |
           if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             cd install/docker/noble
-            sed -i -e "s/25-jdk-noble/25-jre-noble/g" Dockerfile
+            sed -i -e "s/26-jdk-noble/26-jre-noble/g" Dockerfile
             sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
             mvn -DdockerTag=${{ env.DOCKER_TAG }}-noble package
             docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
@@ -419,7 +419,7 @@ jobs:
         run: |
           if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             cd install/docker/noble
-            sed -i -e "s/25-jdk-noble/25-jre-noble/g" Dockerfile
+            sed -i -e "s/26-jdk-noble/26-jre-noble/g" Dockerfile
             sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
             mvn -DdockerTag=latest-noble package
             docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar
@@ -430,7 +430,7 @@ jobs:
         run: |
           if [[ ${{ env.DOCKER_TAG }} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.(alpha|beta)\.[0-9]+\.[0-9]+$ ]]; then
             cd install/docker/noble
-            sed -i -e "s/25-jdk-noble/25-jre-noble/g" Dockerfile
+            sed -i -e "s/26-jdk-noble/26-jre-noble/g" Dockerfile
             sed -i -e "s/EXPOSE 3333/#EXPOSE 3333/g" Dockerfile
             mvn -DdockerTag=latest-noble package
             docker import target/docker/jpsonic/jpsonic/tmp/docker-build.tar

--- a/install/docker/alpine/Dockerfile
+++ b/install/docker/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:25-jdk-alpine
+FROM eclipse-temurin:26-jdk-alpine
 
 LABEL description="Jpsonic is a free, web-based media streamer, providing ubiquitious access to your music." \
       url="https://github.com/jpsonic/jpsonic"

--- a/install/docker/noble/Dockerfile
+++ b/install/docker/noble/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:25-jdk-noble
+FROM eclipse-temurin:26-jdk-noble
 
 LABEL description="Jpsonic is a free, web-based media streamer, providing ubiquitious access to your music." \
       url="https://github.com/jpsonic/jpsonic"

--- a/pom.xml
+++ b/pom.xml
@@ -1178,9 +1178,9 @@
       </properties>
     </profile>
     <profile>
-      <id>release25</id>
+      <id>release26</id>
       <properties>
-        <java.version>25</java.version>
+        <java.version>26</java.version>
         <maven.compiler.release>${java.version}</maven.compiler.release>
       </properties>
     </profile>


### PR DESCRIPTION
# Overview

This PR updates the project to use **Java 26** in preparation for the next JVM migration and future architectural enhancements.

## Background

The Java release cycle has accelerated, and staying current is essential for leveraging modern library features and performance improvements.

### Minimum Requirement (Java 21)
Jpsonic currently targets **Java 21** as its baseline for standard WAR distributions. Since v115.0, many critical libraries have raised their minimum requirement to Java 21. As a result, support for Java 17 is being discontinued. This is an irreversible transition to align with the current ecosystem.

### Proactive Adoption of Modern Java
For Docker-based environments, we aim to provide the most recent Java environment available. This allows users to benefit from JVM improvements simply by updating their Docker images. "Latest" is defined as the most recent version available via [Eclipse Temurin](https://temurin.net) that remains compatible with our current library stack.

Furthermore, Jpsonic is planning long-term design changes to align with [Project Valhalla](https://openjdk.org/projects/valhalla/). Maintaining compatibility with the latest Java versions is crucial for this roadmap.

## Java Version Strategy (v115.0 and later)

The execution environments for Jpsonic will be categorized as follows:


| Target / Distribution | Java Version | Role / Justification |
| :--- | :--- | :--- |
| **Java 17** | N/A | **Deprecated.** No longer supported from v115.0 onwards. |
| **Java 21** | **Standard** | **Baseline for WAR distribution.** The minimum version required for core libraries. |
| **Java 24** | **Docker (UBI 9)** | Used exclusively for Red Hat UBI 9 images. Limited to Java 24 due to the latest available Eclipse Temurin package on UBI 9. |
| **Java 26** | **Latest** | **Used for Alpine and Ubuntu Docker images.** Provides the cutting-edge runtime environment for modern deployments. |



## Changes

- **CI update**: Adjusted workflows to target the new Java version.  
- **WAR distribution**: Previously supporting JVM 21, 24 and 25, now updated to JVM 21, 24 and **26**.  
- **Docker images**: Base image updated from Java 25 to Java 26, using **Alpine**, **Ubuntu Noble**.  

### Java version selection by base image

This pull request updates the Java runtime versions used by each Docker base image with the following policy:

- **Alpine** and **Ubuntu Noble** images have been bumped to **Java 26**.  
  These distributions already provide stable Java 26 builds and do not impose restrictive CPU requirements.

- The **UBI9** image continues to use **Java 24**.  
  At the time of this change, Java 25 or higher is not yet available for UBI9-based images.  
  In addition, newer UBI-based images target more recent CPU instruction sets, which are not commonly supported on personal NAS-class hardware. (UBI10 uses glibc built for x86-64-v3, which is not supported on common NAS devices.) This decision prioritizes runtime compatibility and deployment stability over strict version uniformity.  
Once Java 26 becomes available for UBI9 without additional hardware constraints, the UBI image can be upgraded accordingly.

