### PR TITLE
Remove PGJDBC-NG

### DIFF
--- a/cve-suppressed.xml
+++ b/cve-suppressed.xml
@@ -22,15 +22,6 @@
         <cve>CVE-2025-48976</cve>
     </suppress>
     <suppress>
-        <notes><![CDATA[
-            pgjdbc-ng depends on Netty internally; however, the vulnerability conditions are not met.
-            In Jpsonic, pgjdbc-ng is used strictly as a PostgreSQL database client,
-            and Netty HTTP codecs or HTTP handlers are neither explicitly nor implicitly used.
-            Therefore, CVE-2025-67735 is not applicable.]]></notes>
-        <gav regex="true">.*netty.*$</gav>
-        <cve>CVE-2025-67735</cve>
-    </suppress>
-    <suppress>
         <notes><![CDATA[False positive. Already using jetty 12.1.5.]]></notes>
         <gav regex="true">org\.mortbay\.jasper:mortbay-apache-el:.*</gav>
         <cve>CVE-2025-5115</cve>
@@ -141,21 +132,6 @@
         <notes><![CDATA[False positive.]]></notes>
         <gav regex="true">org\.mortbay\.jasper:mortbay-apache-jsp:.*</gav>
         <cve>CVE-2026-25854</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-            Netty is present only for PGJDBC-NG Unix Domain Socket client connectivity.
-            This CVE affects Netty HTTP/2 server-side frame processing,
-            which is not used in this application; therefore, this finding is not applicable.]]></notes>
-        <gav regex="true">.*netty.*$</gav>
-        <cve>CVE-2026-33871</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-            For PGJDBC-NG using only Unix Domain Socket client connections,
-            the HTTP/1.1 server-side chunked transfer extension parsing is not executed.]]></notes>
-        <gav regex="true">.*netty.*$</gav>
-        <cve>CVE-2026-33870</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -301,10 +301,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>com.impossibl.pgjdbc-ng</groupId>
-      <artifactId>pgjdbc-ng</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
       <scope>compile</scope>
@@ -537,52 +533,6 @@
       <artifactId>metrics-jmx</artifactId>
       <version>4.2.25</version>
       <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-common</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-buffer</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-resolver</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-handler</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-unix-common</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-kqueue</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-classes-kqueue</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-epoll</artifactId>
-      <classifier>linux-x86_64</classifier>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-classes-epoll</artifactId>
     </dependency>
 
   </dependencies>

--- a/jpsonic-main/src/main/webapp/WEB-INF/jsp/databaseSettings.jsp
+++ b/jpsonic-main/src/main/webapp/WEB-INF/jsp/databaseSettings.jsp
@@ -10,7 +10,6 @@
 <script>
 
 const driverNamePostgres = "org.postgresql.Driver";
-const driverNamePgJdbcNg = "com.impossibl.postgres.jdbc.PGDriver";
 const driverNameMariaDB = "org.mariadb.jdbc.Driver";
 const driverNameMySQL = "com.mysql.jdbc.Driver";
 
@@ -20,10 +19,6 @@ function getJdbcURL(name, host, port, dbName) {
         return "jdbc:postgresql://"
                 + (!host ? "127.0.0.1" : host) + ":" + (!port ? "5432" : port)
                 + "/" + dbName + "?stringtype=unspecified";
-    } else if(name == 'PGJDBC-NG') {
-        return "jdbc:pgsql://"
-                + (!host ? "127.0.0.1" : host) + ":" + (!port ? "5432" : port)
-                + "/" + dbName;
     } else if(name == 'MariaDB') {
         return "jdbc:mariadb://"
                 + (!host ? "127.0.0.1" : host) + ":" + (!port ? "3306" : port)
@@ -42,10 +37,6 @@ function updateHelperContent(name) {
     var driverName;
     if(name == 'Postgres') {
         driverName = driverNamePostgres;
-        $("#mysqlVarcharMaxlength").val("0");
-        $("#usertableQuote").val("\"");
-    } else if(name == 'PGJDBC-NG') {
-        driverName = driverNamePgJdbcNg;
         $("#mysqlVarcharMaxlength").val("0");
         $("#usertableQuote").val("\"");
     } else if(name == 'MariaDB') {
@@ -179,7 +170,6 @@ $(document).ready(function () {
             <dd id="driverDd">
                 <ul class="driverPreset">
                     <li><a href="javascript:updateHelperContent('Postgres');">Postgres</a></li>
-                    <li><a href="javascript:updateHelperContent('PGJDBC-NG');">Postgres(PGJDBC-NG)</a></li>
                     <li><a href="javascript:updateHelperContent('MariaDB');">MariaDB</a></li>
                     <li><a href="javascript:updateHelperContent('MySQL');">MySQL</a></li>
                 </ul>

--- a/pom.xml
+++ b/pom.xml
@@ -70,9 +70,7 @@
     <versions.mockito-junit-jupiter>5.20.0</versions.mockito-junit-jupiter>
     <versions.moxy>4.0.9</versions.moxy>
     <versions.mysql-connector-j>9.7.0</versions.mysql-connector-j>
-    <versions.netty>4.1.127.Final</versions.netty>
     <versions.os-platform-finder>1.1</versions.os-platform-finder>
-    <versions.pgjdbc-ng>0.8.9</versions.pgjdbc-ng>
     <versions.pmd>7.24.0</versions.pmd>
     <versions.postgresql>42.7.11</versions.postgresql>
     <versions.recaptcha>1.0.4</versions.recaptcha>
@@ -377,114 +375,6 @@
         <version>${versions.postgresql}</version>
         <scope>runtime</scope>
       </dependency>
-      <dependency>
-        <groupId>com.impossibl.pgjdbc-ng</groupId>
-        <artifactId>pgjdbc-ng</artifactId>
-        <version>${versions.pgjdbc-ng}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-common</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-buffer</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-resolver</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-unix-common</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-kqueue</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-classes-kqueue</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-epoll</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-classes-epoll</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-common</artifactId>
-        <version>${versions.netty}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-buffer</artifactId>
-        <version>${versions.netty}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-transport</artifactId>
-        <version>${versions.netty}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-resolver</artifactId>
-        <version>${versions.netty}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-codec</artifactId>
-        <version>${versions.netty}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-handler</artifactId>
-        <version>${versions.netty}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-transport-native-unix-common</artifactId>
-        <version>${versions.netty}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-transport-native-kqueue</artifactId>
-        <version>${versions.netty}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-transport-classes-kqueue</artifactId>
-        <version>${versions.netty}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-transport-native-epoll</artifactId>
-        <version>${versions.netty}</version>
-        <classifier>linux-x86_64</classifier>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-transport-classes-epoll</artifactId>
-        <version>${versions.netty}</version>
-      </dependency>
 
       <dependency>
         <groupId>org.apache.ant</groupId>
@@ -667,13 +557,6 @@
         <groupId>org.apache.tomcat.embed</groupId>
         <artifactId>tomcat-embed-jasper</artifactId>
         <version>${versions.tomcat}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-bom</artifactId>
-        <version>${versions.netty}</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.angus</groupId>


### PR DESCRIPTION
## Summary
Remove the obsolete `PGJDBC-NG` dependency from the project.

## Reasons for Change
- **Eliminate Security Noise**: The library is no longer actively maintained. It frequently triggers CVE warnings (often false positives) due to its internal Netty dependency, which is difficult to override.
- **Modern Alternatives**: While PGJDBC-NG was once essential for Linux/Unix domain socket support, this can now be achieved using the standard PostgreSQL JDBC driver with Spring Boot's standard configuration.
- **Dependency Cleanup**: Removing this specialized driver reduces technical debt and aligns the project with modern, standard practices.

## Impact
- Removed PGJDBC-NG driver references.
- Users requiring Unix domain socket connections should migrate to the standard JDBC driver's `socketFactory` configuration.
