### PR TITLE
Update Libs

### DIFF
--- a/airsonic-taglibs/pom.xml
+++ b/airsonic-taglibs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>115.0.0</version>
+    <version>115.0.1</version>
   </parent>
   <artifactId>airsonic-taglibs</artifactId>
   <name>Airsonic Tag Libs</name>

--- a/cve-suppressed.xml
+++ b/cve-suppressed.xml
@@ -175,4 +175,19 @@
         <cpe>cpe:2.3:a:mortbay_jetty:jetty:.*</cpe>
         <cve>CVE-2026-2332</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[False positive.]]></notes>
+        <gav regex="true">org\.mortbay\.jasper:mortbay-apache-jsp:.*</gav>
+        <cve>CVE-2026-41284</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[False positive.]]></notes>
+        <gav regex="true">org\.mortbay\.jasper:mortbay-apache-jsp:.*</gav>
+        <cve>CVE-2026-42498</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[False positive.]]></notes>
+        <gav regex="true">org\.mortbay\.jasper:mortbay-apache-jsp:.*</gav>
+        <cve>CVE-2026-43514</cve>
+    </suppress>
 </suppressions>

--- a/install/docker/alpine/pom.xml
+++ b/install/docker/alpine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>115.0.0</version>
+        <version>115.0.1</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/noble/pom.xml
+++ b/install/docker/noble/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>115.0.0</version>
+        <version>115.0.1</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/install/docker/ubi9/pom.xml
+++ b/install/docker/ubi9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <relativePath>../../../pom.xml</relativePath>
         <artifactId>jpsonic</artifactId>
-        <version>115.0.0</version>
+        <version>115.0.1</version>
         <groupId>com.tesshu.jpsonic.player</groupId>
     </parent>
     <packaging>pom</packaging>

--- a/jpsonic-main/pom.xml
+++ b/jpsonic-main/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>115.0.0</version>
+    <version>115.0.1</version>
   </parent>
   <artifactId>jpsonic-main</artifactId>
   <packaging>war</packaging>

--- a/jpsonic-upnp-template/pom.xml
+++ b/jpsonic-upnp-template/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>115.0.0</version>
+    <version>115.0.1</version>
   </parent>
   <artifactId>jpsonic-upnp-template</artifactId>
   <name>Upnp Template</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tesshu.jpsonic.player</groupId>
   <artifactId>jpsonic</artifactId>
-  <version>115.0.0</version>
+  <version>115.0.1</version>
   <packaging>pom</packaging>
   <name>Jpsonic</name>
 
@@ -484,11 +484,11 @@
         <artifactId>httpclient5</artifactId>
         <version>${versions.httpclient5}</version>
       </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents.core5</groupId>
-      <artifactId>httpcore5</artifactId>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5</artifactId>
         <version>${versions.httpcore5}</version>
-    </dependency>
+      </dependency>
 
       <dependency>
         <groupId>org.jfree</groupId>

--- a/subsonic-rest-api/pom.xml
+++ b/subsonic-rest-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.tesshu.jpsonic.player</groupId>
     <artifactId>jpsonic</artifactId>
-    <version>115.0.0</version>
+    <version>115.0.1</version>
   </parent>
   <artifactId>subsonic-rest-api</artifactId>
   <name>Subsonic REST API</name>


### PR DESCRIPTION
## 🐥 Maintenance

False positive suppression only.

Currently, the entire NVD infrastructure is experiencing major structural changes and disruptions.
(The main causes are that the NVD system is struggling to handle the skyrocketing volume of CVE processing loads, combined with the large-scale transition to a new operational model announced by NIST in April 2026.)
Due to frequent build retries, release timing may be slightly delayed.
(The latest version has been uploaded to Docker, so using that is recommended.)

## 🛡️ Vulnerabilities

No vulnerabilities found.

<img width="494" height="734" alt="image" src="https://github.com/user-attachments/assets/d91bdd00-568c-4ce5-8827-0046cefca12e" />

